### PR TITLE
feat: Send CSI u sequence for Shift+Enter to match iTerm2, Ghostty, a…

### DIFF
--- a/src/terminal/pool.ts
+++ b/src/terminal/pool.ts
@@ -209,6 +209,14 @@ export async function createTerminal(
       }
     }
 
+    // Shift+Enter → send CSI u sequence (like iTerm2, Ghostty, Kitty)
+    // This allows CLI tools (e.g. Claude Code) to distinguish Shift+Enter from Enter.
+    if (_event.type === "keydown" && _event.key === "Enter" && _event.shiftKey && !_event.metaKey && !_event.altKey && !_event.ctrlKey) {
+      _event.preventDefault();
+      handleTerminalInput(sessionId, "\x1b[13;2u");
+      return false;
+    }
+
     // Let xterm handle everything else natively.
     return true;
   });


### PR DESCRIPTION
## What does this PR do?

Shift+Enter now inserts a newline in CLI tools that support it (e.g. Claude Code), matching the behavior of iTerm2, Ghostty, and Kitty terminals.

## Related Issue

Closes #106 

## Type of Change

- [x] Bug fix
- [ ] Performance improvement
- [ ] New feature (approved in discussion)
- [ ] Documentation
- [ ] Refactoring (no behavior change)
