### PR TITLE
Remove plugin items from the status bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,7 +142,7 @@ function AppContent() {
     return runtime;
   });
 
-  const { commands: pluginCommands, panels: pluginPanels, statusBarItems: pluginStatusBarItems, pluginsWithSettings } = usePluginRuntime(pluginRuntime);
+  const { commands: pluginCommands, panels: pluginPanels, pluginsWithSettings } = usePluginRuntime(pluginRuntime);
   const pluginUpdater = usePluginUpdateChecker(pluginRuntime);
 
   useEffect(() => {
@@ -618,8 +618,6 @@ function AppContent() {
 
       <StatusBar
         onOpenShortcuts={() => setShortcutsOpen(true)}
-        pluginStatusBarItems={pluginStatusBarItems}
-        onPluginStatusBarClick={(command) => pluginRuntime.executeCommand(command)}
         updateAvailable={updater.state.available}
         updateVersion={updater.state.version}
         updateDownloading={updater.state.downloading}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -24,8 +24,6 @@ function formatElapsed(createdAt: string): string {
 
 interface StatusBarProps {
   onOpenShortcuts?: () => void;
-  pluginStatusBarItems?: { id: string; text: string; tooltip?: string; alignment: "left" | "right"; priority?: number; command?: string; pluginId: string; visible: boolean }[];
-  onPluginStatusBarClick?: (command: string) => void;
   updateAvailable?: boolean;
   updateVersion?: string;
   updateDownloading?: boolean;
@@ -34,7 +32,7 @@ interface StatusBarProps {
   onCheckForUpdates?: () => void;
 }
 
-export function StatusBar({ onOpenShortcuts, pluginStatusBarItems, onPluginStatusBarClick, updateAvailable, updateVersion, updateDownloading, updateProgress, onShowUpdate, onCheckForUpdates }: StatusBarProps) {
+export function StatusBar({ onOpenShortcuts, updateAvailable, updateVersion, updateDownloading, updateProgress, onShowUpdate, onCheckForUpdates }: StatusBarProps) {
   const active = useActiveSession();
   const sessions = useSessionList();
   const totalCost = useTotalCost();
@@ -148,19 +146,6 @@ export function StatusBar({ onOpenShortcuts, pluginStatusBarItems, onPluginStatu
             <span className="status-bar-divider" />
           </>
         )}
-        {pluginStatusBarItems?.filter(item => item.visible && item.alignment === "right").map(item => (
-          <span key={item.id} className="status-bar-plugin-group">
-            <span
-              className="status-bar-item"
-              title={item.tooltip}
-              style={{ cursor: item.command ? "pointer" : "default" }}
-              onClick={item.command ? () => onPluginStatusBarClick?.(item.command!) : undefined}
-            >
-              {item.text}
-            </span>
-            <span className="status-bar-divider" />
-          </span>
-        ))}
         {updateAvailable && !updateDownloading && (
           <>
             <span className="status-bar-item status-bar-update" onClick={onShowUpdate} title={`Update to v${updateVersion}`}>

--- a/src/plugins/usePluginRuntime.ts
+++ b/src/plugins/usePluginRuntime.ts
@@ -1,11 +1,10 @@
 import { useState, useEffect } from "react";
-import type { PluginRuntime, RuntimeStatusBarItem } from "./PluginRuntime";
+import type { PluginRuntime } from "./PluginRuntime";
 import type { PluginCommandContribution, PluginPanelContribution } from "./types";
 
 export function usePluginRuntime(runtime: PluginRuntime | null) {
 	const [commands, setCommands] = useState<(PluginCommandContribution & { pluginId: string; pluginName: string })[]>([]);
 	const [panels, setPanels] = useState<(PluginPanelContribution & { pluginId: string })[]>([]);
-	const [statusBarItems, setStatusBarItems] = useState<RuntimeStatusBarItem[]>([]);
 	const [pluginsWithSettings, setPluginsWithSettings] = useState<{ pluginId: string; pluginName: string }[]>([]);
 
 	useEffect(() => {
@@ -14,7 +13,6 @@ export function usePluginRuntime(runtime: PluginRuntime | null) {
 		const refresh = () => {
 			setCommands(runtime.getAllCommands());
 			setPanels(runtime.getAllPanels());
-			setStatusBarItems(runtime.getAllStatusBarItems());
 			setPluginsWithSettings(runtime.getPluginsWithSettings());
 		};
 
@@ -25,5 +23,5 @@ export function usePluginRuntime(runtime: PluginRuntime | null) {
 		return runtime.subscribe(refresh);
 	}, [runtime]);
 
-	return { commands, panels, statusBarItems, pluginsWithSettings, runtime };
+	return { commands, panels, pluginsWithSettings, runtime };
 }

--- a/src/styles/components/StatusBar.css
+++ b/src/styles/components/StatusBar.css
@@ -241,9 +241,3 @@
   flex-shrink: 0;
   box-shadow: 0 0 4px currentColor;
 }
-
-/* ─── Plugin Status Bar Items ──────────────── */
-
-.status-bar-plugin-group {
-  display: contents;
-}


### PR DESCRIPTION
## Summary
- Removed plugin status bar items from the footer to keep it clean and minimal
- Plugins are still accessible from their panel icons in the sidebar

Closes #95