### PR TITLE
feat(ssh): Add support for recent connections and integration with tmux

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1993,6 +1993,8 @@ const VALID_SETTING_KEYS: &[&str] = &[
     "plugin_auto_update",
     "plugin_ignored_updates",
     "plugin_last_update_check",
+    // SSH
+    "ssh_connection_history",
 ];
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -239,6 +239,11 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             // Session management
             pty::create_session,
+            pty::ssh_list_tmux_sessions,
+            pty::ssh_list_tmux_windows,
+            pty::ssh_tmux_select_window,
+            pty::ssh_tmux_new_window,
+            pty::ssh_tmux_rename_window,
             pty::write_to_session,
             pty::nudge_realm_context,
             pty::resize_session,

--- a/src-tauri/src/pty/commands.rs
+++ b/src-tauri/src/pty/commands.rs
@@ -13,7 +13,217 @@ use crate::pty::models::*;
 use crate::pty::{ai_launch_command, detect_shell, get_working_directory, PtySession};
 use crate::AppState;
 
+// ─── SSH / tmux helpers ─────────────────────────────────────────────
+
+fn resolve_ssh_user(user: Option<String>) -> String {
+    user.unwrap_or_else(|| {
+        std::env::var("USER")
+            .or_else(|_| std::env::var("USERNAME"))
+            .unwrap_or_else(|_| "root".to_string())
+    })
+}
+
+/// Build a base SSH command with common options.
+fn ssh_command(user: &str, host: &str, port: u16) -> std::process::Command {
+    let mut cmd = std::process::Command::new("ssh");
+    cmd.arg("-o").arg("ConnectTimeout=5");
+    cmd.arg("-o").arg("BatchMode=yes");
+    if port != 22 {
+        cmd.arg("-p").arg(port.to_string());
+    }
+    cmd.arg(format!("{}@{}", user, host));
+    cmd
+}
+
+/// Run a remote SSH command and return (stdout, stderr, success).
+fn ssh_exec(
+    user: &str,
+    host: &str,
+    port: u16,
+    remote_cmd: &str,
+) -> Result<(String, String, bool), String> {
+    let mut cmd = ssh_command(user, host, port);
+    cmd.arg(remote_cmd);
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to run ssh: {}", e))?;
+    Ok((
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.success(),
+    ))
+}
+
 // ─── Tauri Commands ─────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn ssh_list_tmux_sessions(
