### PR TITLE
Fix extra spaces when copying multi-line terminal text

### DIFF
--- a/src/terminal/TerminalPool.ts
+++ b/src/terminal/TerminalPool.ts
@@ -499,9 +499,13 @@ export function terminalHasSelection(sessionId: string): boolean {
   return pool.get(sessionId)?.terminal.hasSelection() ?? false;
 }
 
-/** Get the selected text from the terminal (canvas-based selection). */
+/** Get the selected text from the terminal (canvas-based selection).
+ *  Trims trailing whitespace from each line to avoid padding spaces
+ *  that xterm includes when soft-wrapped lines fill the terminal width. */
 export function terminalGetSelection(sessionId: string): string {
-  return pool.get(sessionId)?.terminal.getSelection() ?? "";
+  const raw = pool.get(sessionId)?.terminal.getSelection() ?? "";
+  if (!raw) return raw;
+  return raw.split("\n").map(line => line.trimEnd()).join("\n");
 }
 
 /** Write arbitrary text into the terminal as if pasted (e.g. a file path from a drop event).

--- a/src/terminal/pool.ts
+++ b/src/terminal/pool.ts
@@ -217,6 +217,17 @@ export async function createTerminal(
     handleTerminalInput(sessionId, data);
   });
 
+  // Strip trailing whitespace from copied text (Cmd+C / Ctrl+C).
+  // xterm pads soft-wrapped lines to the full terminal width, which
+  // causes extra spaces when pasting into other applications.
+  container.addEventListener("copy", (e: ClipboardEvent) => {
+    const sel = terminal.getSelection();
+    if (!sel || !e.clipboardData) return;
+    const cleaned = sel.split("\n").map(l => l.trimEnd()).join("\n");
+    e.clipboardData.setData("text/plain", cleaned);
+    e.preventDefault();
+  });
+
   // Track user scroll position to avoid jumping during streaming
   terminal.onScroll(() => {
     const entry = pool.get(sessionId);


### PR DESCRIPTION
## Summary
- Strip trailing whitespace from each line when copying text from the terminal
- Applied to both context menu copy and native Cmd+C/Ctrl+C keyboard shortcut
- xterm.js pads soft-wrapped lines to the full terminal width, which caused extra spaces when pasting into other apps

Closes #87