### PR TITLE
feat: add keyboard navigation to suggestion overlay

### DIFF
--- a/src/__tests__/suggestion-overlay-keyboard.test.ts
+++ b/src/__tests__/suggestion-overlay-keyboard.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Suggestion Overlay Keyboard Navigation Tests
+ *
+ * Tests for keyboard navigation of the suggestion overlay:
+ * - Arrow keys (↑/↓) navigate with wrapping
+ * - Application cursor mode (\x1bOA/\x1bOB) support
+ * - Overlay-only guard (no intelligenceActive dependency for key interception)
+ * - Enter/Tab accept highlighted suggestion
+ * - Enter passes through when nothing highlighted
+ * - Esc dismisses without accepting
+ * - Typing resets selection to null
+ * - Keys pass through when overlay is not visible
+ * - Acceptance writes suffix only (not full command)
+ * - Phase change dismisses overlay
+ * - Ctrl-C dismisses overlay then passes through
+ * - Mouse interaction (onSelect, onAccept, scrollIntoView)
+ */
+import { describe, it, expect, vi } from "vitest";
+
+// @ts-expect-error — fs is a Node built-in, not in browser tsconfig
+import { readFileSync } from "fs";
+
+// ─── Mock Tauri APIs ─────────────────────────────────────────────────
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+// ─── Source Code for Structural Tests ─────────────────────────────────
+
+const TERMINAL_POOL_SRC: string = readFileSync(
+  new URL("../terminal/TerminalPool.ts", import.meta.url),
+  "utf-8",
+);
+
+const POOL_SRC: string = readFileSync(
+  new URL("../terminal/pool.ts", import.meta.url),
+  "utf-8",
+);
+
+const OVERLAY_SRC: string = readFileSync(
+  new URL("../terminal/intelligence/SuggestionOverlay.tsx", import.meta.url),
+  "utf-8",
+);
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/** Simulates moveSuggestionSelection logic extracted from source */
+function moveSuggestionSelection(
+  selectedIndex: number | null,
+  delta: number,
+  count: number,
+): number {
+  if (selectedIndex === null) {
+    return delta > 0 ? 0 : count - 1;
+  }
+  return ((selectedIndex + delta) % count + count) % count;
+}
+
+// =============================================================================
+// DOWN ARROW TESTS
+// =============================================================================
+
+describe("Overlay: Down arrow selects first item", () => {
+  it("down arrow from null selection goes to index 0", () => {
+    const result = moveSuggestionSelection(null, 1, 5);
+    expect(result).toBe(0);
+  });
+
+  it("source handles null selectedIndex for down arrow", () => {
+    expect(TERMINAL_POOL_SRC).toContain("s.selectedIndex === null");
+    expect(TERMINAL_POOL_SRC).toContain("delta > 0 ? 0 : count - 1");
+  });
+});
+
+describe("Overlay: Down arrow wraps to top", () => {
+  it("down arrow from last item wraps to 0", () => {
+    expect(moveSuggestionSelection(4, 1, 5)).toBe(0);
+  });
+
+  it("wrapping uses modular arithmetic, not clamping", () => {
+    const moveFn = TERMINAL_POOL_SRC.match(
+      /function moveSuggestionSelection[\s\S]*?\n\}/,
+    );
+    expect(moveFn).not.toBeNull();
+    expect(moveFn![0]).not.toContain("Math.max");
+    expect(moveFn![0]).not.toContain("Math.min");
+  });
+});
+
+// =============================================================================
+// UP ARROW TESTS
+// =============================================================================
+
+describe("Overlay: Up arrow selects last item", () => {
+  it("up arrow from null selection goes to last item", () => {
+    expect(moveSuggestionSelection(null, -1, 5)).toBe(4);
+  });
+
+  it("up arrow from null with 3 items goes to index 2", () => {
+    expect(moveSuggestionSelection(null, -1, 3)).toBe(2);
+  });
+});
+
+describe("Overlay: Up arrow wraps to bottom", () => {
+  it("up arrow from index 0 wraps to last item", () => {
+    expect(moveSuggestionSelection(0, -1, 5)).toBe(4);
+  });
+
+  it("up arrow from index 0 with 3 items wraps to index 2", () => {
+    expect(moveSuggestionSelection(0, -1, 3)).toBe(2);
+  });
+});
+
+// =============================================================================
+// APPLICATION CURSOR MODE — CRITICAL REGRESSION GUARD
+// =============================================================================
+
+describe("Overlay: Application cursor mode sequences handled", () => {
+  it("source intercepts \\x1bOA (application mode up arrow)", () => {
+    expect(TERMINAL_POOL_SRC).toContain('"\\x1bOA"');
+    // Must be in the same condition as normal mode
+    const upArrowLine = TERMINAL_POOL_SRC.match(
+      /data === "\\x1b\[A" \|\| data === "\\x1bOA"/,
+    );
+    expect(upArrowLine).not.toBeNull();
+  });
+
+  it("source intercepts \\x1bOB (application mode down arrow)", () => {
+    expect(TERMINAL_POOL_SRC).toContain('"\\x1bOB"');
+    const downArrowLine = TERMINAL_POOL_SRC.match(
+      /data === "\\x1b\[B" \|\| data === "\\x1bOB"/,
+    );
+    expect(downArrowLine).not.toBeNull();
+  });
+
+  it("source intercepts \\x1bOC (application mode right arrow) for ghost text", () => {
+    expect(TERMINAL_POOL_SRC).toContain('"\\x1bOC"');
+    const rightArrowLine = TERMINAL_POOL_SRC.match(
+      /data === "\\x1b\[C" \|\| data === "\\x1bOC"/,
+    );
+    expect(rightArrowLine).not.toBeNull();
+  });
+});
+
+// =============================================================================
+// OVERLAY-ONLY GUARD — PREVENTS PHASE-FLICKER DROPS
+// =============================================================================
+
+describe("Overlay: Key interception guards on overlay visibility, not intelligenceActive", () => {
+  it("overlay key interception uses overlayVisible guard without intelligenceActive", () => {
+    // The guard should be: if (overlayVisible && entry.suggestionState)
+    // NOT: if (intelligenceActive && overlayVisible && entry.suggestionState)
+    // This prevents phase-flicker (brief "busy" from shell echo) from dropping arrow keys
+    expect(TERMINAL_POOL_SRC).toContain(
+      "if (overlayVisible && entry.suggestionState)",
+    );
+  });
+
+  it("intelligenceActive is NOT part of the overlay interception guard", () => {
+    // The line after the overlay interception comment should NOT include intelligenceActive
+    const lines = TERMINAL_POOL_SRC.split("\n");
+    const guardIdx = lines.findIndex((l) => l.includes("Overlay key interception"));
+    expect(guardIdx).toBeGreaterThan(-1);
+    // Find the next if-statement after the comment block
+    let ifLine = "";
+    for (let i = guardIdx + 1; i < lines.length; i++) {
+      if (lines[i].trim().startsWith("if (")) {
+        ifLine = lines[i];
+        break;
+      }
+    }
+    expect(ifLine).toContain("overlayVisible");
+    expect(ifLine).not.toContain("intelligenceActive");
+  });
+
+  it("intelligenceActive is still used for suggestion computation gating", () => {
+    // intelligenceActive should still gate suggestion computation, not key interception
+    expect(TERMINAL_POOL_SRC).toContain(
+      '(phase === "idle" || phase === "shell_ready")',
+    );
+  });
+});
+
+// =============================================================================
+// ENTER TESTS
+// =============================================================================
+
+describe("Overlay: Enter accepts selected suggestion", () => {
+  it("source calls executeSuggestion when selectedIndex is not null", () => {
+    const handleFn = TERMINAL_POOL_SRC.match(
+      /\/\/ Enter — accept highlighted[\s\S]*?\/\/ Fall through to normal Enter/,
+    );
+    expect(handleFn).not.toBeNull();
+    expect(handleFn![0]).toContain("selectedIndex !== null");
+    expect(handleFn![0]).toContain("executeSuggestion(sessionId)");
+  });
+
+  it("executeSuggestion guards against null selectedIndex", () => {
+    const execFn = TERMINAL_POOL_SRC.match(
+      /function executeSuggestion[\s\S]*?\n\}/,
+    );
+    expect(execFn).not.toBeNull();
+    expect(execFn![0]).toContain("selectedIndex === null");
+  });
+});
+
+describe("Overlay: Enter passes through when nothing selected", () => {
+  it("source dismisses overlay and falls through when selectedIndex is null", () => {
+    const handleFn = TERMINAL_POOL_SRC.match(
+      /\/\/ Enter — accept highlighted[\s\S]*?\/\/ Fall through to normal Enter/,
+    );
+    expect(handleFn).not.toBeNull();
+    expect(handleFn![0]).toContain("dismissSuggestions(sessionId)");
+    // Must NOT return after dismiss — should fall through to PTY
+    const afterDismiss = handleFn![0].split("dismissSuggestions(sessionId)")[1];
+    expect(afterDismiss).not.toMatch(/return;\s*\/\/ CONSUME/);
+  });
+});
+
+// =============================================================================
+// ESC TEST
+// =============================================================================
+
+describe("Overlay: Esc dismisses without accepting", () => {
+  it("source handles Escape by dismissing only (no suggestion acceptance)", () => {
+    const handleFn = TERMINAL_POOL_SRC.match(
+      /\/\/ Escape — dismiss overlay[\s\S]*?return; \/\/ CONSUME/,
+    );
+    expect(handleFn).not.toBeNull();
+    const escBlock = handleFn![0];
+    expect(escBlock).toContain("dismissSuggestions(sessionId)");
+    expect(escBlock).not.toContain("acceptSuggestion");
+    expect(escBlock).not.toContain("executeSuggestion");
+  });
+});
+
+// =============================================================================
+// TYPING RESETS SELECTION
+// =============================================================================
+
+describe("Overlay: Typing resets selection to null", () => {
+  it("computeSuggestions sets selectedIndex to null (not 0)", () => {
+    const computeFn = TERMINAL_POOL_SRC.match(
+      /function computeSuggestions[\s\S]*?\n\}/,
+    );
+    expect(computeFn).not.toBeNull();
+    expect(computeFn![0]).toContain("selectedIndex: null");
+    expect(computeFn![0]).not.toContain("selectedIndex: 0");
+  });
+});
+
+// =============================================================================
+// TAB TESTS
+// =============================================================================
+
+describe("Overlay: Tab accepts selected suggestion", () => {
+  it("source checks selectedIndex !== null before accepting on Tab", () => {
+    const handleFn = TERMINAL_POOL_SRC.match(
+      /\/\/ Tab — accept selected[\s\S]*?\/\/ Nothing highlighted/,
+    );
+    expect(handleFn).not.toBeNull();
+    expect(handleFn![0]).toContain("selectedIndex !== null");
+    expect(handleFn![0]).toContain("acceptSuggestion(sessionId)");
+  });
+
+  it("acceptSuggestion guards against null selectedIndex", () => {
+    const acceptFn = TERMINAL_POOL_SRC.match(
+      /function acceptSuggestion\(sessionId: string\)[\s\S]*?\n\}/,
+    );
+    expect(acceptFn).not.toBeNull();
+    expect(acceptFn![0]).toContain("selectedIndex === null");
+  });
+});
+
+// =============================================================================
+// PASSTHROUGH TESTS (overlay NOT visible)
+// =============================================================================
+
+describe("Overlay: Keys pass through when not visible", () => {
+  it("arrows are NOT intercepted when overlay is hidden", () => {
+    // After the overlay block, there should be no standalone arrow interception
+    const outsideOverlay = TERMINAL_POOL_SRC.split(
+      "// Any other key: pass to PTY, update buffer, re-query",
+    )[1] ?? "";
+    expect(outsideOverlay).not.toMatch(
+      /if\s*\(data === "\\x1b\[A"\)/,
+    );
+    expect(outsideOverlay).not.toMatch(
+      /if\s*\(data === "\\x1b\[B"\)/,
+    );
+  });
+
+  it("Enter outside overlay block passes through to PTY", () => {
+    expect(TERMINAL_POOL_SRC).toContain("writeToSession(sessionId, utf8ToBase64(data))");
+  });
+
+  it("Esc outside overlay block does not consume the event", () => {
+    const updateFn = TERMINAL_POOL_SRC.match(
+      /function updateInputBuffer[\s\S]*?\n\}/,
+    );
+    expect(updateFn).not.toBeNull();
+    expect(updateFn![0]).toContain("0x1b");
+    expect(updateFn![0]).toContain("dismissSuggestionsForEntry");
+  });
+});
+
+// =============================================================================
+// ACCEPTANCE LOGIC
+// =============================================================================
+
+describe("Overlay: Acceptance writes suffix correctly", () => {
+  it("acceptSuggestion erases current input then writes selected text", () => {
+    const acceptFn = TERMINAL_POOL_SRC.match(
+      /function acceptSuggestion\(sessionId: string\)[\s\S]*?\n\}/,
+    );
+    expect(acceptFn).not.toBeNull();
+    const body = acceptFn![0];
+    expect(body).toContain('\\x7f".repeat(currentInput.length)');
+    expect(body).toContain("eraseSequence + selected.text");
+    expect(body).toContain("entry.inputBuffer = selected.text");
+  });
+
+  it("executeSuggestion erases and writes full suggestion + Enter", () => {
+    const execFn = TERMINAL_POOL_SRC.match(
+      /function executeSuggestion[\s\S]*?\n\}/,
+    );
+    expect(execFn).not.toBeNull();
+    const body = execFn![0];
+    expect(body).toContain('selected.text + "\\r"');
+    expect(body).toContain("historyProvider.addCommand(selected.text)");
+  });
+});
+
+// =============================================================================
+// PHASE CHANGE DISMISSAL
+// =============================================================================
+
+describe("Overlay: Dismisses on phase change", () => {
+  it("setSessionPhase dismisses suggestions when phase leaves idle/shell_ready", () => {
+    const phaseFn = POOL_SRC.match(
+      /export function setSessionPhase[\s\S]*?\n\}/,
+    );
+    expect(phaseFn).not.toBeNull();
+    expect(phaseFn![0]).toContain("dismissSuggestions");
+  });
+});
+
+// =============================================================================
+// CTRL-C HANDLING
+// =============================================================================
+
+describe("Overlay: Ctrl-C dismisses overlay when visible", () => {
+  it("source handles Ctrl-C in overlay block by dismissing", () => {
+    const handleFn = TERMINAL_POOL_SRC.match(
+      /\/\/ Ctrl-C — dismiss overlay[\s\S]*?\/\/ Fall through/,
+    );
+    expect(handleFn).not.toBeNull();
+    expect(handleFn![0]).toContain("dismissSuggestions(sessionId)");
+    // Must fall through (not return) so Ctrl-C reaches PTY
+    expect(handleFn![0]).not.toContain("return;");
+  });
+});
+
+// =============================================================================
+// SELECTEDINDEX TYPE & MOUSE INTERACTION
+// =============================================================================
+
+describe("Overlay: SuggestionState and component features", () => {
+  it("SuggestionState interface declares selectedIndex as number | null", () => {
+    expect(OVERLAY_SRC).toContain("selectedIndex: number | null");
+  });
+
+  it("overlay component checks for null when applying selected class", () => {
+    expect(OVERLAY_SRC).toContain("selectedIndex !== null");
+  });
+
+  it("overlay component uses scrollIntoView for highlighted items", () => {
+    expect(OVERLAY_SRC).toContain("scrollIntoView");
+  });
+
+  it("overlay component supports onSelect callback for mouse hover", () => {
+    expect(OVERLAY_SRC).toContain("onSelect?.(i)");
+    expect(OVERLAY_SRC).toContain("onMouseEnter");
+  });
+
+  it("overlay component supports onAccept callback for mouse click", () => {
+    expect(OVERLAY_SRC).toContain("onAccept?.(i)");
+    expect(OVERLAY_SRC).toContain("onClick");
+  });
+
+  it("overlay prevents mousedown from stealing terminal focus", () => {
+    expect(OVERLAY_SRC).toContain("onMouseDown");
+    expect(OVERLAY_SRC).toContain("e.preventDefault()");
+  });
+
+  it("overlay supports flip-above positioning", () => {
+    expect(OVERLAY_SRC).toContain("flipAbove");
+    expect(OVERLAY_SRC).toContain("suggestion-overlay-above");
+  });
+});
+
+// =============================================================================
+// PUBLIC API FOR MOUSE INTERACTION
+// =============================================================================
+
+describe("Overlay: Public functions for mouse interaction", () => {
+  it("selectSuggestion is exported for hover highlighting", () => {
+    expect(TERMINAL_POOL_SRC).toContain("export function selectSuggestion(");
+  });
+
+  it("acceptSuggestionAtIndex is exported for click acceptance", () => {
+    expect(TERMINAL_POOL_SRC).toContain("export function acceptSuggestionAtIndex(");
+  });
+
+  it("selectSuggestion updates ghost text to preview the hovered item", () => {
+    const fn = TERMINAL_POOL_SRC.match(
+      /export function selectSuggestion[\s\S]*?\n\}/,
+    );
+    expect(fn).not.toBeNull();
+    expect(fn![0]).toContain("showGhostText");
+  });
+});
+
+// =============================================================================
+// WRAPPING ARITHMETIC
+// =============================================================================
+
+describe("Overlay: Navigation wrapping is correct for all boundary cases", () => {
+  it("navigating down through all items and back to top", () => {
+    const count = 4;
+    let idx: number | null = null;
+    idx = moveSuggestionSelection(idx, 1, count);
+    expect(idx).toBe(0);
+    idx = moveSuggestionSelection(idx, 1, count);
+    idx = moveSuggestionSelection(idx, 1, count);
+    idx = moveSuggestionSelection(idx, 1, count);
+    expect(idx).toBe(3);
+    idx = moveSuggestionSelection(idx, 1, count);
+    expect(idx).toBe(0);
+  });
+
+  it("navigating up through all items and back to bottom", () => {
+    const count = 4;
+    let idx: number | null = null;
+    idx = moveSuggestionSelection(idx, -1, count);
+    expect(idx).toBe(3);
+    idx = moveSuggestionSelection(idx, -1, count);
+    idx = moveSuggestionSelection(idx, -1, count);
+    idx = moveSuggestionSelection(idx, -1, count);
+    expect(idx).toBe(0);
+    idx = moveSuggestionSelection(idx, -1, count);
+    expect(idx).toBe(3);
+  });
+
+  it("single-item list always stays at 0", () => {
+    expect(moveSuggestionSelection(null, 1, 1)).toBe(0);
+    expect(moveSuggestionSelection(0, 1, 1)).toBe(0);
+    expect(moveSuggestionSelection(0, -1, 1)).toBe(0);
+  });
+
+  it("two-item list wraps correctly", () => {
+    expect(moveSuggestionSelection(null, 1, 2)).toBe(0);
+    expect(moveSuggestionSelection(0, 1, 2)).toBe(1);
+    expect(moveSuggestionSelection(1, 1, 2)).toBe(0);
+    expect(moveSuggestionSelection(null, -1, 2)).toBe(1);
+    expect(moveSuggestionSelection(0, -1, 2)).toBe(1);
+    expect(moveSuggestionSelection(1, -1, 2)).toBe(0);
+  });
+});

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -5,7 +5,8 @@ import { detectProject } from "../api/projects";
 import {
   attach, detach, has, showGhostText, clearGhostText,
   subscribeSuggestions, setSessionPhase, setSessionCwd,
-  getHistoryProvider, refitActive, acceptSuggestionAtIndex,
+  getHistoryProvider, refitActive,
+  acceptSuggestionAtIndex, selectSuggestion,
 } from "../terminal/TerminalPool";
 import { useExecutionMode, useAutonomousSettings, useSession } from "../state/SessionContext";
 import { SuggestionOverlay, type SuggestionState } from "../terminal/intelligence/SuggestionOverlay";
