### PR TITLE
Fix suggestion overlay appearing inside interactive CLI tools

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -264,6 +264,7 @@ pub fn run() {
             pty::add_workspace_path,
             pty::update_session_group,
             pty::get_available_shells,
+            pty::is_shell_foreground,
             // Terminal Command Intelligence
             pty::detect_shell_environment,
             pty::read_shell_history,

--- a/src-tauri/src/pty/commands.rs
+++ b/src-tauri/src/pty/commands.rs
@@ -1459,6 +1459,89 @@ pub fn write_to_session(
     Ok(())
 }
 
+/// Check whether the shell is the foreground process in the PTY.
+///
+/// Returns `true` when the shell itself owns the terminal's foreground process
+/// group — i.e. the user is at a shell prompt and no child program (Claude Code,
+/// vim, htop, etc.) is running in the foreground.
+///
+/// Strategy:
+///   1. macOS — open the TTY slave device and call `tcgetpgrp()` to get the
+///      foreground PGID, then compare with the shell's own PGID.
+///   2. Linux — read `/proc/{pid}/stat` to obtain `pgrp` and `tpgid`.
+///   3. Fallback — enumerate the shell's direct children; if none exist the
+///      shell is assumed to be at its prompt.
+#[tauri::command]
+pub fn is_shell_foreground(
+    state: State<'_, AppState>,
+    session_id: String,
+) -> Result<bool, String> {
+    let mgr = state.pty_manager.lock().map_err(|e| e.to_string())?;
+    let session = mgr
+        .sessions
+        .get(&session_id)
+        .ok_or_else(|| format!("Session {} not found", session_id))?;
+
+    let shell_pid = session
+        .child
+        .process_id()
+        .ok_or_else(|| "Shell process ID not available".to_string())?;
+
+    // ── macOS: tcgetpgrp on the TTY slave ──
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(ref tty_path) = session.tty_path {
+            if let Ok(tty_cstr) =
+                std::ffi::CString::new(tty_path.to_string_lossy().into_owned())
+            {
+                let fd = unsafe {
+                    libc::open(tty_cstr.as_ptr(), libc::O_RDONLY | libc::O_NOCTTY)
+                };
+                if fd >= 0 {
+                    let fg_pgid = unsafe { libc::tcgetpgrp(fd) };
+                    unsafe { libc::close(fd) };
+                    if fg_pgid > 0 {
+                        let shell_pgid = unsafe { libc::getpgid(shell_pid as i32) };
+                        if shell_pgid > 0 {
+                            return Ok(fg_pgid == shell_pgid);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Linux: read tpgid from /proc/{pid}/stat ──
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(stat) = std::fs::read_to_string(format!("/proc/{}/stat", shell_pid)) {
+            // stat format: pid (comm) state ppid pgrp session tty_nr tpgid ...
+            // comm can contain spaces/parens — find the last ')' first.
+            if let Some(after_comm) = stat.rfind(')').map(|i| &stat[i + 2..]) {
+                let fields: Vec<&str> = after_comm.split_whitespace().collect();
+                // fields: [0]=state [1]=ppid [2]=pgrp [3]=session [4]=tty_nr [5]=tpgid
+                if fields.len() > 5 {
+                    if let (Ok(pgrp), Ok(tpgid)) =
+                        (fields[2].parse::<i32>(), fields[5].parse::<i32>())
+                    {
+                        return Ok(tpgid == pgrp);
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Fallback: no direct children → shell is at prompt ──
+    #[cfg(unix)]
+    {
+        let children = enumerate_child_pids(shell_pid);
+        return Ok(children.is_empty());
+    }
+
+    #[cfg(not(unix))]
+    Ok(true)
+}
+
 #[tauri::command]
 pub fn nudge_realm_context(state: State<'_, AppState>, session_id: String) -> Result<bool, String> {
     // Check if there are realms attached

--- a/src/__tests__/suggestion-overlay-keyboard.test.ts
+++ b/src/__tests__/suggestion-overlay-keyboard.test.ts
@@ -420,6 +420,130 @@ describe("Overlay: Public functions for mouse interaction", () => {
 });
 
 // =============================================================================
+// ALTERNATE BUFFER & SCROLL GUARDS
+// =============================================================================
+
+describe("Overlay: Suppressed when phase is not shell-interactive", () => {
+  it("computeSuggestions uses lastStablePhase (immune to echo-flicker)", () => {
+    const computeFn = TERMINAL_POOL_SRC.match(
+      /function computeSuggestions[\s\S]*?\n\}/,
+    );
+    expect(computeFn).not.toBeNull();
+    // Must use lastStablePhase (not sessionPhase) to avoid echo-flicker
+    expect(computeFn![0]).toContain("lastStablePhase");
+    expect(computeFn![0]).toContain('lastStablePhase !== "idle"');
+    expect(computeFn![0]).toContain('lastStablePhase !== "shell_ready"');
+  });
+
+  it("setSessionPhase tracks lastStablePhase (excludes 'busy')", () => {
+    // pool.ts must update lastStablePhase for all phases except "busy"
+    expect(POOL_SRC).toContain("lastStablePhase");
+    expect(POOL_SRC).toContain('phase !== "busy"');
+  });
+});
+
+describe("Overlay: Suppressed during alternate screen buffer", () => {
+  it("computeSuggestions checks for alternate buffer and returns early", () => {
+    const computeFn = TERMINAL_POOL_SRC.match(
+      /function computeSuggestions[\s\S]*?\n\}/,
+    );
+    expect(computeFn).not.toBeNull();
+    expect(computeFn![0]).toContain('buffer.active.type === "alternate"');
+  });
+
+  it("handleTerminalInput dismisses overlay when alternate buffer is active", () => {
+    // When the terminal switches to alternate buffer (interactive CLI tool starts),
+    // the overlay should be dismissed so keys reach the tool
+    expect(TERMINAL_POOL_SRC).toContain(
+      'entry.terminal.buffer.active.type === "alternate"',
+    );
+    // The dismissal should happen BEFORE the overlay interception guard
+    const src = TERMINAL_POOL_SRC;
+    const altCheck = src.indexOf('buffer.active.type === "alternate"');
+    const overlayGuard = src.indexOf("Overlay key interception");
+    expect(altCheck).toBeGreaterThan(0);
+    expect(overlayGuard).toBeGreaterThan(altCheck);
+  });
+});
+
+describe("Overlay: Suppressed when user scrolled up", () => {
+  it("computeSuggestions checks userScrolledUp flag", () => {
+    const computeFn = TERMINAL_POOL_SRC.match(
+      /function computeSuggestions[\s\S]*?\n\}/,
+    );
+    expect(computeFn).not.toBeNull();
+    expect(computeFn![0]).toContain("userScrolledUp");
+  });
+});
+
+describe("Overlay: OS-level foreground process check (synchronous cached poll)", () => {
+  it("computeSuggestions checks entry.shellIsForeground synchronously", () => {
+    const computeFn = TERMINAL_POOL_SRC.match(
+      /function computeSuggestions[\s\S]*?\n\}/,
+    );
+    expect(computeFn).not.toBeNull();
+    expect(computeFn![0]).toContain("shellIsForeground");
+  });
+
+  it("computeSuggestions is synchronous (no async IPC in hot path)", () => {
+    // Must NOT be async — uses cached poll value instead
+    expect(TERMINAL_POOL_SRC).not.toContain(
+      "async function computeSuggestions(",
+    );
+    expect(TERMINAL_POOL_SRC).toContain(
+      "function computeSuggestions(",
+    );
+  });
+
+  it("pool.ts sets up a polling interval for isShellForeground", () => {
+    // The polling timer is started in createTerminal
+    expect(POOL_SRC).toContain("shellFgPollTimer");
+    expect(POOL_SRC).toContain("isShellForeground(sessionId)");
+    expect(POOL_SRC).toContain("setInterval");
+  });
+
+  it("pool.ts cleans up shellFgPollTimer in destroy()", () => {
+    const destroyFn = POOL_SRC.match(
+      /export function destroy[\s\S]*?\n\}/,
+    );
+    expect(destroyFn).not.toBeNull();
+    expect(destroyFn![0]).toContain("shellFgPollTimer");
+    expect(destroyFn![0]).toContain("clearInterval");
+  });
+
+  it("PoolEntry interface includes shellIsForeground and shellFgPollTimer", () => {
+    expect(POOL_SRC).toContain("shellIsForeground: boolean");
+    expect(POOL_SRC).toContain("shellFgPollTimer:");
+  });
+});
+
+// =============================================================================
+// CURSOR POSITION COORDINATE SPACE
+// =============================================================================
+
+describe("Overlay: Cursor position accounts for DOM offset", () => {
+  it("getCursorPixelPosition uses getBoundingClientRect for coordinate space translation", () => {
+    expect(POOL_SRC).toContain("getBoundingClientRect");
+    // Should query .xterm-screen for the rendering area position
+    expect(POOL_SRC).toContain(".xterm-screen");
+  });
+
+  it("getCursorPixelPosition adds offset from xterm-screen to wrapper", () => {
+    const cursorFn = POOL_SRC.match(
+      /export function getCursorPixelPosition[\s\S]*?\n\}/,
+    );
+    expect(cursorFn).not.toBeNull();
+    const body = cursorFn![0];
+    // Should compute offset between screen element and wrapper
+    expect(body).toContain("screenRect");
+    expect(body).toContain("wrapperRect");
+    // Should add the offset to x and y
+    expect(body).toContain("screenRect.left - wrapperRect.left");
+    expect(body).toContain("screenRect.top - wrapperRect.top");
+  });
+});
+
+// =============================================================================
 // WRAPPING ARITHMETIC
 // =============================================================================
 

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -115,3 +115,8 @@ export function writeToSession(sessionId: string, data: string): Promise<void> {
 export function saveAllSnapshots(): Promise<void> {
   return invoke("save_all_snapshots");
 }
+
+/** Check if the shell is the foreground process (no child program running). */
+export function isShellForeground(sessionId: string): Promise<boolean> {
+  return invoke<boolean>("is_shell_foreground", { sessionId });
+}

--- a/src/terminal/TerminalPool.ts
+++ b/src/terminal/TerminalPool.ts
@@ -133,6 +133,15 @@ function handleTerminalInput(sessionId: string, data: string): void {
     (phase === "idle" || phase === "shell_ready");
   const overlayVisible = entry.suggestionState?.visible ?? false;
 
+  // ── Dismiss stale overlay when alternate buffer becomes active ──
+  // Interactive CLI tools (Claude Code, vim, etc.) switch to the alternate
+  // screen buffer. If the overlay was visible when this happened, dismiss it
+  // immediately so navigation keys reach the tool instead of the overlay.
+  if (overlayVisible && entry.terminal.buffer.active.type === "alternate") {
+    dismissSuggestions(sessionId);
+    clearGhostText(sessionId);
+  }
+
   // ── Overlay key interception (only when overlay is showing) ──
   // Guard on overlay visibility, NOT intelligenceActive — the phase can
   // briefly flip to "busy" from shell echo while the overlay is still visible.
@@ -341,6 +350,31 @@ function computeSuggestions(sessionId: string): void {
   if (!entry || !entry.inputBuffer.trim()) return;
   if (isIntelligenceDisabled()) return;
   if (!shouldShowOverlay(sessionId)) return;
+
+  // Only show suggestions when the shell is at an interactive prompt.
+  // Use lastStablePhase instead of sessionPhase — the current phase can
+  // be "busy" from echo-flicker (both shell AND AI agent echo trigger it).
+  // lastStablePhase tracks the real state: "idle"/"shell_ready" = shell
+  // prompt, "needs_input" = AI agent, "creating"/etc. = lifecycle.
+  if (entry.lastStablePhase !== "idle" && entry.lastStablePhase !== "shell_ready") return;
+
+  // Don't show suggestions when the alternate screen buffer is active.
+  // Interactive CLI tools (Claude Code, vim, htop, etc.) use the alternate
+  // buffer — cursor coordinates in that buffer don't correspond to the shell
+  // prompt, and our input buffer tracking doesn't reflect the tool's input.
+  if (entry.terminal.buffer.active.type === "alternate") return;
+
+  // Don't show suggestions when the user has scrolled up — the cursor is
+  // off-screen and the overlay would appear at a misleading position.
+  if (entry.userScrolledUp) return;
+
+  // OS-level foreground process check — uses a cached value updated by a
+  // 300ms polling interval (see pool.ts createTerminal). Synchronous access
+  // avoids async gaps where state can change between the check and usage.
+  // This is the most reliable guard: tcgetpgrp() / /proc/stat tells us
+  // whether the shell or a child program (AI tools, editors, etc.) owns
+  // the terminal foreground process group.
+  if (!entry.shellIsForeground) return;
 
   // Intent suggestions (colon-prefixed commands)
   if (entry.inputBuffer.trimStart().startsWith(":")) {

--- a/src/terminal/pool.ts
+++ b/src/terminal/pool.ts
@@ -5,7 +5,7 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { listen, UnlistenFn } from "@tauri-apps/api/event";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
 import { isMac } from "../utils/platform";
-import { resizeSession } from "../api/sessions";
+import { resizeSession, isShellForeground } from "../api/sessions";
 import { createHistoryProvider, type HistoryProvider } from "./intelligence/historyProvider";
 import { type SuggestionState } from "./intelligence/SuggestionOverlay";
 import { clearShellEnvironment } from "./intelligence/shellEnvironment";
@@ -33,6 +33,13 @@ export interface PoolEntry {
   suggestionTimer: ReturnType<typeof setTimeout> | null;
   historyProvider: HistoryProvider;
   sessionPhase: string;
+  /** Last phase that wasn't "busy" — immune to echo-flicker.
+   *  "busy" is transient (shell/agent echo); this tracks the real state. */
+  lastStablePhase: string;
+  /** Cached OS-level check: is the shell the foreground process?
+   *  Updated by a periodic poll — checked synchronously in computeSuggestions. */
+  shellIsForeground: boolean;
+  shellFgPollTimer: ReturnType<typeof setInterval> | null;
   cwd: string;
 }
 
@@ -343,7 +350,7 @@ export async function createTerminal(
     throw err;
   }
 
-  pool.set(sessionId, {
+  const entry: PoolEntry = {
     terminal,
     fitAddon,
     container,
@@ -361,9 +368,23 @@ export async function createTerminal(
     suggestionTimer: null,
     historyProvider: createHistoryProvider(),
     sessionPhase: "creating",
+    lastStablePhase: "creating",
+    shellIsForeground: true,
+    shellFgPollTimer: null,
     cwd: "",
-  });
+  };
+
+  pool.set(sessionId, entry);
   creating.delete(sessionId);
+
+  // Start polling the OS-level foreground process check.
+  // This runs every 300ms and caches the result so computeSuggestions
+  // can check it synchronously (no async IPC in the hot path).
+  entry.shellFgPollTimer = setInterval(() => {
+    isShellForeground(sessionId)
+      .then((isFg) => { entry.shellIsForeground = isFg; })
+      .catch(() => { /* IPC failure — keep last known value */ });
+  }, 300);
 }
 
 // ─── Attach / Detach / Destroy ───────────────────────────────────────
@@ -468,6 +489,7 @@ export function destroy(sessionId: string): void {
   entry.unlistenOutput?.();
   entry.unlistenExit?.();
   if (entry.suggestionTimer) clearTimeout(entry.suggestionTimer);
+  if (entry.shellFgPollTimer) clearInterval(entry.shellFgPollTimer);
   entry.terminal.dispose();
   entry.container.remove();
   pool.delete(sessionId);
@@ -556,6 +578,13 @@ export function setSessionPhase(sessionId: string, phase: string): void {
   if (!entry) return;
   const prevPhase = entry.sessionPhase;
   entry.sessionPhase = phase;
+
+  // Track the last non-"busy" phase. "busy" is transient (shell/agent echo
+  // flicker), so it doesn't represent the real session state. Everything
+  // else (idle, shell_ready, needs_input, creating, etc.) is stable.
+  if (phase !== "busy") {
+    entry.lastStablePhase = phase;
+  }
 
   // ── Re-send PTY resize when shell becomes ready ──
   // attach() sends resizeSession() via a double-rAF, but the shell may not
@@ -651,11 +680,27 @@ export function getCursorPixelPosition(entry: PoolEntry): { x: number; y: number
       const cellH = dims.css?.cell?.height ?? dims.actualCellHeight ?? (fontSize * lineHeight);
       const cursorX = entry.terminal.buffer.active.cursorX;
       const cursorY = entry.terminal.buffer.active.cursorY;
-      return {
-        x: cursorX * cellW,
-        y: (cursorY + 1) * cellH, // Below the cursor row
-        cellHeight: cellH,
-      };
+
+      // Cursor position relative to xterm's rendering area (.xterm-screen)
+      let x = cursorX * cellW;
+      let y = (cursorY + 1) * cellH; // Below the cursor row
+
+      // The suggestion overlay is positioned within .terminal-pane-wrapper,
+      // but cursor coordinates are relative to .xterm-screen. These live in
+      // different coordinate spaces — the viewport has padding (4px top/left)
+      // and xterm may add its own offsets. Use actual DOM positions to bridge
+      // the gap accurately.
+      if (entry.viewport?.parentElement) {
+        const screenEl = entry.container.querySelector(".xterm-screen");
+        if (screenEl) {
+          const screenRect = screenEl.getBoundingClientRect();
+          const wrapperRect = entry.viewport.parentElement.getBoundingClientRect();
+          x += screenRect.left - wrapperRect.left;
+          y += screenRect.top - wrapperRect.top;
+        }
+      }
+
+      return { x, y, cellHeight: cellH };
     }
   } catch { /* fallback */ }
   return { x: 0, y: 0, cellHeight: 0 };


### PR DESCRIPTION
## Summary
- Suppress suggestion overlay when the user is inside any child program (Claude Code, vim, htop, etc.) by detecting the terminal's foreground process at the OS level
- Fix overlay positioning coordinate space mismatch between xterm-screen and the wrapper element
- Track stable session phase to ignore transient "busy" echo-flicker from both shell and AI agent keystrokes

Closes #122

## Test plan
- [ ] Open a terminal and verify suggestions still work at the normal shell prompt
- [ ] Launch Claude Code (or any interactive CLI) and verify suggestions do not appear
- [ ] Open vim/htop (alternate buffer tools) and verify suggestions do not appear
- [ ] Verify overlay position is correct relative to the cursor