### PR TITLE
Show changelog before confirming plugin updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,7 @@ import { PluginUpdateBanner } from "./components/PluginUpdateBanner";
 import { ToastContainer } from "./components/ToastContainer";
 import { useToastStore } from "./hooks/useToastStore";
 import { WhatsNewDialog } from "./components/WhatsNewDialog";
+import { PluginUpdateConfirmDialog } from "./components/PluginUpdateConfirmDialog";
 import { OnboardingWizard } from "./components/OnboardingWizard";
 
 function AppContent() {
@@ -144,6 +145,7 @@ function AppContent() {
 
   const { commands: pluginCommands, panels: pluginPanels, pluginsWithSettings } = usePluginRuntime(pluginRuntime);
   const pluginUpdater = usePluginUpdateChecker(pluginRuntime);
+  const [pendingUpdatePlugins, setPendingUpdatePlugins] = useState<typeof pluginUpdater.updatesAvailable | null>(null);
 
   useEffect(() => {
     const loader = new PluginLoader(pluginRuntime);
@@ -576,7 +578,11 @@ function AppContent() {
             </PluginPanelHost>
           );
         })()}
-        <PluginUpdateBanner updater={pluginUpdater} toastStore={toastStore} />
+        <PluginUpdateBanner
+          updater={pluginUpdater}
+          toastStore={toastStore}
+          onShowUpdateConfirm={() => setPendingUpdatePlugins([...pluginUpdater.updatesAvailable])}
+        />
         <div className="main-area">
           <div className="terminal-and-timeline">
             <div className="terminal-container">
@@ -669,7 +675,17 @@ function AppContent() {
       )}
 
       {settingsOpen && (
-        <Settings onClose={() => setSettingsOpen(null)} initialTab={settingsOpen} pluginRuntime={pluginRuntime} />
+        <Settings
+          onClose={() => setSettingsOpen(null)}
+          initialTab={settingsOpen}
+          pluginRuntime={pluginRuntime}
+          onConfirmPluginUpdate={(plugin) => {
+            const info = pluginUpdater.updatesAvailable.find((u) => u.id === plugin.id);
+            if (info) {
+              setPendingUpdatePlugins([info]);
+            }
+          }}
+        />
       )}
 
       {workspaceOpen && (
@@ -678,6 +694,22 @@ function AppContent() {
 
       {projectPickerOpen && activeSession && (
         <ProjectPicker sessionId={activeSession.id} onClose={() => setProjectPickerOpen(false)} />
+      )}
+
+      {pendingUpdatePlugins && pendingUpdatePlugins.length > 0 && (
+        <PluginUpdateConfirmDialog
+          plugins={pendingUpdatePlugins}
+          onConfirm={() => {
+            const plugins = pendingUpdatePlugins;
+            setPendingUpdatePlugins(null);
+            if (plugins.length === 1) {
+              pluginUpdater.updatePlugin(plugins[0]);
+            } else {
+              pluginUpdater.updateAll();
+            }
+          }}
+          onCancel={() => setPendingUpdatePlugins(null)}
+        />
       )}
 
       {sessionCreatorOpen && (

--- a/src/components/PluginManager.tsx
+++ b/src/components/PluginManager.tsx
@@ -48,7 +48,12 @@ const PackageIcon = () => (
 	</svg>
 );
 
-export function PluginManager({ runtime }: { runtime?: PluginRuntime }) {
+interface PluginManagerProps {
+	runtime?: PluginRuntime;
+	onConfirmUpdate?: (plugin: RegistryPlugin) => void;
+}
+
+export function PluginManager({ runtime, onConfirmUpdate }: PluginManagerProps) {
 	const [installed, setInstalled] = useState<PluginEntry[]>([]);
 	const [registry, setRegistry] = useState<RegistryPlugin[]>([]);
 	const [pluginsDir, setPluginsDir] = useState("");
@@ -375,7 +380,13 @@ export function PluginManager({ runtime }: { runtime?: PluginRuntime }) {
 								{p.enabled ? "Disable" : "Enable"}
 							</button>
 							{update && !isUpdating && (
-								<button className="pm-btn pm-btn-update" onClick={() => handleUpdate(update)}>
+								<button className="pm-btn pm-btn-update" onClick={() => {
+									if (onConfirmUpdate) {
+										onConfirmUpdate(update);
+									} else {
+										handleUpdate(update);
+									}
+								}}>
 									Update to v{update.version}
 								</button>
 							)}

--- a/src/components/PluginUpdateBanner.tsx
+++ b/src/components/PluginUpdateBanner.tsx
@@ -5,13 +5,14 @@ import type { ToastStore } from "../hooks/useToastStore";
 interface PluginUpdateNotifierProps {
 	updater: PluginUpdater;
 	toastStore: ToastStore;
+	onShowUpdateConfirm?: () => void;
 }
 
 /**
  * Effect-only component: watches plugin update state and pushes toasts
  * to the shared toast system. Renders nothing to the DOM.
  */
-export function PluginUpdateBanner({ updater, toastStore }: PluginUpdateNotifierProps) {
+export function PluginUpdateBanner({ updater, toastStore, onShowUpdateConfirm }: PluginUpdateNotifierProps) {
 	const { updatesAvailable, updateResults, autoUpdated, dismissed, updateAll, dismissAll, clearResults } = updater;
 
 	// Track which state snapshots we've already shown toasts for,
@@ -45,11 +46,21 @@ export function PluginUpdateBanner({ updater, toastStore }: PluginUpdateNotifier
 			type: "info",
 			duration: null, // persistent — user must act
 			actions: [
-				{ label: "Update All", primary: true, onClick: () => updateAll() },
+				{
+					label: "Review & Update",
+					primary: true,
+					onClick: () => {
+						if (onShowUpdateConfirm) {
+							onShowUpdateConfirm();
+						} else {
+							updateAll();
+						}
+					},
+				},
 				{ label: "Later", onClick: () => dismissAll() },
 			],
 		});
-	}, [updatesAvailable, dismissed, toastStore, updateAll, dismissAll]);
+	}, [updatesAvailable, dismissed, toastStore, updateAll, dismissAll, onShowUpdateConfirm]);
 
 	// ─── Post-update results → toast ───────────────────────
 	useEffect(() => {

--- a/src/components/PluginUpdateConfirmDialog.tsx
+++ b/src/components/PluginUpdateConfirmDialog.tsx
@@ -1,0 +1,89 @@
+import "../styles/components/PluginUpdateConfirmDialog.css";
+import type { PluginUpdateInfo } from "../hooks/usePluginUpdateChecker";
+import type { ChangelogEntry } from "../plugins/types";
+import { hasUpdate } from "../plugins/semver";
+
+interface PluginUpdateConfirmDialogProps {
+	plugins: PluginUpdateInfo[];
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+export function PluginUpdateConfirmDialog({ plugins, onConfirm, onCancel }: PluginUpdateConfirmDialogProps) {
+	if (plugins.length === 0) return null;
+
+	const single = plugins.length === 1;
+
+	return (
+		<div className="puc-backdrop" onClick={onCancel}>
+			<div className="puc-dialog" onClick={(e) => e.stopPropagation()}>
+				<div className="puc-header">
+					<span className="puc-title">
+						{single ? "Update Plugin" : "Update Plugins"}
+					</span>
+					<span className="puc-count">
+						{single ? "1 plugin" : `${plugins.length} plugins`}
+					</span>
+				</div>
+				<div className="puc-body">
+					{plugins.map((plugin) => (
+						<PluginCard key={plugin.id} plugin={plugin} />
+					))}
+				</div>
+				<div className="puc-footer">
+					<button className="puc-btn puc-btn-cancel" onClick={onCancel}>
+						Cancel
+					</button>
+					<button className="puc-btn puc-btn-confirm" onClick={onConfirm}>
+						{single ? "Update" : "Update All"}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function PluginCard({ plugin }: { plugin: PluginUpdateInfo }) {
+	const newEntries = plugin.changelog?.filter(
+		(entry: ChangelogEntry) => hasUpdate(plugin.currentVersion, entry.version)
+	) ?? [];
+
+	return (
+		<div className="puc-plugin">
+			<div className="puc-plugin-header">
+				{plugin.icon && (
+					<div
+						className="puc-plugin-icon"
+						dangerouslySetInnerHTML={{ __html: plugin.icon }}
+					/>
+				)}
+				<span className="puc-plugin-name">{plugin.name}</span>
+				<span className="puc-plugin-versions">
+					v{plugin.currentVersion}
+					<span className="puc-arrow">&rarr;</span>
+					<span className="puc-plugin-new-version">v{plugin.newVersion}</span>
+				</span>
+			</div>
+			{newEntries.length > 0 ? (
+				<div className="puc-changelog">
+					{newEntries.map((entry) => (
+						<div key={entry.version} className="puc-changelog-entry">
+							{newEntries.length > 1 && (
+								<div className="puc-changelog-version">
+									v{entry.version} &middot; {entry.date}
+								</div>
+							)}
+							<ul className="puc-changelog-list">
+								{entry.changes.map((change, i) => (
+									<li key={i}>{change}</li>
+								))}
+							</ul>
+						</div>
+					))}
+				</div>
+			) : (
+				<div className="puc-no-changelog">No changelog available</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -20,11 +20,12 @@ interface SettingsProps {
   onClose: () => void;
   initialTab?: string;
   pluginRuntime?: import("../plugins/PluginRuntime").PluginRuntime;
+  onConfirmPluginUpdate?: (plugin: import("../plugins/types").RegistryPlugin) => void;
 }
 
 const THEMES = THEME_OPTIONS;
 
-export function Settings({ onClose, initialTab, pluginRuntime }: SettingsProps) {
+export function Settings({ onClose, initialTab, pluginRuntime, onConfirmPluginUpdate }: SettingsProps) {
   const [settings, setSettings] = useState<SettingsMap>({});
   const [shells, setShells] = useState<{ name: string; path: string }[]>([]);
   const [activeTab, setActiveTab] = useState(initialTab || "general");
@@ -522,7 +523,7 @@ export function Settings({ onClose, initialTab, pluginRuntime }: SettingsProps) 
                     </p>
                   </div>
                 </div>
-                <PluginManager runtime={pluginRuntime} />
+                <PluginManager runtime={pluginRuntime} onConfirmUpdate={onConfirmPluginUpdate} />
               </>
             )}
 

--- a/src/styles/components/PluginUpdateConfirmDialog.css
+++ b/src/styles/components/PluginUpdateConfirmDialog.css
@@ -1,0 +1,184 @@
+/* ─── Plugin Update Confirm Dialog ──────────────────────── */
+
+.puc-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+  backdrop-filter: blur(2px);
+}
+
+.puc-dialog {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  width: 520px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  animation: overlayIn 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.puc-header {
+  padding: 20px 20px 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.puc-title {
+  font-size: var(--text-xl);
+  font-weight: 600;
+  color: var(--text-0);
+}
+
+.puc-count {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--accent);
+  background: var(--accent-dim);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  margin-left: auto;
+}
+
+.puc-body {
+  padding: 16px 20px;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* ─── Plugin card ──────────────────────────── */
+
+.puc-plugin {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px;
+  background: var(--bg-2);
+}
+
+.puc-plugin-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.puc-plugin-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--text-2);
+}
+
+.puc-plugin-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+}
+
+.puc-plugin-name {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--text-0);
+}
+
+.puc-plugin-versions {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  color: var(--text-3);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.puc-plugin-versions .puc-arrow {
+  color: var(--green);
+}
+
+.puc-plugin-new-version {
+  color: var(--green);
+  font-weight: 500;
+}
+
+/* ─── Changelog within card ────────────────── */
+
+.puc-changelog {
+  margin-top: 8px;
+}
+
+.puc-changelog-entry + .puc-changelog-entry {
+  margin-top: 6px;
+}
+
+.puc-changelog-version {
+  font-size: var(--text-xs);
+  color: var(--text-3);
+  margin-bottom: 2px;
+}
+
+.puc-changelog-list {
+  margin: 0;
+  padding-left: 16px;
+  font-size: var(--text-sm);
+  color: var(--text-1);
+  line-height: 1.6;
+}
+
+.puc-no-changelog {
+  font-size: var(--text-sm);
+  color: var(--text-3);
+  font-style: italic;
+}
+
+/* ─── Footer ───────────────────────────────── */
+
+.puc-footer {
+  padding: 14px 20px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.puc-btn {
+  padding: 7px 20px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: var(--text-base);
+  font-family: var(--font-ui);
+  font-weight: 500;
+  transition: background 0.1s, color 0.1s;
+}
+
+.puc-btn-cancel {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-2);
+}
+
+.puc-btn-cancel:hover {
+  background: var(--bg-hover);
+  color: var(--text-1);
+}
+
+.puc-btn-confirm {
+  background: var(--green-dim);
+  border: 1px solid var(--green);
+  color: var(--green);
+}
+
+.puc-btn-confirm:hover {
+  background: var(--green);
+  color: var(--bg-0);
+}


### PR DESCRIPTION
## Summary
- Added a confirmation dialog that shows changelogs before any plugin update is applied
- Toast notification now shows "Review & Update" instead of "Update All", opening the dialog
- Individual update buttons in the Plugin Manager also route through the dialog
- Dialog displays version transitions (current → new) and changelog entries per plugin

## Test plan
- [ ] When plugin updates are available, toast shows "Review & Update" button
- [ ] Clicking "Review & Update" opens the confirmation dialog with changelogs
- [ ] Clicking "Update" in Plugin Manager expanded view opens the same dialog
- [ ] Confirming in the dialog triggers the actual update
- [ ] Cancelling or clicking outside the dialog dismisses it without updating
- [ ] Dialog correctly filters changelog to only show entries newer than installed version
- [ ] "Update All" vs single "Update" button labels match the number of plugins

Closes #80