### PR TITLE
Add close-confirm toggle in Settings and improve drag-drop zones

### DIFF
--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -722,50 +722,54 @@ export function SessionList({ sessions, activeSessionId, onSelect, onClose, onNe
       const x = event.payload.position.x / dpr;
       const y = event.payload.position.y / dpr;
 
-      if (type === "over") {
-        // Hit-test against project sections
-        let found: string | null = null;
-        for (const [group, el] of projectRefsMap.current) {
-          const rect = el.getBoundingClientRect();
-          if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
-            found = group;
-            break;
+      if (type === "over" || type === "drop") {
+        // Hit-test against project sections and ungrouped area.
+        // Use generous padding (8px) around each target to make drop zones
+        // easier to hit — the visual indicators already show the active zone.
+        const PAD = 8;
+        const hitTest = (): string | null | undefined => {
+          // Check project sections first
+          for (const [group, el] of projectRefsMap.current) {
+            const rect = el.getBoundingClientRect();
+            if (x >= rect.left - PAD && x <= rect.right + PAD &&
+                y >= rect.top - PAD && y <= rect.bottom + PAD) {
+              return group;
+            }
           }
-        }
-        // Hit-test ungrouped area
-        if (!found && ungroupedRef.current) {
-          const rect = ungroupedRef.current.getBoundingClientRect();
-          if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
-            found = "__ungrouped__";
+          // Check ungrouped area — use the entire remaining sidebar height
+          // below the last project section as a valid drop zone. This makes
+          // it much easier to drop into the ungrouped area instead of requiring
+          // the cursor to land in the tiny 4px default zone.
+          if (ungroupedRef.current) {
+            const rect = ungroupedRef.current.getBoundingClientRect();
+            const parent = ungroupedRef.current.parentElement;
+            const bottomEdge = parent ? parent.getBoundingClientRect().bottom : rect.bottom;
+            if (x >= rect.left - PAD && x <= rect.right + PAD &&
+                y >= rect.top - PAD && y <= bottomEdge + PAD) {
+              return "__ungrouped__";
+            }
           }
-        }
-        setDropTarget(found);
-      } else if (type === "drop") {
-        // Hit-test to find drop target
-        let targetGroup: string | null | undefined = undefined;
-        for (const [group, el] of projectRefsMap.current) {
-          const rect = el.getBoundingClientRect();
-          if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
-            targetGroup = group;
-            break;
-          }
-        }
-        if (targetGroup === undefined && ungroupedRef.current) {
-          const rect = ungroupedRef.current.getBoundingClientRect();
-          if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
-            targetGroup = null; // ungrouped
-          }
-        }
-        setDropTarget(null);
-        setIsDraggingSession(false);
+          return undefined;
+        };
 
-        if (targetGroup !== undefined && capturedSessionId) {
-          const session = sessionsRef.current.find((s) => s.id === capturedSessionId);
-          if (session && (session.group || null) !== targetGroup) {
-            handleMoveToProject(capturedSessionId, targetGroup!);
+        const result = hitTest();
+
+        if (type === "over") {
+          setDropTarget(result === undefined ? null : result);
+        } else {
+          // drop
+          const targetGroup = result === "__ungrouped__" ? null : result;
+          setDropTarget(null);
+          setIsDraggingSession(false);
+
+          if (targetGroup !== undefined && capturedSessionId) {
+            const session = sessionsRef.current.find((s) => s.id === capturedSessionId);
+            if (session && (session.group || null) !== targetGroup) {
+              handleMoveToProject(capturedSessionId, targetGroup!);
+            }
           }
+          capturedSessionId = null;
         }
-        capturedSessionId = null;
       }
     }).then((fn) => { if (!cancelled) unlisten = fn; });
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -299,6 +299,22 @@ export function Settings({ onClose, initialTab, pluginRuntime, onConfirmPluginUp
                   </select>
                   <span className="settings-hint-inline">Re-open previous sessions and layout when the app restarts</span>
                 </div>
+
+                <div className="settings-group">
+                  <label className="settings-label">
+                    <input
+                      type="checkbox"
+                      checked={settings.skip_close_confirm !== "true"}
+                      onChange={(e) => {
+                        const skip = !e.target.checked;
+                        updateSetting("skip_close_confirm", skip ? "true" : "false");
+                        dispatch({ type: "SET_SKIP_CLOSE_CONFIRM", skip });
+                      }}
+                    />
+                    {" "}Confirm before closing sessions
+                  </label>
+                  <span className="settings-hint-inline">Show a confirmation dialog when closing a terminal session</span>
+                </div>
               </div>
             )}
 

--- a/src/styles/components/SessionList.css
+++ b/src/styles/components/SessionList.css
@@ -446,15 +446,16 @@
 
 .ungrouped-section {
   min-height: 4px;
-  transition: min-height 0.15s ease, background 0.15s ease;
+  transition: min-height 0.15s ease, background 0.15s ease, padding 0.15s ease;
 }
 
 .ungrouped-section-drag-active {
-  min-height: 40px;
+  min-height: 60px;
   border: 1.5px dashed var(--border, #27272a);
   border-radius: var(--radius);
   margin: 4px 6px;
-  padding: 4px;
+  padding: 8px;
+  flex: 1;
 }
 
 .ungrouped-section-drop-target {
@@ -462,8 +463,9 @@
   outline-offset: -2px;
   border-radius: var(--radius);
   background: color-mix(in srgb, var(--accent, #a78bfa) 12%, transparent);
-  min-height: 40px;
+  min-height: 60px;
   border-color: transparent;
+  flex: 1;
 }
 
 .ungrouped-section-drop-target .ungrouped-divider {


### PR DESCRIPTION
## Summary

- **#130**: Added "Confirm before closing sessions" checkbox in Settings > General so users can re-enable the close confirmation after dismissing "Don't ask again"
- **#129**: Improved drag-and-drop reliability — added 8px hit-test padding, extended ungrouped drop zone to fill remaining sidebar height, increased min-height to 60px, deduplicated hit-test logic

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `npx vitest run` — 1963 passed
- [x] Manual testing: Settings toggle works, drag-drop zones are generous

Closes #129, Closes #130