### PR TITLE
fix: terminal resize not working on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Each release uses the categories: **New**, **Fixed**, **Improved**, **Removed**.
 
 ---
 
+# 0.5.8 (2026-03-14)
+
+## Fixed
+- Terminal sessions now resize correctly when the window is resized on macOS
+- Shell and child processes (e.g. Claude Code) properly pick up new terminal dimensions after resize
+
+---
+
 # 0.5.6 (2026-03-14)
 
 ## New

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hermes-ide",
   "private": true,
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1864,7 +1864,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-ide"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-ide"
-version = "0.5.7"
+version = "0.5.8"
 description = "AI-native terminal"
 authors = ["Gabriel Anhaia"]
 edition = "2021"

--- a/src-tauri/src/pty/commands.rs
+++ b/src-tauri/src/pty/commands.rs
@@ -650,14 +650,20 @@ pub fn create_session(
     let pty_rows = initial_rows.unwrap_or(24);
     let pty_cols = initial_cols.unwrap_or(80);
     let pty_system = native_pty_system();
+    let pty_size = PtySize {
+        rows: pty_rows,
+        cols: pty_cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    };
     let pair = pty_system
-        .openpty(PtySize {
-            rows: pty_rows,
-            cols: pty_cols,
-            pixel_width: 0,
-            pixel_height: 0,
-        })
+        .openpty(pty_size.clone())
         .map_err(|e| format!("Failed to open PTY: {}", e))?;
+
+    // Workaround: portable-pty's openpty() does not apply the initial window
+    // size on macOS — get_size() returns (0, 0) right after creation.
+    // Explicitly resize to ensure the PTY starts with the correct dimensions.
+    let _ = pair.master.resize(pty_size);
 
     let is_ssh = ssh_info_clone.is_some();
 
@@ -1592,6 +1598,7 @@ pub fn resize_session(
         .sessions
         .get(&session_id)
         .ok_or_else(|| format!("Session {} not found", session_id))?;
+
     session
         .master
         .resize(PtySize {
@@ -1601,6 +1608,26 @@ pub fn resize_session(
             pixel_height: 0,
         })
         .map_err(|e| format!("Resize failed: {}", e))?;
+
+    // Explicitly send SIGWINCH to the child process.
+    // On macOS with posix_spawn(POSIX_SPAWN_SETSID), ioctl(TIOCSWINSZ) on the
+    // master fd does NOT automatically deliver SIGWINCH because the parent
+    // process is in a different session than the child.  tcgetpgrp() returns -1
+    // from the parent's context.  Send SIGWINCH directly to the child's process
+    // group (negative PID = entire process group) so the shell and its children
+    // pick up the new terminal dimensions.
+    #[cfg(unix)]
+    {
+        if let Some(child_pid) = session.child.process_id() {
+            let pgid = child_pid as i32;
+            unsafe {
+                // Send to the process group (negative PID), not just the shell.
+                // This ensures child processes (e.g. Claude Code) also receive it.
+                libc::kill(-(pgid), libc::SIGWINCH);
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "HERMES-IDE",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "identifier": "com.hermes-ide.terminal",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/terminal/pool.ts
+++ b/src/terminal/pool.ts
@@ -521,7 +521,7 @@ export function refitActive(): void {
           entry.terminal.scrollToBottom();
         }
         resizeSession(sessionId, entry.terminal.rows, entry.terminal.cols)
-          .catch(() => {});
+          .catch((err) => console.warn("[TerminalPool] Failed to resize session:", err));
       } catch { /* ignore fit errors */ }
     }
   }


### PR DESCRIPTION
## Summary
- Fix terminal sessions not resizing when the window is resized on macOS
- After `openpty()`, explicitly call `resize()` to apply initial PTY dimensions (portable-pty workaround)
- After `resize_session()`, explicitly send `SIGWINCH` to the child process group since `ioctl(TIOCSWINSZ)` doesn't auto-deliver it with `posix_spawn(POSIX_SPAWN_SETSID)`

Closes #132

## Test plan
- [ ] Resize the app window and verify the terminal content reflows correctly
- [ ] Open a CLI tool (e.g. Claude Code) and verify it also picks up the new dimensions
- [ ] Create a new session and verify it starts with correct dimensions
- [ ] Test on macOS specifically