### PR TITLE
fix: suggestion overlay positioning, click support, and expanded results

### DIFF
--- a/src/__tests__/suggestion-engine.test.ts
+++ b/src/__tests__/suggestion-engine.test.ts
@@ -241,14 +241,14 @@ describe("SuggestionEngine - suggest()", () => {
       expect(texts).toContain("git stash");
     });
 
-    it("returns max 6 results", () => {
+    it("returns max 15 results", () => {
       // "git" prefix should match many commands in the index
       // Add a bunch of history entries too
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < 20; i++) {
         history.addCommand(`git custom-cmd-${i}`);
       }
       const results = suggest("git", null, history);
-      expect(results.length).toBeLessThanOrEqual(6);
+      expect(results.length).toBeLessThanOrEqual(15);
     });
   });
 

--- a/src/__tests__/terminal-core.test.ts
+++ b/src/__tests__/terminal-core.test.ts
@@ -22,6 +22,21 @@ const SRC: string = [
   readFileSync(new URL("../terminal/ghostText.ts", import.meta.url), "utf-8"),
 ].join("\n");
 
+const SUGGESTION_OVERLAY_SRC: string = readFileSync(
+  new URL("../terminal/intelligence/SuggestionOverlay.tsx", import.meta.url),
+  "utf-8",
+);
+
+const TERMINAL_PANE_SRC: string = readFileSync(
+  new URL("../components/TerminalPane.tsx", import.meta.url),
+  "utf-8",
+);
+
+const TERMINAL_PANE_CSS: string = readFileSync(
+  new URL("../styles/components/TerminalPane.css", import.meta.url),
+  "utf-8",
+);
+
 const PROVIDER_ACTIONS: string = readFileSync(
   new URL("../components/ProviderActionsBar.tsx", import.meta.url),
   "utf-8",
@@ -502,7 +517,7 @@ describe("Invariant 11: Base64 decode failure drops data (no garbled terminal ou
 
 describe("Invariant 12: acceptSuggestion sets inputBuffer to selected text", () => {
   it("acceptSuggestion updates inputBuffer to selected.text (not empty)", () => {
-    const fn = SRC.match(/function acceptSuggestion[\s\S]*?\n\}/);
+    const fn = SRC.match(/function acceptSuggestion\(sessionId: string\): void[\s\S]*?\n\}/);
     expect(fn).not.toBeNull();
     const body = fn![0];
     // Must set inputBuffer to selected.text, not just ""
@@ -682,5 +697,92 @@ describe("Invariant 24: PROMPT_EOL_MARK set to suppress zsh % indicator", () => 
       }
     }
     expect(prevLine).not.toMatch(/^\s*if\b/);
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// INVARIANT: Suggestion overlay flips above cursor when near bottom
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+describe("Suggestion overlay flip-above positioning", () => {
+  it("getCursorPixelPosition returns cellHeight alongside x/y", () => {
+    const fn = SRC.match(/export function getCursorPixelPosition[\s\S]*?\n\}/);
+    expect(fn).not.toBeNull();
+    const body = fn![0];
+    // Return type must include cellHeight
+    expect(body).toContain("cellHeight");
+    // Must return cellHeight in the object literal
+    expect(body).toMatch(/cellHeight:\s*cellH/);
+  });
+
+  it("SuggestionState includes cellHeight field", () => {
+    expect(SUGGESTION_OVERLAY_SRC).toContain("cellHeight: number");
+  });
+
+  it("SuggestionOverlay uses a ref to measure overflow", () => {
+    expect(SUGGESTION_OVERLAY_SRC).toContain("useRef<HTMLDivElement>");
+    expect(SUGGESTION_OVERLAY_SRC).toContain("useLayoutEffect");
+  });
+
+  it("SuggestionOverlay computes flip-above when overlay exceeds container", () => {
+    // Must check container height vs overlay bottom
+    expect(SUGGESTION_OVERLAY_SRC).toContain("containerHeight");
+    expect(SUGGESTION_OVERLAY_SRC).toContain("setFlipAbove");
+    // Must apply a different top when flipped
+    expect(SUGGESTION_OVERLAY_SRC).toMatch(/flipAbove\s*\?/);
+  });
+
+  it("SuggestionOverlay applies suggestion-overlay-above CSS class when flipped", () => {
+    expect(SUGGESTION_OVERLAY_SRC).toContain("suggestion-overlay-above");
+  });
+
+  it("CSS defines the suggestion-overlay-above animation", () => {
+    expect(TERMINAL_PANE_CSS).toContain(".suggestion-overlay-above");
+    expect(TERMINAL_PANE_CSS).toContain("suggestionFadeInAbove");
+  });
+
+  it("suggestion state includes cellHeight at both call sites", () => {
+    // Both intent suggestions and regular suggestions must pass cellHeight
+    const matches = SRC.match(/cellHeight:\s*pos\.cellHeight/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// INVARIANT: Suggestion overlay supports click-to-accept
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+describe("Suggestion overlay click-to-accept", () => {
+  it("acceptSuggestionAtIndex is exported from TerminalPool", () => {
+    expect(SRC).toContain("export function acceptSuggestionAtIndex");
+  });
+
+  it("acceptSuggestionAtIndex validates index bounds", () => {
+    const fn = SRC.match(/export function acceptSuggestionAtIndex[\s\S]*?\n\}/);
+    expect(fn).not.toBeNull();
+    const body = fn![0];
+    // Must guard against out-of-bounds index
+    expect(body).toMatch(/index\s*<\s*0/);
+    expect(body).toMatch(/index\s*>=\s*s\.suggestions\.length/);
+  });
+
+  it("SuggestionOverlay accepts onAccept prop and binds onClick to items", () => {
+    expect(SUGGESTION_OVERLAY_SRC).toContain("onAccept");
+    expect(SUGGESTION_OVERLAY_SRC).toContain("onClick");
+  });
+
+  it("SuggestionOverlay prevents default on mouseDown to avoid stealing focus", () => {
+    expect(SUGGESTION_OVERLAY_SRC).toContain("onMouseDown");
+    expect(SUGGESTION_OVERLAY_SRC).toContain("preventDefault");
+  });
+
+  it("TerminalPane imports acceptSuggestionAtIndex and passes onAccept to overlay", () => {
+    expect(TERMINAL_PANE_SRC).toContain("acceptSuggestionAtIndex");
+    expect(TERMINAL_PANE_SRC).toContain("onAccept={handleSuggestionAccept}");
+  });
+
+  it("suggestion items use pointer cursor", () => {
+    expect(TERMINAL_PANE_CSS).toMatch(/\.suggestion-item\s*\{[^}]*cursor:\s*pointer/);
   });
 });

--- a/src/__tests__/terminal-intelligence-bugs.test.ts
+++ b/src/__tests__/terminal-intelligence-bugs.test.ts
@@ -560,12 +560,12 @@ describe("Edge cases: suggestionEngine", () => {
     }
   });
 
-  it("suggest never returns more than MAX_RESULTS (6)", () => {
-    for (let i = 0; i < 20; i++) {
+  it("suggest never returns more than MAX_RESULTS (15)", () => {
+    for (let i = 0; i < 30; i++) {
       history.addCommand(`git custom-${i}`);
     }
     const results = suggest("git", null, history);
-    expect(results.length).toBeLessThanOrEqual(6);
+    expect(results.length).toBeLessThanOrEqual(15);
   });
 
   it("suggest deduplicates same command from history and index", () => {

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -1,11 +1,11 @@
 import "../styles/components/TerminalPane.css";
-import { useEffect, useRef, useState, useMemo } from "react";
+import { useEffect, useRef, useState, useMemo, useCallback } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { detectProject } from "../api/projects";
 import {
   attach, detach, has, showGhostText, clearGhostText,
   subscribeSuggestions, setSessionPhase, setSessionCwd,
-  getHistoryProvider, refitActive,
+  getHistoryProvider, refitActive, acceptSuggestionAtIndex,
 } from "../terminal/TerminalPool";
 import { useExecutionMode, useAutonomousSettings, useSession } from "../state/SessionContext";
 import { SuggestionOverlay, type SuggestionState } from "../terminal/intelligence/SuggestionOverlay";
@@ -179,6 +179,10 @@ export function TerminalPane({ sessionId, phase, color }: TerminalPaneProps) {
     }
   }, [phase, sessionId]);
 
+  const handleSuggestionAccept = useCallback((index: number) => {
+    acceptSuggestionAtIndex(sessionId, index);
+  }, [sessionId]);
+
   const showLoading = !ready && (phase === "creating" || phase === "initializing");
   const phaseLabel = phase === "creating" ? "Spawning shell..." :
                      phase === "initializing" ? "Starting shell..." :
@@ -204,7 +208,10 @@ export function TerminalPane({ sessionId, phase, color }: TerminalPaneProps) {
       <div className="terminal-viewport" ref={viewportRef} />
       {tintStyle && <div className="terminal-bg-tint" style={tintStyle} />}
       {suggestionState && (
-        <SuggestionOverlay state={suggestionState} />
+        <SuggestionOverlay
+          state={suggestionState}
+          onAccept={handleSuggestionAccept}
+        />
       )}
     </div>
   );

--- a/src/styles/components/TerminalPane.css
+++ b/src/styles/components/TerminalPane.css
@@ -65,8 +65,10 @@
   border: 1px solid var(--border);
   backdrop-filter: blur(2px);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  min-width: 280px;
-  max-width: 480px;
+  min-width: 320px;
+  max-width: 500px;
+  max-height: 340px;
+  overflow-y: auto;
   padding: 4px;
   opacity: 0;
   animation: suggestionFadeIn 100ms ease-out forwards;
@@ -78,9 +80,22 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
+.suggestion-overlay-above {
+  animation: suggestionFadeInAbove 100ms ease-out forwards;
+}
+
+@keyframes suggestionFadeInAbove {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 .suggestion-item {
   padding: 5px 8px;
-  cursor: default;
+  cursor: pointer;
+}
+
+.suggestion-item:hover {
+  background: var(--bg-hover);
 }
 
 .suggestion-item-selected {

--- a/src/terminal/TerminalPool.ts
+++ b/src/terminal/TerminalPool.ts
@@ -342,6 +342,7 @@ function computeSuggestions(sessionId: string): void {
         selectedIndex: 0,
         cursorX: pos.x,
         cursorY: pos.y,
+        cellHeight: pos.cellHeight,
       };
       entry.suggestionState = state;
       notifySubscribers(sessionId, state);
@@ -366,6 +367,7 @@ function computeSuggestions(sessionId: string): void {
     selectedIndex: 0,
     cursorX: pos.x,
     cursorY: pos.y,
+    cellHeight: pos.cellHeight,
   };
 
   entry.suggestionState = state;
@@ -405,6 +407,19 @@ function moveSuggestionSelection(sessionId: string, delta: number): void {
       showGhostText(sessionId, selected.text.slice(input.length));
     }
   }
+}
+
+/** Accept a suggestion at a given index (used by click-to-select in the overlay) */
+export function acceptSuggestionAtIndex(sessionId: string, index: number): void {
+  const entry = pool.get(sessionId);
+  if (!entry?.suggestionState?.visible) return;
+
+  const s = entry.suggestionState;
+  if (index < 0 || index >= s.suggestions.length) return;
+
+  // Set the selected index then delegate to normal accept
+  entry.suggestionState = { ...s, selectedIndex: index };
+  acceptSuggestion(sessionId);
 }
 
 function acceptSuggestion(sessionId: string): void {

--- a/src/terminal/intelligence/SuggestionOverlay.tsx
+++ b/src/terminal/intelligence/SuggestionOverlay.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { type Suggestion } from "./suggestionEngine";
 
 export interface SuggestionState {
@@ -6,27 +7,58 @@ export interface SuggestionState {
   selectedIndex: number;
   cursorX: number;
   cursorY: number;
+  cellHeight: number;
 }
 
 interface SuggestionOverlayProps {
   state: SuggestionState;
+  onAccept?: (index: number) => void;
 }
 
-export function SuggestionOverlay({ state }: SuggestionOverlayProps) {
+export function SuggestionOverlay({ state, onAccept }: SuggestionOverlayProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const selectedRef = useRef<HTMLDivElement>(null);
+  const [flipAbove, setFlipAbove] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = overlayRef.current;
+    if (!el || !state.visible) return;
+
+    const parent = el.offsetParent as HTMLElement;
+    if (!parent) return;
+
+    const overlayHeight = el.offsetHeight;
+    const containerHeight = parent.clientHeight;
+    setFlipAbove(state.cursorY + overlayHeight > containerHeight);
+  }, [state.visible, state.cursorY, state.suggestions.length, state.selectedIndex]);
+
+  // Scroll selected item into view when navigating with keyboard
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: "nearest" });
+  }, [state.selectedIndex]);
+
   if (!state.visible || state.suggestions.length === 0) return null;
+
+  const top = flipAbove
+    ? state.cursorY - state.cellHeight - (overlayRef.current?.offsetHeight ?? 0)
+    : state.cursorY;
 
   return (
     <div
-      className="suggestion-overlay"
+      ref={overlayRef}
+      className={`suggestion-overlay${flipAbove ? " suggestion-overlay-above" : ""}`}
       style={{
         left: `${state.cursorX}px`,
-        top: `${state.cursorY}px`,
+        top: `${top}px`,
       }}
+      onMouseDown={(e) => e.preventDefault()}
     >
       {state.suggestions.map((s, i) => (
         <div
           key={s.text}
+          ref={i === state.selectedIndex ? selectedRef : undefined}
           className={`suggestion-item${i === state.selectedIndex ? " suggestion-item-selected" : ""}`}
+          onClick={() => onAccept?.(i)}
         >
           <div className="suggestion-item-row">
             <span className="suggestion-command">{s.text}</span>

--- a/src/terminal/intelligence/suggestionEngine.ts
+++ b/src/terminal/intelligence/suggestionEngine.ts
@@ -10,7 +10,7 @@ export interface Suggestion {
   badge?: string;
 }
 
-const MAX_RESULTS = 6;
+const MAX_RESULTS = 15;
 const LENGTH_PENALTY_THRESHOLD = 60;
 
 /**

--- a/src/terminal/pool.ts
+++ b/src/terminal/pool.ts
@@ -638,7 +638,7 @@ export function dismissSuggestionsForEntry(entry: PoolEntry): void {
 
 // ─── Cursor Position Calculation ─────────────────────────────────────
 
-export function getCursorPixelPosition(entry: PoolEntry): { x: number; y: number } {
+export function getCursorPixelPosition(entry: PoolEntry): { x: number; y: number; cellHeight: number } {
   try {
     const term = entry.terminal as any;
     const dims = term._core?._renderService?.dimensions;
@@ -654,10 +654,11 @@ export function getCursorPixelPosition(entry: PoolEntry): { x: number; y: number
       return {
         x: cursorX * cellW,
         y: (cursorY + 1) * cellH, // Below the cursor row
+        cellHeight: cellH,
       };
     }
   } catch { /* fallback */ }
-  return { x: 0, y: 0 };
+  return { x: 0, y: 0, cellHeight: 0 };
 }
 
 /** Get cursor position in pixels for a session (used by TerminalPane) */


### PR DESCRIPTION
## Summary
- Suggestion dropdown now flips above the cursor when typing near the bottom of the terminal, preventing it from being hidden
- Clicking a suggestion with the mouse now accepts it, with hover highlighting for visual feedback
- Increased visible suggestions from 6 to 15 with a scrollable dropdown and auto-scroll on keyboard navigation

## Test plan
- [ ] Type a command near the bottom of the terminal — overlay should appear above the cursor
- [ ] Type a command near the top — overlay should appear below as before
- [ ] Click on a suggestion item — it should be accepted into the input
- [ ] Hover over suggestion items — background highlight should appear
- [ ] Type a prefix that matches many commands (e.g. `git`) — up to 15 suggestions should show
- [ ] Use arrow keys to scroll through all 15 suggestions — selected item should stay visible
- [ ] Run `npm run test` — all 1907 tests pass