+    host: String,
+    port: Option<u16>,
+    user: Option<String>,
+) -> Result<Vec<TmuxSessionEntry>, String> {
+    let user = resolve_ssh_user(user);
+    let port = port.unwrap_or(22);
+
+    let (stdout, stderr, success) = ssh_exec(
+        &user,
+        &host,
+        port,
+        "tmux list-sessions -F '#{session_name}|||#{session_windows}|||#{session_attached}'",
+    )?;
+
+    if !success {
+        if stderr.contains("no server running") || stderr.contains("no sessions") {
+            return Ok(Vec::new());
+        }
+        if stderr.contains("not found") || stderr.contains("No such file") {
+            return Err("tmux is not installed on the remote host".to_string());
+        }
+        return Err(format!("Failed to list tmux sessions: {}", stderr.trim()));
+    }
+
+    let entries: Vec<TmuxSessionEntry> = stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| {
+            let line = line.trim().trim_matches('\'');
+            let parts: Vec<&str> = line.split("|||").collect();
+            if parts.len() >= 3 {
+                Some(TmuxSessionEntry {
+                    name: parts[0].to_string(),
+                    windows: parts[1].parse().unwrap_or(0),
+                    attached: parts[2] == "1",
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(entries)
+}
+
+#[tauri::command]
+pub async fn ssh_list_tmux_windows(
+    host: String,
+    port: Option<u16>,
+    user: Option<String>,
+    tmux_session: String,
+) -> Result<Vec<TmuxWindowEntry>, String> {
+    let user = resolve_ssh_user(user);
+    let port = port.unwrap_or(22);
+
+    let remote_cmd = format!(
+        "tmux list-windows -t '{}' -F '#{{window_index}}|||#{{window_name}}|||#{{window_active}}'",
+        tmux_session.replace('\'', "'\\''")
+    );
+    let (stdout, stderr, success) = ssh_exec(&user, &host, port, &remote_cmd)?;
+
+    if !success {
+        return Err(format!("Failed to list tmux windows: {}", stderr.trim()));
+    }
+
+    let entries: Vec<TmuxWindowEntry> = stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| {
+            let line = line.trim().trim_matches('\'');
+            let parts: Vec<&str> = line.split("|||").collect();
+            if parts.len() >= 3 {
+                Some(TmuxWindowEntry {
+                    index: parts[0].parse().unwrap_or(0),
+                    name: parts[1].to_string(),
+                    active: parts[2] == "1",
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(entries)
+}
+
+#[tauri::command]
+pub async fn ssh_tmux_select_window(
+    host: String,
+    port: Option<u16>,
+    user: Option<String>,
+    tmux_session: String,
+    window_index: u32,
+) -> Result<(), String> {
+    let user = resolve_ssh_user(user);
+    let port = port.unwrap_or(22);
+
+    let remote_cmd = format!(
+        "tmux select-window -t '{}:{}'",
+        tmux_session.replace('\'', "'\\''"),
+        window_index
+    );
+    let (_stdout, stderr, success) = ssh_exec(&user, &host, port, &remote_cmd)?;
+
+    if !success {
+        return Err(format!("Failed to select tmux window: {}", stderr.trim()));
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn ssh_tmux_new_window(
+    host: String,
+    port: Option<u16>,
+    user: Option<String>,
+    tmux_session: String,
+    window_name: Option<String>,
+) -> Result<(), String> {
+    let user = resolve_ssh_user(user);
+    let port = port.unwrap_or(22);
+
+    let remote_cmd = if let Some(name) = window_name {
+        format!(
+            "tmux new-window -t '{}' -n '{}'",
+            tmux_session.replace('\'', "'\\''"),
+            name.replace('\'', "'\\''")
+        )
+    } else {
+        format!(
+            "tmux new-window -t '{}'",
+            tmux_session.replace('\'', "'\\''")
+        )
+    };
+    let (_stdout, stderr, success) = ssh_exec(&user, &host, port, &remote_cmd)?;
+
+    if !success {
+        return Err(format!("Failed to create tmux window: {}", stderr.trim()));
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn ssh_tmux_rename_window(
+    host: String,
+    port: Option<u16>,
+    user: Option<String>,
+    tmux_session: String,
+    window_index: u32,
+    new_name: String,
+) -> Result<(), String> {
+    let user = resolve_ssh_user(user);
+    let port = port.unwrap_or(22);
+
+    let remote_cmd = format!(
+        "tmux rename-window -t '{}:{}' '{}'",
+        tmux_session.replace('\'', "'\\''"),
+        window_index,
+        new_name.replace('\'', "'\\''")
+    );
+    let (_stdout, stderr, success) = ssh_exec(&user, &host, port, &remote_cmd)?;
+
+    if !success {
+        return Err(format!("Failed to rename tmux window: {}", stderr.trim()));
+    }
+    Ok(())
+}
 
 // Tauri command handler — params come from frontend invocation
 #[allow(clippy::too_many_arguments)]
@@ -32,6 +242,7 @@ pub fn create_session(
     ssh_host: Option<String>,
     ssh_port: Option<u16>,
     ssh_user: Option<String>,
+    tmux_session: Option<String>,
 ) -> Result<SessionUpdate, String> {
     let session_id = session_id.unwrap_or_else(|| Uuid::new_v4().to_string());
     let shell = state
@@ -122,6 +333,7 @@ pub fn create_session(
                     .or_else(|_| std::env::var("USERNAME"))
                     .unwrap_or_else(|_| "root".to_string())
             }),
+            tmux_session: tmux_session.clone(),
         }),
     };
 
@@ -152,6 +364,14 @@ pub fn create_session(
             c.arg(info.port.to_string());
         }
         c.arg(format!("{}@{}", info.user, info.host));
+        // Attach to tmux session if specified.
+        // `new-session -A` attaches if it exists, creates if it doesn't.
+        if let Some(ref tmux_name) = info.tmux_session {
+            c.arg(format!(
+                "tmux new-session -A -s '{}'",
+                tmux_name.replace('\'', "'\\''")
+            ));
+        }
         c
     } else {
         #[cfg(unix)]

--- a/src-tauri/src/pty/models.rs
+++ b/src-tauri/src/pty/models.rs
@@ -130,6 +130,22 @@ pub struct SshConnectionInfo {
     pub host: String,
     pub port: u16,
     pub user: String,
+    #[serde(default)]
+    pub tmux_session: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TmuxSessionEntry {
+    pub name: String,
+    pub windows: u32,
+    pub attached: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TmuxWindowEntry {
+    pub index: u32,
+    pub name: String,
+    pub active: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/__tests__/tmux-integration.test.ts
+++ b/src/__tests__/tmux-integration.test.ts
@@ -1,0 +1,539 @@
+/**
+ * Tests for tmux integration with SSH remote sessions.
+ *
+ * Covers:
+ * - TmuxSessionEntry type shape
+ * - TmuxWindowEntry type shape
+ * - SshConnectionInfo with tmux_session field
+ * - CreateSessionOpts tmuxSession field
+ * - Workspace persistence with tmux sessions
+ * - Session reducer with tmux sessions
+ * - SSH+tmux label conventions
+ * - SSH connection history helpers
+ */
+import { describe, it, expect, vi } from "vitest";
+
+// ─── Mock Tauri APIs ─────────────────────────────────────────────────
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.reject(new Error("mocked"))),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+vi.mock("@tauri-apps/api/window", () => ({ getCurrentWindow: vi.fn() }));
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: vi.fn(() => ({
+    onDragDropEvent: vi.fn(() => Promise.resolve(() => {})),
+  })),
+}));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn(), save: vi.fn() }));
+vi.mock("../terminal/TerminalPool", () => ({
+  createTerminal: vi.fn(),
+  destroy: vi.fn(),
+  updateSettings: vi.fn(),
+  writeScrollback: vi.fn(),
+}));
+vi.mock("../utils/notifications", () => ({
+  initNotifications: vi.fn(),
+  notifyLongRunningDone: vi.fn(),
+}));
+
+// ─── Imports ─────────────────────────────────────────────────────────
+import type {
+  SessionData,
+  SshConnectionInfo,
+  CreateSessionOpts,
+  TmuxSessionEntry,
+  TmuxWindowEntry,
+  SavedWorkspace,
+} from "../types/session";
+import {
+  parseSshHistory,
+  addToSshHistory,
+  type SshHistoryEntry,
+} from "../components/SessionCreator";
+import { validateSavedWorkspace } from "../types/session";
+import { sessionReducer, initialState } from "../state/SessionContext";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+function makeSession(overrides?: Partial<SessionData>): SessionData {
+  return {
+    id: "sess-1",
+    label: "Session 1",
+    description: "",
+    color: "#ff0000",
+    group: null,
+    phase: "idle",
+    working_directory: "/home/user/project",
+    shell: "bash",
+    created_at: "2025-01-01T00:00:00Z",
+    last_activity_at: "2025-01-01T00:00:00Z",
+    workspace_paths: [],
+    detected_agent: null,
+    metrics: {
+      output_lines: 0,
+      error_count: 0,
+      stuck_score: 0,
+      token_usage: {},
+      tool_calls: [],
+      tool_call_summary: {},
+      files_touched: [],
+      recent_errors: [],
+      recent_actions: [],
+      available_actions: [],
+      memory_facts: [],
+      latency_p50_ms: null,
+      latency_p95_ms: null,
+      latency_samples: [],
+      token_history: [],
+    },
+    ai_provider: null,
+    auto_approve: false,
+    context_injected: false,
+    ssh_info: null,
+    ...overrides,
+  };
+}
+
+function makeSshInfo(overrides?: Partial<SshConnectionInfo>): SshConnectionInfo {
+  return {
+    host: "192.168.1.100",
+    port: 22,
+    user: "deploy",
+    ...overrides,
+  };
+}
+
+// =====================================================================
+// TmuxSessionEntry type shape
+// =====================================================================
+describe("TmuxSessionEntry type shape", () => {
+  it("has name, windows, and attached fields", () => {
+    const entry: TmuxSessionEntry = {
+      name: "main",
+      windows: 3,
+      attached: true,
+    };
+    expect(entry.name).toBe("main");
+    expect(entry.windows).toBe(3);
+    expect(entry.attached).toBe(true);
+  });
+
+  it("windows is a number", () => {
+    const entry: TmuxSessionEntry = {
+      name: "dev",
+      windows: 5,
+      attached: false,
+    };
+    expect(typeof entry.windows).toBe("number");
+  });
+
+  it("attached is boolean", () => {
+    const attached: TmuxSessionEntry = { name: "a", windows: 1, attached: true };
+    const detached: TmuxSessionEntry = { name: "b", windows: 1, attached: false };
+    expect(typeof attached.attached).toBe("boolean");
+    expect(typeof detached.attached).toBe("boolean");
+    expect(attached.attached).toBe(true);
+    expect(detached.attached).toBe(false);
+  });
+});
+
+// =====================================================================
+// TmuxWindowEntry type shape
+// =====================================================================
+describe("TmuxWindowEntry type shape", () => {
+  it("has index, name, and active fields", () => {
+    const entry: TmuxWindowEntry = {
+      index: 0,
+      name: "bash",
+      active: true,
+    };
+    expect(entry.index).toBe(0);
+    expect(entry.name).toBe("bash");
+    expect(entry.active).toBe(true);
+  });
+
+  it("index is a number", () => {
+    const entry: TmuxWindowEntry = {
+      index: 3,
+      name: "vim",
+      active: false,
+    };
+    expect(typeof entry.index).toBe("number");
+  });
+});
+
+// =====================================================================
+// SshConnectionInfo with tmux_session
+// =====================================================================
+describe("SshConnectionInfo with tmux_session", () => {
+  it("tmux_session is optional (undefined when not set)", () => {
+    const info = makeSshInfo();
+    expect(info.tmux_session).toBeUndefined();
+  });
+
+  it("can hold a tmux session name", () => {
+    const info = makeSshInfo({ tmux_session: "my-dev-session" });
+    expect(info.tmux_session).toBe("my-dev-session");
+  });
+
+  it("defaults to undefined for existing sessions (backward compat)", () => {
+    const info: SshConnectionInfo = { host: "old-server", port: 22, user: "root" };
+    expect(info.tmux_session).toBeUndefined();
+    // Ensure accessing it does not throw
+    expect(() => info.tmux_session).not.toThrow();
+  });
+});
+
+// =====================================================================
+// CreateSessionOpts tmuxSession field
+// =====================================================================
+describe("CreateSessionOpts tmuxSession field", () => {
+  it("supports tmuxSession parameter", () => {
+    const opts: CreateSessionOpts = {
+      sshHost: "192.168.1.100",
+      sshPort: 22,
+      sshUser: "deploy",
+      tmuxSession: "main",
+    };
+    expect(opts.tmuxSession).toBe("main");
+  });
+
+  it("tmuxSession is optional", () => {
+    const opts: CreateSessionOpts = {
+      sshHost: "192.168.1.100",
+      sshUser: "deploy",
+    };
+    expect(opts.tmuxSession).toBeUndefined();
+  });
+
+  it("can combine SSH fields with tmuxSession", () => {
+    const opts: CreateSessionOpts = {
+      sshHost: "prod.example.com",
+      sshPort: 2222,
+      sshUser: "admin",
+      tmuxSession: "deploy-session",
+    };
+    expect(opts.sshHost).toBe("prod.example.com");
+    expect(opts.sshPort).toBe(2222);
+    expect(opts.sshUser).toBe("admin");
+    expect(opts.tmuxSession).toBe("deploy-session");
+  });
+});
+
+// =====================================================================
+// Workspace persistence with tmux sessions
+// =====================================================================
+describe("Workspace persistence with tmux sessions", () => {
+  it("validates workspace with tmux_session on ssh_info", () => {
+    const result = validateSavedWorkspace({
+      version: 1,
+      sessions: [{
+        id: "s1",
+        label: "deploy@server [main]",
+        description: "",
+        color: "#39c5cf",
+        group: null,
+        working_directory: "",
+        ai_provider: null,
+        auto_approve: false,
+        project_ids: [],
+        ssh_info: {
+          host: "192.168.1.100",
+          port: 22,
+          user: "deploy",
+          tmux_session: "main",
+        },
+      }],
+      layout: null,
+      focused_pane_id: null,
+      active_session_id: "s1",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.sessions[0].ssh_info).toEqual({
+      host: "192.168.1.100",
+      port: 22,
+      user: "deploy",
+      tmux_session: "main",
+    });
+  });
+
+  it("round-trips tmux session through JSON serialization", () => {
+    const workspace: SavedWorkspace = {
+      version: 1,
+      sessions: [{
+        id: "s1",
+        label: "admin@prod [deploy]",
+        description: "",
+        color: "#39c5cf",
+        group: null,
+        working_directory: "",
+        ai_provider: null,
+        auto_approve: false,
+        project_ids: [],
+        ssh_info: {
+          host: "prod.example.com",
+          port: 2222,
+          user: "admin",
+          tmux_session: "deploy",
+        },
+      }],
+      layout: null,
+      focused_pane_id: null,
+      active_session_id: "s1",
+    };
+
+    const json = JSON.stringify(workspace);
+    const parsed = JSON.parse(json);
+    const validated = validateSavedWorkspace(parsed);
+    expect(validated).not.toBeNull();
+    expect(validated!.sessions[0].ssh_info!.tmux_session).toBe("deploy");
+  });
+
+  it("handles ssh_info without tmux_session (backward compat)", () => {
+    const result = validateSavedWorkspace({
+      version: 1,
+      sessions: [{
+        id: "s1",
+        label: "deploy@server",
+        description: "",
+        color: "#39c5cf",
+        group: null,
+        working_directory: "",
+        ai_provider: null,
+        auto_approve: false,
+        project_ids: [],
+        ssh_info: { host: "192.168.1.100", port: 22, user: "deploy" },
+      }],
+      layout: null,
+      focused_pane_id: null,
+      active_session_id: "s1",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.sessions[0].ssh_info).toBeDefined();
+    expect(result!.sessions[0].ssh_info!.tmux_session).toBeUndefined();
+  });
+
+  it("preserves tmux_session in mixed local/SSH workspace", () => {
+    const result = validateSavedWorkspace({
+      version: 1,
+      sessions: [
+        {
+          id: "local-1",
+          label: "Local Dev",
+          description: "",
+          color: "#ff0000",
+          group: null,
+          working_directory: "/home/user/project",
+          ai_provider: null,
+          auto_approve: false,
+          project_ids: [],
+          ssh_info: null,
+        },
+        {
+          id: "ssh-1",
+          label: "deploy@prod [web]",
+          description: "",
+          color: "#39c5cf",
+          group: null,
+          working_directory: "",
+          ai_provider: null,
+          auto_approve: false,
+          project_ids: [],
+          ssh_info: {
+            host: "prod.example.com",
+            port: 22,
+            user: "deploy",
+            tmux_session: "web",
+          },
+        },
+      ],
+      layout: null,
+      focused_pane_id: null,
+      active_session_id: "local-1",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.sessions).toHaveLength(2);
+    expect(result!.sessions[0].ssh_info).toBeNull();
+    expect(result!.sessions[1].ssh_info!.tmux_session).toBe("web");
+  });
+});
+
+// =====================================================================
+// Session reducer with tmux sessions
+// =====================================================================
+describe("Session reducer with tmux sessions", () => {
+  it("SESSION_UPDATED stores tmux_session in ssh_info", () => {
+    const session = makeSession({
+      id: "ssh-tmux-1",
+      label: "deploy@server [main]",
+      ssh_info: makeSshInfo({ tmux_session: "main" }),
+    });
+    const state = sessionReducer(initialState, {
+      type: "SESSION_UPDATED",
+      session,
+    });
+    expect(state.sessions["ssh-tmux-1"]).toBeDefined();
+    expect(state.sessions["ssh-tmux-1"].ssh_info!.tmux_session).toBe("main");
+  });
+
+  it("can update tmux session info independently", () => {
+    const session = makeSession({
+      id: "ssh-tmux-1",
+      label: "deploy@server [dev]",
+      ssh_info: makeSshInfo({ tmux_session: "dev" }),
+    });
+    let state = sessionReducer(initialState, {
+      type: "SESSION_UPDATED",
+      session,
+    });
+    expect(state.sessions["ssh-tmux-1"].ssh_info!.tmux_session).toBe("dev");
+
+    // Update to a different tmux session
+    const updated = makeSession({
+      id: "ssh-tmux-1",
+      label: "deploy@server [prod]",
+      ssh_info: makeSshInfo({ tmux_session: "prod" }),
+    });
+    state = sessionReducer(state, {
+      type: "SESSION_UPDATED",
+      session: updated,
+    });
+    expect(state.sessions["ssh-tmux-1"].ssh_info!.tmux_session).toBe("prod");
+  });
+
+  it("SESSION_REMOVED cleans up tmux SSH session", () => {
+    const session = makeSession({
+      id: "ssh-tmux-1",
+      label: "deploy@server [main]",
+      ssh_info: makeSshInfo({ tmux_session: "main" }),
+    });
+    let state = sessionReducer(initialState, {
+      type: "SESSION_UPDATED",
+      session,
+    });
+    expect(state.sessions["ssh-tmux-1"]).toBeDefined();
+
+    state = sessionReducer(state, { type: "SESSION_REMOVED", id: "ssh-tmux-1" });
+    expect(state.sessions["ssh-tmux-1"]).toBeUndefined();
+  });
+});
+
+// =====================================================================
+// SSH+tmux label conventions
+// =====================================================================
+describe("SSH+tmux label conventions", () => {
+  it("label includes tmux session name in brackets: \"user@host [session]\"", () => {
+    const info = makeSshInfo({
+      user: "admin",
+      host: "prod.example.com",
+      tmux_session: "web",
+    });
+    const label = info.tmux_session
+      ? `${info.user}@${info.host} [${info.tmux_session}]`
+      : `${info.user}@${info.host}`;
+    expect(label).toBe("admin@prod.example.com [web]");
+  });
+
+  it("label without tmux session is just \"user@host\"", () => {
+    const info = makeSshInfo({
+      user: "deploy",
+      host: "staging.example.com",
+    });
+    const label = info.tmux_session
+      ? `${info.user}@${info.host} [${info.tmux_session}]`
+      : `${info.user}@${info.host}`;
+    expect(label).toBe("deploy@staging.example.com");
+  });
+});
+
+// =====================================================================
+// SSH connection history helpers
+// =====================================================================
+describe("SSH connection history helpers", () => {
+  it("parseSshHistory returns empty array for invalid JSON", () => {
+    expect(parseSshHistory("not-json")).toEqual([]);
+    expect(parseSshHistory("")).toEqual([]);
+    expect(parseSshHistory("{broken")).toEqual([]);
+  });
+
+  it("parseSshHistory parses valid JSON array", () => {
+    const entries: SshHistoryEntry[] = [
+      { host: "server1", user: "root", port: 22, lastUsed: "2025-01-01" },
+      { host: "server2", user: "admin", port: 2222, lastUsed: "2025-01-02" },
+    ];
+    const result = parseSshHistory(JSON.stringify(entries));
+    expect(result).toHaveLength(2);
+    expect(result[0].host).toBe("server1");
+    expect(result[1].port).toBe(2222);
+  });
+
+  it("addToSshHistory adds new entry at the front", () => {
+    const existing: SshHistoryEntry[] = [
+      { host: "old-server", user: "root", port: 22, lastUsed: "2025-01-01" },
+    ];
+    const newEntry: SshHistoryEntry = {
+      host: "new-server",
+      user: "deploy",
+      port: 22,
+      lastUsed: "2025-06-01",
+    };
+    const result = addToSshHistory(existing, newEntry);
+    expect(result).toHaveLength(2);
+    expect(result[0].host).toBe("new-server");
+    expect(result[1].host).toBe("old-server");
+  });
+
+  it("addToSshHistory deduplicates by host+user+port (moves to front)", () => {
+    const existing: SshHistoryEntry[] = [
+      { host: "server-a", user: "root", port: 22, lastUsed: "2025-01-01" },
+      { host: "server-b", user: "deploy", port: 22, lastUsed: "2025-01-02" },
+      { host: "server-c", user: "admin", port: 2222, lastUsed: "2025-01-03" },
+    ];
+    const duplicate: SshHistoryEntry = {
+      host: "server-b",
+      user: "deploy",
+      port: 22,
+      lastUsed: "2025-06-15",
+    };
+    const result = addToSshHistory(existing, duplicate);
+    expect(result).toHaveLength(3);
+    expect(result[0].host).toBe("server-b");
+    expect(result[0].lastUsed).toBe("2025-06-15");
+    expect(result[1].host).toBe("server-a");
+    expect(result[2].host).toBe("server-c");
+  });
+
+  it("addToSshHistory respects maxEntries limit", () => {
+    const existing: SshHistoryEntry[] = Array.from({ length: 5 }, (_, i) => ({
+      host: `server-${i}`,
+      user: "root",
+      port: 22,
+      lastUsed: `2025-01-0${i + 1}`,
+    }));
+    const newEntry: SshHistoryEntry = {
+      host: "newest",
+      user: "root",
+      port: 22,
+      lastUsed: "2025-06-01",
+    };
+    const result = addToSshHistory(existing, newEntry, 3);
+    expect(result).toHaveLength(3);
+    expect(result[0].host).toBe("newest");
+  });
+
+  it("addToSshHistory updates lastUsed on duplicate", () => {
+    const existing: SshHistoryEntry[] = [
+      { host: "myhost", user: "admin", port: 22, lastUsed: "2025-01-01" },
+    ];
+    const updated: SshHistoryEntry = {
+      host: "myhost",
+      user: "admin",
+      port: 22,
+      lastUsed: "2025-12-25",
+    };
+    const result = addToSshHistory(existing, updated);
+    expect(result).toHaveLength(1);
+    expect(result[0].lastUsed).toBe("2025-12-25");
+  });
+});

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { SessionData, SessionHistoryEntry } from "../types/session";
+import type { SessionData, SessionHistoryEntry, TmuxSessionEntry, TmuxWindowEntry } from "../types/session";
 
 export function createSession(opts: {
   sessionId: string | null;
@@ -13,8 +13,57 @@ export function createSession(opts: {
   sshHost?: string | null;
   sshPort?: number | null;
   sshUser?: string | null;
+  tmuxSession?: string | null;
 }): Promise<SessionData> {
   return invoke<SessionData>("create_session", opts);
+}
+
+export function sshListTmuxSessions(
+  host: string,
+  port?: number,
+  user?: string,
+): Promise<TmuxSessionEntry[]> {
+  return invoke<TmuxSessionEntry[]>("ssh_list_tmux_sessions", { host, port, user });
+}
+
+export function sshListTmuxWindows(
+  host: string,
+  tmuxSession: string,
+  port?: number,
+  user?: string,
+): Promise<TmuxWindowEntry[]> {
+  return invoke<TmuxWindowEntry[]>("ssh_list_tmux_windows", { host, port, user, tmuxSession });
+}
+
+export function sshTmuxSelectWindow(
+  host: string,
+  tmuxSession: string,
+  windowIndex: number,
+  port?: number,
+  user?: string,
+): Promise<void> {
+  return invoke("ssh_tmux_select_window", { host, port, user, tmuxSession, windowIndex });
+}
+
+export function sshTmuxRenameWindow(
+  host: string,
+  tmuxSession: string,
+  windowIndex: number,
+  newName: string,
+  port?: number,
+  user?: string,
+): Promise<void> {
+  return invoke("ssh_tmux_rename_window", { host, port, user, tmuxSession, windowIndex, newName });
+}
+
+export function sshTmuxNewWindow(
+  host: string,
+  tmuxSession: string,
+  port?: number,
+  user?: string,
+  windowName?: string,
+): Promise<void> {
+  return invoke("ssh_tmux_new_window", { host, port, user, tmuxSession, windowName });
 }
 
 export function closeSession(sessionId: string): Promise<void> {

--- a/src/components/SessionCreator.tsx
+++ b/src/components/SessionCreator.tsx
@@ -4,11 +4,45 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { Project } from "../hooks/useSessionProjects";
 import { CreateSessionOpts } from "../state/SessionContext";
 import { getProjects, createProject, deleteProject } from "../api/projects";
-import { getSessions } from "../api/sessions";
+import { getSessions, sshListTmuxSessions } from "../api/sessions";
+import { getSetting, setSetting } from "../api/settings";
+import type { TmuxSessionEntry } from "../types/session";
 import { gitListBranchesForRealm } from "../api/git";
 import { LANG_COLORS } from "../utils/langColors";
 import { SessionBranchSelector } from "./SessionBranchSelector";
 import { SESSION_COLORS } from "./SessionList";
+
+// ─── SSH Connection History ──────────────────────────────────────────
+
+export interface SshHistoryEntry {
+  host: string;
+  user: string;
+  port: number;
+  lastUsed: string;
+}
+
+const SSH_HISTORY_KEY = "ssh_connection_history";
+const SSH_HISTORY_MAX = 10;
+
+export function parseSshHistory(json: string): SshHistoryEntry[] {
+  try {
+    const arr = JSON.parse(json);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+export function addToSshHistory(
+  existing: SshHistoryEntry[],
+  entry: SshHistoryEntry,
+  maxEntries = SSH_HISTORY_MAX,
+): SshHistoryEntry[] {
+  const filtered = existing.filter(
+    (e) => !(e.host === entry.host && e.user === entry.user && e.port === entry.port),
+  );
+  return [entry, ...filtered].slice(0, maxEntries);
+}
 
 const AI_PROVIDERS = [
   { id: "claude", label: "Claude", description: "Claude Code CLI", enabled: true },
@@ -26,7 +60,7 @@ const AUTO_APPROVE_FLAGS: Record<string, { flag: string; description: string }> 
 };
 
 // Internal step identifiers (not displayed to user)
-type Step = "projects" | "branch" | "ai" | "confirm";
+type Step = "projects" | "branch" | "ai" | "tmux" | "confirm";
 
 interface SessionCreatorProps {
   onClose: () => void;
@@ -63,6 +97,16 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
   const [sshHost, setSshHost] = useState("");
   const [sshUser, setSshUser] = useState("");
   const [sshPort, setSshPort] = useState("22");
+  const [sshHistory, setSshHistory] = useState<SshHistoryEntry[]>([]);
+
+  // Tmux session discovery state
+  const [tmuxSessions, setTmuxSessions] = useState<TmuxSessionEntry[]>([]);
+  const [tmuxLoading, setTmuxLoading] = useState(false);
+  const [tmuxError, setTmuxError] = useState<string | null>(null);
+  const [selectedTmuxSession, setSelectedTmuxSession] = useState<string | null>(null);
+  const [tmuxAvailable, setTmuxAvailable] = useState(true);
+  const [newTmuxSessionName, setNewTmuxSessionName] = useState("");
+  const [showNewTmuxInput, setShowNewTmuxInput] = useState(false);
 
   // Color selection state — no color by default
   const [selectedColor, setSelectedColor] = useState<string>("");
@@ -85,7 +129,7 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
 
   // Compute ordered steps for display
   const orderedSteps = useMemo<Step[]>(() => {
-    if (connectionType === "ssh") return ["projects", "confirm"];
+    if (connectionType === "ssh") return ["projects", "tmux", "confirm"];
     const steps: Step[] = ["projects"];
     if (showBranchStep) steps.push("branch");
     steps.push("ai", "confirm");
@@ -113,6 +157,13 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
     getProjects()
       .then((r) => setAllProjects(r))
       .catch((err) => console.warn("[SessionCreator] Failed to load projects:", err));
+    getSetting(SSH_HISTORY_KEY)
+      .then((json) => {
+        const history = parseSshHistory(json);
+        console.log("[SessionCreator] Loaded SSH history:", history.length, "entries");
+        setSshHistory(history);
+      })
+      .catch((err) => console.warn("[SessionCreator] Failed to load SSH history:", err));
     getSessions()
       .then((sessions) => {
         const groups = [...new Set(sessions.map((s) => s.group).filter((g): g is string => !!g))].sort();
@@ -132,6 +183,36 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
       })
       .catch((err) => console.warn("[SessionCreator] Failed to load sessions:", err));
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Discover tmux sessions when entering the tmux step.
+  // If tmux is not installed, skip straight to confirm.
+  useEffect(() => {
+    if (step !== "tmux" || !sshHost.trim()) return;
+    setTmuxLoading(true);
+    setTmuxError(null);
+    setTmuxAvailable(true);
+    sshListTmuxSessions(sshHost.trim(), parseInt(sshPort) || 22, sshUser || undefined)
+      .then((sessions) => {
+        console.log("[SessionCreator] Discovered tmux sessions:", sessions);
+        setTmuxSessions(sessions);
+        setTmuxLoading(false);
+      })
+      .catch((err) => {
+        console.warn("[SessionCreator] tmux discovery failed:", err);
+        const msg = String(err);
+        if (msg.includes("not installed")) {
+          // tmux not available — skip this step entirely
+          setTmuxAvailable(false);
+          setTmuxSessions([]);
+          setSelectedTmuxSession(null);
+          setTmuxLoading(false);
+          setStep("confirm");
+        } else {
+          setTmuxError(msg);
+          setTmuxLoading(false);
+        }
+      });
+  }, [step, sshHost, sshPort, sshUser]);
 
   useEffect(() => {
     if (step === "projects") searchRef.current?.focus();
@@ -248,8 +329,11 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
       const firstProjectPath = selectedProjectIds.length > 0
         ? allProjects.find((r) => r.id === selectedProjectIds[0])?.path
         : undefined;
+      const sshLabel = selectedTmuxSession
+        ? `${sshUser || "ssh"}@${sshHost} [${selectedTmuxSession}]`
+        : `${sshUser || "ssh"}@${sshHost}`;
       await onCreate({
-        label: label || (connectionType === "ssh" ? `${sshUser || "ssh"}@${sshHost}` : undefined),
+        label: label || (connectionType === "ssh" ? sshLabel : undefined),
         description: description || undefined,
         group: selectedGroup || undefined,
         color: selectedColor,
@@ -262,7 +346,21 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
         sshHost: connectionType === "ssh" ? sshHost : undefined,
         sshPort: connectionType === "ssh" ? (parseInt(sshPort) || 22) : undefined,
         sshUser: connectionType === "ssh" ? (sshUser || undefined) : undefined,
+        tmuxSession: connectionType === "ssh" ? (selectedTmuxSession || undefined) : undefined,
       });
+      // Save SSH connection to history
+      if (connectionType === "ssh" && sshHost.trim()) {
+        const entry: SshHistoryEntry = {
+          host: sshHost.trim(),
+          user: sshUser.trim() || "",
+          port: parseInt(sshPort) || 22,
+          lastUsed: new Date().toISOString(),
+        };
+        const updated = addToSshHistory(sshHistory, entry);
+        console.log("[SessionCreator] Saving SSH history:", updated.length, "entries");
+        setSetting(SSH_HISTORY_KEY, JSON.stringify(updated))
+          .catch((err) => console.warn("[SessionCreator] Failed to save SSH history:", err));
+      }
     } finally {
       setCreating(false);
     }
@@ -367,6 +465,31 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
 
             {connectionType === "ssh" && (
               <div className="session-creator-ssh-fields">
+                {sshHistory.length > 0 && !sshHost && (
+                  <div className="session-creator-ssh-history">
+                    <span className="session-creator-ssh-history-label">Recent</span>
+                    <div className="session-creator-ssh-history-list">
+                      {sshHistory.map((h, i) => (
+                        <button
+                          key={`${h.host}-${h.user}-${h.port}-${i}`}
+                          className="session-creator-ssh-history-item"
+                          onClick={() => {
+                            setSshHost(h.host);
+                            setSshUser(h.user);
+                            setSshPort(String(h.port));
+                          }}
+                        >
+                          <span className="session-creator-ssh-history-host">
+                            {h.user ? `${h.user}@` : ""}{h.host}
+                          </span>
+                          {h.port !== 22 && (
+                            <span className="session-creator-ssh-history-port">:{h.port}</span>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
                 <input
                   ref={searchRef}
                   className="command-palette-input"
@@ -534,6 +657,111 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
           />
         )}
 
+        {/* Tmux session picker (SSH only) */}
+        {step === "tmux" && (
+          <div className="session-creator-body">
+            <div className="session-creator-section-title">tmux Sessions</div>
+            {tmuxLoading && (
+              <div className="command-palette-empty">Connecting to {sshHost}...</div>
+            )}
+            {tmuxError && (
+              <div className="command-palette-empty">
+                Failed to discover tmux sessions: {tmuxError}
+              </div>
+            )}
+            {!tmuxLoading && !tmuxError && tmuxAvailable && (
+              <>
+              <div className="session-creator-list">
+                {tmuxSessions.map((ts) => (
+                  <div
+                    key={ts.name}
+                    className={`project-picker-item ${selectedTmuxSession === ts.name ? "project-picker-item-attached" : ""}`}
+                    onClick={() => { setSelectedTmuxSession(ts.name); setShowNewTmuxInput(false); }}
+                  >
+                    <span className="project-picker-check">
+                      {selectedTmuxSession === ts.name ? "[x]" : "[ ]"}
+                    </span>
+                    <div className="project-picker-info">
+                      <div className="project-picker-name">{ts.name}</div>
+                      <div className="project-picker-path">
+                        {ts.windows} window{ts.windows !== 1 ? "s" : ""}
+                        {ts.attached ? " (attached)" : ""}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+                {/* Create new tmux session */}
+                {!showNewTmuxInput ? (
+                  <div
+                    className="project-picker-item"
+                    onClick={() => { setShowNewTmuxInput(true); setNewTmuxSessionName(""); }}
+                  >
+                    <span className="project-picker-check" style={{ opacity: 0.5 }}>+</span>
+                    <div className="project-picker-info">
+                      <div className="project-picker-name">New tmux session</div>
+                      <div className="project-picker-path">Create a new persistent session</div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="project-picker-item project-picker-item-attached">
+                    <span className="project-picker-check">[x]</span>
+                    <div className="project-picker-info" style={{ width: "100%" }}>
+                      <input
+                        className="command-palette-input"
+                        autoFocus
+                        placeholder="Session name..."
+                        value={newTmuxSessionName}
+                        onChange={(e) => {
+                          setNewTmuxSessionName(e.target.value);
+                          // Keep selectedTmuxSession in sync so Next is enabled
+                          setSelectedTmuxSession(e.target.value.trim() || null);
+                        }}
+                        onClick={(e) => e.stopPropagation()}
+                        onKeyDown={(e) => {
+                          e.stopPropagation();
+                          if (e.key === "Enter" && newTmuxSessionName.trim()) {
+                            setSelectedTmuxSession(newTmuxSessionName.trim());
+                            setShowNewTmuxInput(false);
+                          }
+                          if (e.key === "Escape") {
+                            setShowNewTmuxInput(false);
+                            setSelectedTmuxSession(null);
+                          }
+                        }}
+                        onBlur={() => {
+                          if (newTmuxSessionName.trim()) {
+                            setSelectedTmuxSession(newTmuxSessionName.trim());
+                          }
+                          setShowNewTmuxInput(false);
+                        }}
+                        autoComplete="off"
+                        autoCorrect="off"
+                        spellCheck={false}
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+              <span className="settings-hint-inline">
+                tmux sessions persist on the server — reconnect anytime to pick up where you left off
+              </span>
+              </>
+            )}
+            <div className="session-creator-actions">
+              <button className="session-creator-btn-secondary" onClick={goBack}>
+                Back
+              </button>
+              <button
+                className="session-creator-btn-primary"
+                onClick={goNext}
+                disabled={tmuxLoading || !selectedTmuxSession}
+              >
+                {tmuxLoading ? "Discovering..." : "Next"}
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* Step 3: Pick AI Engine */}
         {step === "ai" && (
           <div className="session-creator-body" ref={aiStepRef} tabIndex={-1} style={{ outline: "none" }}>
@@ -611,6 +839,10 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
                   <div className="session-creator-summary-row">
                     <span className="session-creator-summary-label">Host:</span>
                     <span className="session-creator-summary-value">{sshUser ? `${sshUser}@` : ""}{sshHost}{sshPort !== "22" ? `:${sshPort}` : ""}</span>
+                  </div>
+                  <div className="session-creator-summary-row">
+                    <span className="session-creator-summary-label">tmux:</span>
+                    <span className="session-creator-summary-value">{selectedTmuxSession || "None (plain shell)"}</span>
                   </div>
                 </>
               ) : (

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -1,7 +1,8 @@
 import "../styles/components/SessionList.css";
 import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import { SessionData } from "../state/SessionContext";
-import { updateSessionGroup, updateSessionLabel, updateSessionDescription, updateSessionColor } from "../api/sessions";
+import { updateSessionGroup, updateSessionLabel, updateSessionDescription, updateSessionColor, sshListTmuxWindows, sshTmuxSelectWindow, sshTmuxNewWindow, sshTmuxRenameWindow } from "../api/sessions";
+import type { TmuxWindowEntry } from "../types/session";
 import { encodeSessionDrag, setDraggedSession, getDraggedSession } from "./SplitPane";
 // Note: HTML5 drag events don't fire in Tauri (dragDropEnabled: true intercepts them).
 // We use getCurrentWebview().onDragDropEvent() with position-based hit testing instead.
@@ -95,6 +96,112 @@ function SessionItemGitInfo({ sessionId, isDestroyed }: { sessionId: string; isD
         <span className="session-item-git-ahead-behind">
           {ahead > 0 && `↑${ahead}`}{ahead > 0 && behind > 0 && " "}{behind > 0 && `↓${behind}`}
         </span>
+      )}
+    </div>
+  );
+}
+
+/** Sub-component: tmux window tabs for SSH sessions with tmux attached. */
+function TmuxWindowTabs({ session }: { session: SessionData }) {
+  const [windows, setWindows] = useState<TmuxWindowEntry[]>([]);
+  const [expanded, setExpanded] = useState(true);
+  const [renamingIndex, setRenamingIndex] = useState<number | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const refreshRef = useRef<() => void>();
+  const info = session.ssh_info;
+
+  // Refresh tmux windows periodically
+  useEffect(() => {
+    if (!info?.tmux_session || session.phase === "destroyed") return;
+
+    let cancelled = false;
+    const refresh = () => {
+      sshListTmuxWindows(info.host, info.tmux_session!, info.port, info.user)
+        .then((w) => { if (!cancelled) setWindows(w); })
+        .catch(() => {});
+    };
+    refreshRef.current = refresh;
+
+    refresh();
+    const interval = setInterval(refresh, 5000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, [info?.host, info?.port, info?.user, info?.tmux_session, session.phase]);
+
+  if (!info?.tmux_session || session.phase === "destroyed" || windows.length === 0) return null;
+
+  const handleSelectWindow = (index: number) => {
+    // Optimistic: mark the clicked window as active immediately
+    setWindows((prev) => prev.map((w) => ({ ...w, active: w.index === index })));
+    sshTmuxSelectWindow(info.host, info.tmux_session!, index, info.port, info.user)
+      .then(() => refreshRef.current?.())
+      .catch((err) => { console.warn("[TmuxWindows] select failed:", err); refreshRef.current?.(); });
+  };
+
+  const handleNewWindow = () => {
+    sshTmuxNewWindow(info.host, info.tmux_session!, info.port, info.user)
+      .then(() => refreshRef.current?.())
+      .catch((err) => console.warn("[TmuxWindows] new window failed:", err));
+  };
+
+  const handleRename = (index: number, name: string) => {
+    if (!name.trim()) { setRenamingIndex(null); return; }
+    // Optimistic update
+    setWindows((prev) => prev.map((w) => w.index === index ? { ...w, name: name.trim() } : w));
+    setRenamingIndex(null);
+    sshTmuxRenameWindow(info.host, info.tmux_session!, index, name.trim(), info.port, info.user)
+      .then(() => refreshRef.current?.())
+      .catch((err) => { console.warn("[TmuxWindows] rename failed:", err); refreshRef.current?.(); });
+  };
+
+  return (
+    <div className="tmux-windows">
+      <div className="tmux-windows-header" onClick={() => setExpanded(!expanded)}>
+        <span className="tmux-windows-chevron">{expanded ? "▾" : "▸"}</span>
+        <span className="tmux-windows-label">tmux windows</span>
+        <button
+          className="tmux-windows-add"
+          onClick={(e) => { e.stopPropagation(); handleNewWindow(); }}
+          title="New tmux window"
+        >
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" width="12" height="12">
+            <line x1="8" y1="3" x2="8" y2="13" />
+            <line x1="3" y1="8" x2="13" y2="8" />
+          </svg>
+        </button>
+      </div>
+      {expanded && (
+        <div className="tmux-windows-list">
+          {windows.map((w) => (
+            <div
+              key={w.index}
+              className={`tmux-window-item ${w.active ? "tmux-window-active" : ""}`}
+              onClick={(e) => { e.stopPropagation(); handleSelectWindow(w.index); }}
+              onDoubleClick={(e) => { e.stopPropagation(); setRenamingIndex(w.index); setRenameValue(w.name); }}
+            >
+              <span className="tmux-window-index">{w.index}</span>
+              {renamingIndex === w.index ? (
+                <input
+                  className="tmux-window-rename-input"
+                  autoFocus
+                  value={renameValue}
+                  onChange={(e) => setRenameValue(e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => {
+                    e.stopPropagation();
+                    if (e.key === "Enter") handleRename(w.index, renameValue);
+                    if (e.key === "Escape") setRenamingIndex(null);
+                  }}
+                  onBlur={() => handleRename(w.index, renameValue)}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+              ) : (
+                <span className="tmux-window-name">{w.name}</span>
+              )}
+              {w.active && <span className="tmux-window-active-dot" />}
+            </div>
+          ))}
+        </div>
       )}
     </div>
   );
@@ -708,7 +815,7 @@ export function SessionList({ sessions, activeSessionId, onSelect, onClose, onNe
             <InlineDescriptionEditor sessionId={session.id} description={session.description} isActive={isActive} />
             <div className="session-item-meta">
               {session.ssh_info && (
-                <span className="session-ssh-tag">SSH</span>
+                <span className="session-ssh-tag">SSH{session.ssh_info.tmux_session ? ` · ${session.ssh_info.tmux_session}` : ""}</span>
               )}
               {session.detected_agent && (
                 <span className="session-agent-tag">{session.detected_agent.name}</span>
@@ -751,6 +858,10 @@ export function SessionList({ sessions, activeSessionId, onSelect, onClose, onNe
             title="End session"
           >&times;</button>
         </div>
+        {/* Tmux window tabs for SSH+tmux sessions */}
+        {session.ssh_info?.tmux_session && isActive && (
+          <TmuxWindowTabs session={session} />
+        )}
         {/* Move-to-project dropdown */}
         {moveSessionId === session.id && (
           <div className="session-move-project-dropdown" onClick={(e) => e.stopPropagation()}>

--- a/src/state/SessionContext.tsx
+++ b/src/state/SessionContext.tsx
@@ -756,6 +756,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
                 sshHost: saved.ssh_info?.host || null,
                 sshPort: saved.ssh_info?.port || null,
                 sshUser: saved.ssh_info?.user || null,
+                tmuxSession: saved.ssh_info?.tmux_session || null,
               });
               await createTerminal(newSession.id, newSession.color);
 
@@ -867,6 +868,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         sshHost: opts?.sshHost || null,
         sshPort: opts?.sshPort || null,
         sshUser: opts?.sshUser || null,
+        tmuxSession: opts?.tmuxSession || null,
       });
       await createTerminal(session.id, session.color);
 

--- a/src/styles/components/SessionCreator.css
+++ b/src/styles/components/SessionCreator.css
@@ -529,3 +529,51 @@
   flex-shrink: 0;
 }
 
+.session-creator-ssh-history {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.session-creator-ssh-history-label {
+  font-size: var(--text-sm);
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.session-creator-ssh-history-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.session-creator-ssh-history-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--text-1);
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.session-creator-ssh-history-item:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+}
+
+.session-creator-ssh-history-host {
+  color: var(--text-0);
+}
+
+.session-creator-ssh-history-port {
+  color: var(--text-3);
+  font-size: 10px;
+}
+

--- a/src/styles/components/SessionList.css
+++ b/src/styles/components/SessionList.css
@@ -910,3 +910,122 @@
   outline: none;
   font-family: var(--font-ui);
 }
+
+/* ─── Tmux Window Tabs ─────────────────────────────── */
+
+.tmux-windows {
+  margin-left: 12px;
+  border-left: 1px solid var(--border);
+  padding-left: 8px;
+  margin-bottom: 2px;
+}
+
+.tmux-windows-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 4px;
+  font-size: var(--text-sm);
+  color: var(--text-3);
+  cursor: pointer;
+  user-select: none;
+}
+
+.tmux-windows-header:hover { color: var(--text-2); }
+
+.tmux-windows-chevron {
+  font-size: 9px;
+  width: 10px;
+  text-align: center;
+}
+
+.tmux-windows-label {
+  flex: 1;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.tmux-windows-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-2);
+  cursor: pointer;
+  padding: 2px;
+  border-radius: var(--radius-sm);
+  opacity: 0.7;
+  transition: opacity 0.1s, background 0.1s;
+}
+
+.tmux-windows-header:hover .tmux-windows-add { opacity: 1; }
+
+.tmux-windows-add:hover {
+  color: var(--text-0);
+  background: var(--bg-3);
+  border-color: var(--text-3);
+  opacity: 1;
+}
+
+.tmux-windows-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.tmux-window-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 6px;
+  font-size: var(--text-sm);
+  color: var(--text-2);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+
+.tmux-window-item:hover {
+  background: var(--bg-3);
+  color: var(--text-1);
+}
+
+.tmux-window-active {
+  color: var(--text-1);
+}
+
+.tmux-window-index {
+  color: var(--text-3);
+  font-size: 10px;
+  min-width: 10px;
+  text-align: right;
+}
+
+.tmux-window-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tmux-window-active-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #39c5cf;
+  flex-shrink: 0;
+}
+
+.tmux-window-rename-input {
+  flex: 1;
+  background: var(--bg-2);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  color: var(--text-0);
+  font-size: var(--text-sm);
+  font-family: var(--font-ui);
+  padding: 1px 4px;
+  outline: none;
+  min-width: 0;
+}

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -67,6 +67,19 @@ export interface SshConnectionInfo {
   host: string;
   port: number;
   user: string;
+  tmux_session?: string | null;
+}
+
+export interface TmuxSessionEntry {
+  name: string;
+  windows: number;
+  attached: boolean;
+}
+
+export interface TmuxWindowEntry {
+  index: number;
+  name: string;
+  active: boolean;
 }
 
 export interface SessionData {
@@ -137,6 +150,7 @@ export interface CreateSessionOpts {
   sshHost?: string;
   sshPort?: number;
   sshUser?: string;
+  tmuxSession?: string;
 }
 
 // ─── Workspace Restore ──────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Native integration with tmux, allowing session persistance on remote servers, this means you can easily create a tmux session, and if you reboot your device the session continues to run on the remote server, and you can later pick up where you left off.


## Type of Change

- [ ] Bug fix
- [ ] Performance improvement
- [x] New feature (approved in discussion)
- [ ] Documentation
- [ ] Refactoring (no behavior change)

## Screenshots
<img width="480" height="441" alt="CleanShot 2026-03-11 at 08 23 49" src="https://github.com/user-attachments/assets/0524ad24-ddc7-4422-8239-f13b023cabcf" />
<img width="476" height="637" alt="CleanShot 2026-03-11 at 08 24 22" src="https://github.com/user-attachments/assets/8ce3ccd5-a4d1-4c97-9cc9-58b2573320b8" />
<img width="902" height="570" alt="CleanShot 2026-03-11 at 08 24 44" src="https://github.com/user-attachments/assets/e4b097b4-b54a-4c6d-8985-482508ba6f2b" />
<img width="677" height="522" alt="CleanShot 2026-03-11 at 08 25 18" src="https://github.com/user-attachments/assets/3c4104d7-d040-4e4d-8ca1-f73d35aacee2" />
