### PR TITLE
Fix plugin hot-reload not applying new code

### DIFF
--- a/src/plugins/PluginLoader.ts
+++ b/src/plugins/PluginLoader.ts
@@ -74,12 +74,15 @@ export class PluginLoader {
 
 	/**
 	 * Load a single plugin from its directory.
+	 * If the plugin is already loaded (e.g. during hot-reload), the old
+	 * version is fully cleaned up before the new one is loaded.
 	 */
 	private async loadPlugin(info: InstalledPluginInfo): Promise<void> {
-		if (this.loadedPlugins.has(info.id)) {
-			console.warn(`[PluginLoader] Plugin "${info.id}" already loaded, skipping`);
-			return;
-		}
+		// Clean up any previously loaded version of this plugin.
+		// Handles hot-reload: removes old script tag, global reference,
+		// and unregisters from the runtime so the new version can register.
+		// All operations are no-ops if the plugin isn't loaded yet.
+		await this.cleanupPlugin(info.id);
 
 		// Parse manifest
 		let manifest: PluginManifest;


### PR DESCRIPTION
## Summary
- Fix plugin updates requiring a full IDE restart to take effect
- `loadPlugin` now always cleans up the previous version before loading the new one
- This ensures the old script tag, global `window.__hermesPlugins` reference, and runtime registration are removed so the new code can register and activate

## Root cause
`hotLoadPlugins` created a new `PluginLoader` and called `loadAllPlugins()`, but the runtime still had the old plugins registered. `runtime.register()` silently returned early when it saw existing IDs, and `activateStartupPlugins()` skipped them because they were already `"active"`. The new code was never loaded.

## Test plan
- [ ] Install a plugin, then update it — verify the new behavior is active immediately without restarting
- [ ] Verify auto-update path also applies changes immediately
- [ ] Verify initial plugin load on startup still works normally

Closes #79