### PR TITLE
feat: add sessionActions plugin placement for per-session toolbar buttons

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1970,7 +1970,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-ide"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,6 +118,9 @@ function AppContent() {
       onStatusBarUpdate: (itemId, update) => {
         pluginRuntimeRef.current?.updateStatusBarItem(itemId, update);
       },
+      onSessionActionBadgeUpdate: (actionId, badge) => {
+        pluginRuntimeRef.current?.updateSessionActionBadge(actionId, badge);
+      },
       onNotification: async (options) => {
         try {
           const { sendNotification } = await import("@tauri-apps/plugin-notification");
@@ -144,7 +147,7 @@ function AppContent() {
     return runtime;
   });
 
-  const { commands: pluginCommands, panels: pluginPanels, pluginsWithSettings } = usePluginRuntime(pluginRuntime);
+  const { commands: pluginCommands, panels: pluginPanels, pluginsWithSettings, sessionActions: pluginSessionActions } = usePluginRuntime(pluginRuntime);
   const pluginUpdater = usePluginUpdateChecker(pluginRuntime);
   const [pendingUpdatePlugins, setPendingUpdatePlugins] = useState<typeof pluginUpdater.updatesAvailable | null>(null);
 
@@ -521,7 +524,7 @@ function AppContent() {
             tabs={[
               { id: "sessions", label: `Sessions (${fmt("{mod}B")})`, icon: SessionsIcon, badge: sessions.length || undefined },
               ...pluginPanels
-                .filter(p => p.side === "left")
+                .filter(p => p.side === "left" && !pluginSessionActions.some(a => a.panelId === p.id))
                 .map(p => ({
                   id: p.id,
                   label: p.name,
@@ -564,9 +567,20 @@ function AppContent() {
                 null
               }
               onViewChange={(view: SessionView) => {
+                if (view) setActivePluginPanel(null);
                 dispatch({ type: "SET_SUBVIEW_PANEL", panel: view });
               }}
               gitBadge={activeGitSummary.changeCount || undefined}
+              pluginSessionActions={pluginSessionActions}
+              activePluginPanel={activePluginPanel}
+              onPluginActionClick={(_actionId, panelId) => {
+                if (activePluginPanel === panelId) {
+                  setActivePluginPanel(null);
+                } else {
+                  dispatch({ type: "SET_SUBVIEW_PANEL", panel: null });
+                  setActivePluginPanel(panelId);
+                }
+              }}
             />
           </PanelErrorBoundary>
         )}

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -12,6 +12,7 @@ import { fmt } from "../utils/platform";
 import { useSessionGitSummary } from "../hooks/useSessionGitSummary";
 import { useRemoteSshInfo } from "../hooks/useRemoteSshInfo";
 import { PortForwardsPanel } from "./PortForwardsPanel";
+import type { PluginSessionActionContribution } from "../plugins/types";
 
 export const SESSION_COLORS = [
   "#58a6ff", "#3fb950", "#bc8cff", "#f78166",
@@ -33,6 +34,9 @@ interface SessionListProps {
   onViewChange: (view: SessionView) => void;
   /** Number of git changes for the active session */
   gitBadge?: number;
+  pluginSessionActions?: (PluginSessionActionContribution & { pluginId: string; badge?: { text?: string; count?: number } })[];
+  activePluginPanel?: string | null;
+  onPluginActionClick?: (actionId: string, panelId: string) => void;
 }
 
 function timeAgo(dateStr: string): string {
@@ -499,7 +503,7 @@ function InlineProjectNameEditor({
   );
 }
 
-export function SessionList({ sessions, activeSessionId, onSelect, onClose, onNewSession, onReconnect, activeView, onViewChange, gitBadge }: SessionListProps) {
+export function SessionList({ sessions, activeSessionId, onSelect, onClose, onNewSession, onReconnect, activeView, onViewChange, gitBadge, pluginSessionActions, activePluginPanel, onPluginActionClick }: SessionListProps) {
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const [renameSessionId, setRenameSessionId] = useState<string | null>(null);
   const [newGroupSessionId, setNewGroupSessionId] = useState<string | null>(null);
@@ -978,6 +982,19 @@ export function SessionList({ sessions, activeSessionId, onSelect, onClose, onNe
                 </svg>
               </button>
             )}
+            {pluginSessionActions?.map((action) => (
+              <button
+                key={action.id}
+                className={`session-subview-btn${activePluginPanel === action.panelId ? " session-subview-active" : ""}`}
+                onClick={() => onPluginActionClick?.(action.id, action.panelId)}
+                title={action.name}
+              >
+                <span dangerouslySetInnerHTML={{ __html: action.icon }} />
+                {action.badge?.count ? (
+                  <span className="session-subview-badge">{action.badge.count}</span>
+                ) : null}
+              </button>
+            ))}
           </div>
         )}
         {/* Port forwards panel for SSH sessions */}

--- a/src/plugins/PluginAPI.ts
+++ b/src/plugins/PluginAPI.ts
@@ -17,6 +17,7 @@ export interface HermesPluginAPI {
 		togglePanel(panelId: string): void;
 		showToast(message: string, options?: { type?: "info" | "success" | "warning" | "error"; duration?: number }): void;
 		updateStatusBarItem(itemId: string, update: { text?: string; tooltip?: string; visible?: boolean }): void;
+		updateSessionActionBadge(actionId: string, badge: { text?: string; count?: number }): void;
 	};
 	commands: {
 		register(commandId: string, handler: () => void | Promise<void>): Disposable;
@@ -75,6 +76,7 @@ export interface PluginAPICallbacks {
 	onPanelHide: PanelToggleCallback;
 	onToast: ToastCallback;
 	onStatusBarUpdate: StatusBarUpdateCallback;
+	onSessionActionBadgeUpdate?: (actionId: string, badge: { text?: string; count?: number }) => void;
 	onSettingChanged?: (pluginId: string, key: string, value: string | number | boolean) => void;
 	onEventSubscribe?: (event: HermesEvent, callback: (...args: unknown[]) => void) => Disposable;
 	onNotification?: (options: { title: string; body?: string }) => Promise<void>;
@@ -129,6 +131,9 @@ export function createPluginAPI(
 			},
 			updateStatusBarItem(itemId: string, update: { text?: string; tooltip?: string; visible?: boolean }) {
 				callbacks.onStatusBarUpdate(itemId, update);
+			},
+			updateSessionActionBadge(actionId: string, badge: { text?: string; count?: number }) {
+				callbacks.onSessionActionBadgeUpdate?.(actionId, badge);
 			},
 		},
 		commands: {

--- a/src/plugins/PluginRuntime.ts
+++ b/src/plugins/PluginRuntime.ts
@@ -1,4 +1,4 @@
-import type { PluginManifest, PluginCommandContribution, PluginPanelContribution, PluginStatusBarItem, HermesEvent } from "./types";
+import type { PluginManifest, PluginCommandContribution, PluginPanelContribution, PluginStatusBarItem, PluginSessionActionContribution, HermesEvent } from "./types";
 import { createPluginAPI, type HermesPluginAPI, type PluginPanelProps, type PluginAPICallbacks } from "./PluginAPI";
 
 export type PluginActivateFn = (api: HermesPluginAPI) => void | Promise<void>;
@@ -29,6 +29,7 @@ export class PluginRuntime {
 	private commandHandlers = new Map<string, () => void | Promise<void>>();
 	private panelComponents = new Map<string, React.ComponentType<PluginPanelProps>>();
 	private statusBarOverrides = new Map<string, { text?: string; tooltip?: string; visible?: boolean }>();
+	private sessionActionBadges = new Map<string, { text?: string; count?: number }>();
 	private changeListeners = new Set<() => void>();
 	private eventListeners = new Map<HermesEvent, Set<(...args: unknown[]) => void>>();
 	private callbacks: PluginAPICallbacks;
@@ -146,6 +147,9 @@ export class PluginRuntime {
 		for (const item of entry.module.manifest.contributes.statusBarItems ?? []) {
 			this.statusBarOverrides.delete(item.id);
 		}
+		for (const action of entry.module.manifest.contributes.sessionActions ?? []) {
+			this.sessionActionBadges.delete(action.id);
+		}
 
 		this.plugins.delete(pluginId);
 		this.notify();
@@ -249,6 +253,23 @@ export class PluginRuntime {
 			}
 		}
 		return result;
+	}
+
+	getAllSessionActions(): (PluginSessionActionContribution & { pluginId: string; badge?: { text?: string; count?: number } })[] {
+		const result: (PluginSessionActionContribution & { pluginId: string; badge?: { text?: string; count?: number } })[] = [];
+		for (const [id, entry] of this.plugins) {
+			if (entry.status !== "active") continue;
+			for (const action of entry.module.manifest.contributes.sessionActions ?? []) {
+				const badge = this.sessionActionBadges.get(action.id);
+				result.push({ ...action, pluginId: id, badge });
+			}
+		}
+		return result;
+	}
+
+	updateSessionActionBadge(actionId: string, badge: { text?: string; count?: number }): void {
+		this.sessionActionBadges.set(actionId, badge);
+		this.notify();
 	}
 
 	updateStatusBarItem(itemId: string, update: { text?: string; tooltip?: string; visible?: boolean }): void {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -20,7 +20,15 @@ export interface PluginContributions {
 	commands?: PluginCommandContribution[];
 	panels?: PluginPanelContribution[];
 	statusBarItems?: PluginStatusBarItem[];
+	sessionActions?: PluginSessionActionContribution[];
 	settings?: PluginSettingsSchema;
+}
+
+export interface PluginSessionActionContribution {
+	id: string;        // unique action ID
+	panelId: string;   // references a panel in contributes.panels
+	name: string;      // tooltip label
+	icon: string;      // inline SVG string
 }
 
 export interface PluginCommandContribution {

--- a/src/plugins/usePluginRuntime.ts
+++ b/src/plugins/usePluginRuntime.ts
@@ -1,11 +1,12 @@
 import { useState, useEffect } from "react";
 import type { PluginRuntime } from "./PluginRuntime";
-import type { PluginCommandContribution, PluginPanelContribution } from "./types";
+import type { PluginCommandContribution, PluginPanelContribution, PluginSessionActionContribution } from "./types";
 
 export function usePluginRuntime(runtime: PluginRuntime | null) {
 	const [commands, setCommands] = useState<(PluginCommandContribution & { pluginId: string; pluginName: string })[]>([]);
 	const [panels, setPanels] = useState<(PluginPanelContribution & { pluginId: string })[]>([]);
 	const [pluginsWithSettings, setPluginsWithSettings] = useState<{ pluginId: string; pluginName: string }[]>([]);
+	const [sessionActions, setSessionActions] = useState<(PluginSessionActionContribution & { pluginId: string; badge?: { text?: string; count?: number } })[]>([]);
 
 	useEffect(() => {
 		if (!runtime) return;
@@ -14,6 +15,7 @@ export function usePluginRuntime(runtime: PluginRuntime | null) {
 			setCommands(runtime.getAllCommands());
 			setPanels(runtime.getAllPanels());
 			setPluginsWithSettings(runtime.getPluginsWithSettings());
+			setSessionActions(runtime.getAllSessionActions());
 		};
 
 		// Initial load
@@ -23,5 +25,5 @@ export function usePluginRuntime(runtime: PluginRuntime | null) {
 		return runtime.subscribe(refresh);
 	}, [runtime]);
 
-	return { commands, panels, pluginsWithSettings, runtime };
+	return { commands, panels, pluginsWithSettings, sessionActions, runtime };
 }


### PR DESCRIPTION
## Summary
- Adds `sessionActions` as a new plugin contribution type, allowing plugins to place buttons in each session's sub-view toolbar (next to Git, Files, Search)
- Plugins can update badge counts on their session action buttons via `api.ui.updateSessionActionBadge()`
- Panels referenced by a session action are automatically hidden from the ActivityBar to avoid duplication
- Switching between plugin panels and built-in sub-views (git/files/search) is properly bridged

## Changed files
- `src/plugins/types.ts` — `PluginSessionActionContribution` interface
- `src/plugins/PluginRuntime.ts` — badge state, `getAllSessionActions()`, `updateSessionActionBadge()`
- `src/plugins/PluginAPI.ts` — exposed `updateSessionActionBadge()` to plugins
- `src/plugins/usePluginRuntime.ts` — surfaces `sessionActions` in React state
- `src/components/SessionList.tsx` — renders plugin action buttons in toolbar
- `src/App.tsx` — wires callbacks, passes props, bridges toggle logic

## Test plan
- [ ] Create a session, verify Notes button appears in sub-view toolbar
- [ ] Click Notes button — panel opens as sidebar
- [ ] Click again — panel closes
- [ ] Add content to notes — badge shows line count
- [ ] Switch between Notes and built-in sub-views (Git, Files, Search) — mutual exclusion works
- [ ] Notes tab no longer appears in the ActivityBar