### PR TITLE
Fix toast notifications hidden behind title bar

### DIFF
--- a/src/__tests__/toast-positioning.test.ts
+++ b/src/__tests__/toast-positioning.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression test: toast container must be positioned below the topbar.
+ *
+ * The `top` value in ToastContainer.css must reference `--topbar-h`
+ * so toasts clear the title bar regardless of its height.
+ *
+ * See: https://github.com/hermes-hq/hermes-ide/issues/134
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const css = readFileSync(
+	resolve(__dirname, "../styles/components/ToastContainer.css"),
+	"utf-8",
+);
+
+describe("ToastContainer positioning", () => {
+	it("uses --topbar-h token for top offset (not a hardcoded value)", () => {
+		// Extract the .toast-container block
+		const containerMatch = css.match(
+			/\.toast-container\s*\{([^}]+)\}/,
+		);
+		expect(containerMatch).not.toBeNull();
+		const block = containerMatch![1];
+
+		// `top` must reference --topbar-h to stay in sync with the title bar
+		const topLine = block.match(/top\s*:\s*(.+?);/);
+		expect(topLine).not.toBeNull();
+		expect(topLine![1]).toContain("var(--topbar-h)");
+	});
+
+	it("adds positive gap below the topbar", () => {
+		const containerMatch = css.match(
+			/\.toast-container\s*\{([^}]+)\}/,
+		);
+		const block = containerMatch![1];
+		const topLine = block.match(/top\s*:\s*(.+?);/);
+
+		// Should use calc() to add spacing beyond the topbar
+		expect(topLine![1]).toMatch(/calc\(\s*var\(--topbar-h\)\s*\+/);
+	});
+});

--- a/src/styles/components/ToastContainer.css
+++ b/src/styles/components/ToastContainer.css
@@ -2,7 +2,7 @@
 
 .toast-container {
 	position: fixed;
-	top: 36px;
+	top: calc(var(--topbar-h) + 8px);
 	right: 12px;
 	z-index: 9999;
 	display: flex;


### PR DESCRIPTION
## Summary
- Toast container used hardcoded `top: 36px` while the topbar height is `40px` (`--topbar-h`), causing toasts to render partially behind the title bar
- Changed to `calc(var(--topbar-h) + 8px)` so positioning stays in sync with the topbar token
- Added regression test that asserts the CSS uses `--topbar-h` (not a hardcoded value)

Closes #134