### PR TITLE
Fix duplicate update buttons in Plugin Manager

### DIFF
--- a/src/components/PluginManager.tsx
+++ b/src/components/PluginManager.tsx
@@ -310,24 +310,13 @@ export function PluginManager({ runtime }: { runtime?: PluginRuntime }) {
 						{update && <span className="pm-badge pm-badge-update">update</span>}
 					</div>
 					<div className="pm-row-action">
-						{isUpdating ? (
-							<span className="pm-progress"><span className="pm-spinner" /></span>
-						) : update ? (
-							<button
-								className="pm-btn pm-btn-update pm-btn-sm"
-								onClick={(e) => { e.stopPropagation(); handleUpdate(update); }}
-							>
-								Update
-							</button>
-						) : (
-							<button
-								className="pm-btn pm-btn-sm"
-								onClick={(e) => { e.stopPropagation(); handleToggleEnabled(p.manifest.id, p.enabled); }}
-								disabled={isToggling}
-							>
-								{p.enabled ? "Disable" : "Enable"}
-							</button>
-						)}
+						<button
+							className="pm-btn pm-btn-sm"
+							onClick={(e) => { e.stopPropagation(); handleToggleEnabled(p.manifest.id, p.enabled); }}
+							disabled={isToggling}
+						>
+							{p.enabled ? "Disable" : "Enable"}
+						</button>
 					</div>
 				</div>
 				{isExpanded && (


### PR DESCRIPTION
## Summary
- Removed the duplicate "Update" button from the compact plugin row
- Row action now always shows Disable/Enable
- Update is only available via "Update to vX.Y.Z" in the expanded detail panel
- "update" badge still shown on the row to indicate availability

Closes #75