@@ -179,6 +180,10 @@ export function TerminalPane({ sessionId, phase, color }: TerminalPaneProps) {
     }
   }, [phase, sessionId]);
 
+  const handleSuggestionSelect = useCallback((index: number) => {
+    selectSuggestion(sessionId, index);
+  }, [sessionId]);
+
   const handleSuggestionAccept = useCallback((index: number) => {
     acceptSuggestionAtIndex(sessionId, index);
   }, [sessionId]);
@@ -210,6 +215,7 @@ export function TerminalPane({ sessionId, phase, color }: TerminalPaneProps) {
       {suggestionState && (
         <SuggestionOverlay
           state={suggestionState}
+          onSelect={handleSuggestionSelect}
           onAccept={handleSuggestionAccept}
         />
       )}

--- a/src/styles/components/TerminalPane.css
+++ b/src/styles/components/TerminalPane.css
@@ -92,13 +92,15 @@
 .suggestion-item {
   padding: 5px 8px;
   cursor: pointer;
+  border-radius: var(--radius-sm);
 }
 
 .suggestion-item:hover {
   background: var(--bg-hover);
 }
 
-.suggestion-item-selected {
+.suggestion-item-selected,
+.suggestion-item-selected:hover {
   background: var(--bg-hover);
 }
 
@@ -161,4 +163,3 @@
 .suggestion-badge-lint { color: var(--violet); background: var(--violet-dim); }
 .suggestion-badge-prisma { color: var(--badge-prisma); background: rgba(45, 55, 72, 0.20); }
 .suggestion-badge-intent { color: var(--green); background: var(--green-dim); }
-

--- a/src/terminal/TerminalPool.ts
+++ b/src/terminal/TerminalPool.ts
@@ -134,37 +134,54 @@ function handleTerminalInput(sessionId: string, data: string): void {
   const overlayVisible = entry.suggestionState?.visible ?? false;
 
   // ── Overlay key interception (only when overlay is showing) ──
-  if (intelligenceActive && overlayVisible && entry.suggestionState) {
-    // Up arrow
-    if (data === "\x1b[A") {
+  // Guard on overlay visibility, NOT intelligenceActive — the phase can
+  // briefly flip to "busy" from shell echo while the overlay is still visible.
+  // Intelligence gating controls *showing* the overlay; once visible, we
+  // must always intercept navigation keys to prevent them reaching the PTY.
+  if (overlayVisible && entry.suggestionState) {
+    // Up arrow — move selection up (wrapping)
+    // Handles both normal mode (\x1b[A) and application cursor mode (\x1bOA)
+    if (data === "\x1b[A" || data === "\x1bOA") {
       moveSuggestionSelection(sessionId, -1);
       return; // CONSUME
     }
-    // Down arrow
-    if (data === "\x1b[B") {
+    // Down arrow — move selection down (wrapping)
+    if (data === "\x1b[B" || data === "\x1bOB") {
       moveSuggestionSelection(sessionId, 1);
       return; // CONSUME
     }
-    // Tab — accept selected (respects shell compatibility)
+    // Tab — accept selected if an item is highlighted (respects shell compatibility)
     if (data === "\t") {
-      if (shouldConsumeTab(sessionId, true)) {
+      if (entry.suggestionState.selectedIndex !== null && shouldConsumeTab(sessionId, true)) {
         acceptSuggestion(sessionId);
         return; // CONSUME
       }
-      // Fall through — let shell handle Tab
+      // Nothing highlighted or shell should handle Tab — fall through
     }
-    // Enter — execute selected suggestion
+    // Enter — accept highlighted suggestion, or pass through if nothing highlighted
     if (data === "\r") {
-      executeSuggestion(sessionId);
-      return; // CONSUME
+      if (entry.suggestionState.selectedIndex !== null) {
+        executeSuggestion(sessionId);
+        return; // CONSUME
+      }
+      // Nothing highlighted — dismiss overlay and let Enter pass through to PTY
+      dismissSuggestions(sessionId);
+      clearGhostText(sessionId);
+      // Fall through to normal Enter handling (buffer update + PTY write)
     }
     // Escape — dismiss overlay
     if (data === "\x1b" || data === "\x1b\x1b") {
       dismissSuggestions(sessionId);
       return; // CONSUME
     }
+    // Ctrl-C — dismiss overlay, then pass through to PTY
+    if (data === "\x03") {
+      dismissSuggestions(sessionId);
+      clearGhostText(sessionId);
+      // Fall through — Ctrl-C will be sent to PTY below
+    }
     // Right arrow — accept ghost text inline
-    if (data === "\x1b[C" && entry.ghostText) {
+    if ((data === "\x1b[C" || data === "\x1bOC") && entry.ghostText) {
       acceptGhostInline(sessionId);
       return; // CONSUME
     }
@@ -339,7 +356,7 @@ function computeSuggestions(sessionId: string): void {
           score: 1000 - i,
           badge: "intent",
         })),
-        selectedIndex: 0,
+        selectedIndex: null,
         cursorX: pos.x,
         cursorY: pos.y,
         cellHeight: pos.cellHeight,
@@ -364,7 +381,7 @@ function computeSuggestions(sessionId: string): void {
   const state: SuggestionState = {
     visible: true,
     suggestions: results,
-    selectedIndex: 0,
+    selectedIndex: null,
     cursorX: pos.x,
     cursorY: pos.y,
     cellHeight: pos.cellHeight,
@@ -393,12 +410,20 @@ function moveSuggestionSelection(sessionId: string, delta: number): void {
 
   const s = entry.suggestionState;
   const count = s.suggestions.length;
-  const newIndex = Math.max(0, Math.min(count - 1, s.selectedIndex + delta));
+
+  let newIndex: number;
+  if (s.selectedIndex === null) {
+    // Nothing highlighted yet
+    newIndex = delta > 0 ? 0 : count - 1;
+  } else {
+    // Wrap around at boundaries
+    newIndex = ((s.selectedIndex + delta) % count + count) % count;
+  }
 
   entry.suggestionState = { ...s, selectedIndex: newIndex };
   notifySubscribers(sessionId, entry.suggestionState);
 
-  // Update ghost text to selected suggestion
+  // Update ghost text to preview the highlighted suggestion
   clearGhostText(sessionId);
   const selected = s.suggestions[newIndex];
   if (selected && shouldShowGhostText(sessionId)) {
@@ -424,7 +449,7 @@ export function acceptSuggestionAtIndex(sessionId: string, index: number): void 
 
 function acceptSuggestion(sessionId: string): void {
   const entry = pool.get(sessionId);
-  if (!entry?.suggestionState?.visible) return;
+  if (!entry?.suggestionState?.visible || entry.suggestionState.selectedIndex === null) return;
 
   const selected = entry.suggestionState.suggestions[entry.suggestionState.selectedIndex];
   if (!selected) return;
@@ -450,7 +475,7 @@ function acceptSuggestion(sessionId: string): void {
 
 function executeSuggestion(sessionId: string): void {
   const entry = pool.get(sessionId);
-  if (!entry?.suggestionState?.visible) return;
+  if (!entry?.suggestionState?.visible || entry.suggestionState.selectedIndex === null) return;
 
   const selected = entry.suggestionState.suggestions[entry.suggestionState.selectedIndex];
   if (!selected) return;
@@ -484,6 +509,29 @@ function acceptGhostInline(sessionId: string): void {
   writeToSession(sessionId, utf8ToBase64(ghostContent)).catch((err) => {
     console.warn(`[TerminalPool] write_to_session (ghost inline) failed for ${sessionId}:`, err);
   });
+}
+
+// ─── Public Suggestion Interaction (for mouse clicks) ────────────────
+
+/** Highlight a suggestion by index (e.g. on mouse hover). */
+export function selectSuggestion(sessionId: string, index: number): void {
+  const entry = pool.get(sessionId);
+  if (!entry?.suggestionState?.visible) return;
+  const s = entry.suggestionState;
+  if (index < 0 || index >= s.suggestions.length) return;
+
+  entry.suggestionState = { ...s, selectedIndex: index };
+  notifySubscribers(sessionId, entry.suggestionState);
+
+  // Update ghost text to preview the highlighted suggestion
+  clearGhostText(sessionId);
+  const selected = s.suggestions[index];
+  if (selected && shouldShowGhostText(sessionId)) {
+    const input = entry.inputBuffer.trim();
+    if (selected.text.startsWith(input) && selected.text.length > input.length) {
+      showGhostText(sessionId, selected.text.slice(input.length));
+    }
+  }
 }
 
 // ─── Public Utility Exports ──────────────────────────────────────────

--- a/src/terminal/intelligence/SuggestionOverlay.tsx
+++ b/src/terminal/intelligence/SuggestionOverlay.tsx
@@ -4,7 +4,7 @@ import { type Suggestion } from "./suggestionEngine";
 export interface SuggestionState {
   visible: boolean;
   suggestions: Suggestion[];
-  selectedIndex: number;
+  selectedIndex: number | null;
   cursorX: number;
   cursorY: number;
   cellHeight: number;
@@ -12,10 +12,11 @@ export interface SuggestionState {
 
 interface SuggestionOverlayProps {
   state: SuggestionState;
+  onSelect?: (index: number) => void;
   onAccept?: (index: number) => void;
 }
 
-export function SuggestionOverlay({ state, onAccept }: SuggestionOverlayProps) {
+export function SuggestionOverlay({ state, onSelect, onAccept }: SuggestionOverlayProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLDivElement>(null);
   const [flipAbove, setFlipAbove] = useState(false);
@@ -53,26 +54,30 @@ export function SuggestionOverlay({ state, onAccept }: SuggestionOverlayProps) {
       }}
       onMouseDown={(e) => e.preventDefault()}
     >
-      {state.suggestions.map((s, i) => (
-        <div
-          key={s.text}
-          ref={i === state.selectedIndex ? selectedRef : undefined}
-          className={`suggestion-item${i === state.selectedIndex ? " suggestion-item-selected" : ""}`}
-          onClick={() => onAccept?.(i)}
-        >
-          <div className="suggestion-item-row">
-            <span className="suggestion-command">{s.text}</span>
-            {s.badge && (
-              <span className={`suggestion-badge suggestion-badge-${s.badge}`}>
-                {s.badge}
-              </span>
+      {state.suggestions.map((s, i) => {
+        const isSelected = state.selectedIndex !== null && i === state.selectedIndex;
+        return (
+          <div
+            key={s.text}
+            ref={isSelected ? selectedRef : undefined}
+            className={`suggestion-item${isSelected ? " suggestion-item-selected" : ""}`}
+            onMouseEnter={() => onSelect?.(i)}
+            onClick={() => onAccept?.(i)}
+          >
+            <div className="suggestion-item-row">
+              <span className="suggestion-command">{s.text}</span>
+              {s.badge && (
+                <span className={`suggestion-badge suggestion-badge-${s.badge}`}>
+                  {s.badge}
+                </span>
+              )}
+            </div>
+            {s.description && isSelected && (
+              <div className="suggestion-description">{s.description}</div>
             )}
           </div>
-          {s.description && i === state.selectedIndex && (
-            <div className="suggestion-description">{s.description}</div>
-          )}
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
Closes #120

## Summary

- Arrow keys navigate suggestions with wrapping, supporting both normal and application cursor mode
- No item highlighted by default — Enter passes through to shell unless user explicitly selects
- Mouse hover highlights items, click accepts
- Key interception guards on overlay visibility only (not phase), preventing dropped keystrokes from shell echo phase-flicker
- 42 regression tests covering navigation, acceptance, passthrough, and edge cases

## Test plan

- [ ] Type a prefix, overlay appears, press ↓ → first item highlights
- [ ] Press ↓ past last item → wraps to top
- [ ] Press ↑ from top → wraps to bottom
- [ ] Press Enter with highlight → suggestion accepted and executed
- [ ] Press Enter without highlight → typed command executes normally
- [ ] Press Esc → overlay dismisses, typed text stays
- [ ] Press ↑/↓ with no overlay → shell history works normally
- [ ] Mouse hover highlights items, click accepts
- [ ] Ctrl+C with overlay → dismisses overlay, SIGINT sent
- [ ] All 1949 existing tests pass