### PR TITLE
feat: Fixing resize bug

### DIFF
--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -5,7 +5,7 @@ import { detectProject } from "../api/projects";
 import {
   attach, detach, has, showGhostText, clearGhostText,
   subscribeSuggestions, setSessionPhase, setSessionCwd,
-  getHistoryProvider,
+  getHistoryProvider, refitActive,
 } from "../terminal/TerminalPool";
 import { useExecutionMode, useAutonomousSettings, useSession } from "../state/SessionContext";
 import { SuggestionOverlay, type SuggestionState } from "../terminal/intelligence/SuggestionOverlay";
@@ -67,22 +67,41 @@ export function TerminalPane({ sessionId, phase, color }: TerminalPaneProps) {
     return () => { detach(sessionId); };
   }, [sessionId]);
 
-  // Handle resize when container size changes (debounced)
+  // Handle resize when container size changes (debounced).
+  // Uses double-rAF to ensure CSS layout has settled before measuring.
   useEffect(() => {
     if (!viewportRef.current) return;
     let resizeTimer: ReturnType<typeof setTimeout>;
+
+    const doRefit = () => {
+      // Double-rAF: first frame triggers layout, second frame measures it.
+      // This is necessary because percentage-based CSS heights may not resolve
+      // within the same frame that triggered the ResizeObserver.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          refitActive();
+        });
+      });
+    };
+
     const observer = new ResizeObserver(() => {
       clearTimeout(resizeTimer);
-      resizeTimer = setTimeout(() => {
-        if (has(sessionId) && viewportRef.current) {
-          attach(sessionId, viewportRef.current);
-        }
-      }, 100);
+      resizeTimer = setTimeout(doRefit, 100);
     });
     observer.observe(viewportRef.current);
+
+    // Fallback: also listen for window resize events.
+    // ResizeObserver can miss some cases (e.g. window restore from minimized).
+    const onWindowResize = () => {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(doRefit, 100);
+    };
+    window.addEventListener("resize", onWindowResize);
+
     return () => {
       clearTimeout(resizeTimer);
       observer.disconnect();
+      window.removeEventListener("resize", onWindowResize);
     };
   }, [sessionId]);
 

--- a/src/styles/components/TerminalPane.css
+++ b/src/styles/components/TerminalPane.css
@@ -11,6 +11,7 @@
   width: 100%;
   height: 100%;
   padding: 4px 0 0 4px;
+  box-sizing: border-box;
   overflow: hidden;
 }
 

--- a/src/terminal/pool.ts
+++ b/src/terminal/pool.ts
@@ -392,13 +392,15 @@ export function destroy(sessionId: string): void {
 }
 
 export function refitActive(): void {
-  for (const entry of pool.values()) {
+  for (const [sessionId, entry] of pool) {
     if (entry.attached && entry.opened) {
       try {
         entry.fitAddon.fit();
         if (!entry.userScrolledUp) {
           entry.terminal.scrollToBottom();
         }
+        resizeSession(sessionId, entry.terminal.rows, entry.terminal.cols)
+          .catch(() => {});
       } catch { /* ignore fit errors */ }
     }
   }


### PR DESCRIPTION
## What does this PR do?

1. refitActive() now sends resize to PTY (pool.ts): Previously it only called 
  fitAddon.fit() without notifying the backend PTY about the new dimensions. The
   terminal would re-render at the right size but the shell/tmux wouldn't know  
  about the new cols/rows.                                                      
  2. Double-rAF in resize handler (TerminalPane.tsx): The ResizeObserver     
  callback now uses a double requestAnimationFrame before measuring. The first
  frame triggers CSS layout reflow; the second measures the settled dimensions.
  This handles the case where percentage-based heights (100%) don't resolve in
  the same frame as the parent resize.
  3. Window resize fallback + box-sizing fix (TerminalPane.tsx +
  TerminalPane.css):
    - Added window.addEventListener("resize") as a fallback for cases the
  ResizeObserver might miss (e.g., window restore from minimized state)
    - Added box-sizing: border-box to .terminal-viewport so its padding: 4px 0 0
   4px doesn't cause it to overflow its parent by 4px (which could affect
  dimension calculations)

## Type of Change

- [x] Bug fix
- [ ] Performance improvement
- [ ] New feature (approved in discussion)
- [ ] Documentation
- [ ] Refactoring (no behavior change)
