### PR TITLE
feat: Plugin API extensions for Pixel Office

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod process;
 #[doc(hidden)]
 pub mod pty;
 mod realm;
+mod transcript;
 mod workspace;
 
 use std::collections::HashSet;
@@ -257,6 +258,7 @@ pub fn run() {
             };
 
             app.manage(state);
+            app.manage(Mutex::new(transcript::TranscriptWatcherState::default()));
 
             // Save workspace when the main window is about to close
             let save_handle = app.handle().clone();
@@ -449,6 +451,9 @@ pub fn run() {
             plugins::plugin_fetch_url,
             // Clipboard
             clipboard::copy_image_to_clipboard,
+            // Transcript watching
+            transcript::start_transcript_watcher,
+            transcript::stop_transcript_watcher,
         ])
         .build(tauri::generate_context!())
         .expect("error while building HERMES-IDE")

--- a/src-tauri/src/transcript.rs
+++ b/src-tauri/src/transcript.rs
@@ -1,0 +1,348 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use tauri::{AppHandle, Emitter, State};
+use uuid::Uuid;
+
+use crate::AppState;
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TranscriptEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub tool_name: Option<String>,
+    pub tool_input: Option<serde_json::Value>,
+    pub timestamp: f64,
+    pub session_id: String,
+}
+
+/// Internal representation of a JSONL record from Claude Code transcripts.
+#[derive(Debug, Deserialize)]
+struct JsonlRecord {
+    #[serde(rename = "type")]
+    record_type: Option<String>,
+    subtype: Option<String>,
+    message: Option<JsonlMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonlMessage {
+    content: Option<Vec<JsonlContent>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonlContent {
+    #[serde(rename = "type")]
+    content_type: Option<String>,
+    name: Option<String>,
+    input: Option<serde_json::Value>,
+    #[allow(dead_code)]
+    text: Option<String>,
+}
+
+/// State for active transcript watchers.
+#[derive(Default)]
+pub struct TranscriptWatcherState {
+    pub watchers: HashMap<String, Arc<AtomicBool>>,
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+/// Find the Claude Code JSONL transcript file for a given working directory.
+/// Claude Code stores transcripts in `~/.claude/projects/<path-hash>/`.
+/// We look for the most recently modified `.jsonl` file.
+fn find_transcript_file(working_directory: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    let claude_dir = home.join(".claude").join("projects");
+    if !claude_dir.is_dir() {
+        return None;
+    }
+
+    // Claude Code uses the workspace path to determine the project directory.
+    // The directory name is a sanitised version of the absolute path where
+    // slashes are replaced with hyphens and the leading slash is dropped.
+    // e.g. /Users/foo/code/bar -> Users-foo-code-bar
+    let sanitised = working_directory.trim_start_matches('/').replace('/', "-");
+
+    let project_dir = claude_dir.join(&sanitised);
+    if !project_dir.is_dir() {
+        // Fallback: scan all project dirs looking for one that matches
+        // by checking if a `.project_path` file exists with matching content,
+        // or just find the most recently modified .jsonl across all dirs.
+        return find_most_recent_jsonl_across(&claude_dir);
+    }
+
+    find_most_recent_jsonl_in(&project_dir)
+}
+
+fn find_most_recent_jsonl_in(dir: &std::path::Path) -> Option<PathBuf> {
+    let mut best: Option<(PathBuf, std::time::SystemTime)> = None;
+
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                if let Ok(meta) = path.metadata() {
+                    if let Ok(modified) = meta.modified() {
+                        if best.as_ref().is_none_or(|(_, t)| modified > *t) {
+                            best = Some((path, modified));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    best.map(|(p, _)| p)
+}
+
+fn find_most_recent_jsonl_across(claude_projects_dir: &std::path::Path) -> Option<PathBuf> {
+    let mut best: Option<(PathBuf, std::time::SystemTime)> = None;
+
+    if let Ok(project_dirs) = std::fs::read_dir(claude_projects_dir) {
+        for dir_entry in project_dirs.flatten() {
+            let dir_path = dir_entry.path();
+            if !dir_path.is_dir() {
+                continue;
+            }
+            if let Some((path, modified)) = find_most_recent_jsonl_in(&dir_path).and_then(|p| {
+                p.metadata()
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+                    .map(|t| (p, t))
+            }) {
+                if best.as_ref().is_none_or(|(_, t)| modified > *t) {
+                    best = Some((path, modified));
+                }
+            }
+        }
+    }
+
+    best.map(|(p, _)| p)
+}
+
+/// Parse a single JSONL line into a TranscriptEvent (or None if not relevant).
+fn parse_jsonl_line(line: &str, session_id: &str) -> Vec<TranscriptEvent> {
+    let record: JsonlRecord = match serde_json::from_str(line) {
+        Ok(r) => r,
+        Err(_) => return vec![],
+    };
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+        * 1000.0;
+
+    let mut events = Vec::new();
+    let record_type = record.record_type.as_deref().unwrap_or("");
+
+    match record_type {
+        "assistant" => {
+            if let Some(msg) = &record.message {
+                if let Some(contents) = &msg.content {
+                    for content in contents {
+                        let ct = content.content_type.as_deref().unwrap_or("");
+                        match ct {
+                            "tool_use" => {
+                                events.push(TranscriptEvent {
+                                    event_type: "tool_start".to_string(),
+                                    tool_name: content.name.clone(),
+                                    tool_input: content.input.clone(),
+                                    timestamp,
+                                    session_id: session_id.to_string(),
+                                });
+                            }
+                            "text" => {
+                                events.push(TranscriptEvent {
+                                    event_type: "text".to_string(),
+                                    tool_name: None,
+                                    tool_input: None,
+                                    timestamp,
+                                    session_id: session_id.to_string(),
+                                });
+                            }
+                            "thinking" => {
+                                events.push(TranscriptEvent {
+                                    event_type: "thinking".to_string(),
+                                    tool_name: None,
+                                    tool_input: None,
+                                    timestamp,
+                                    session_id: session_id.to_string(),
+                                });
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+        "user" => {
+            if let Some(msg) = &record.message {
+                if let Some(contents) = &msg.content {
+                    for content in contents {
+                        if content.content_type.as_deref() == Some("tool_result") {
+                            events.push(TranscriptEvent {
+                                event_type: "tool_end".to_string(),
+                                tool_name: None,
+                                tool_input: None,
+                                timestamp,
+                                session_id: session_id.to_string(),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        "system" => {
+            if record.subtype.as_deref() == Some("turn_duration") {
+                events.push(TranscriptEvent {
+                    event_type: "turn_end".to_string(),
+                    tool_name: None,
+                    tool_input: None,
+                    timestamp,
+                    session_id: session_id.to_string(),
+                });
+            }
+        }
+        _ => {}
+    }
+
+    events
+}
+
+// ─── Tauri Commands ─────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn start_transcript_watcher(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    transcript_watchers: State<'_, Mutex<TranscriptWatcherState>>,
+    session_id: String,
+) -> Result<String, String> {
+    // Look up the session's working directory
+    let working_directory = {
+        let mgr = state
+            .pty_manager
+            .lock()
+            .map_err(|e| format!("Lock error: {}", e))?;
+        let pty_session = mgr
+            .sessions
+            .get(&session_id)
+            .ok_or_else(|| format!("Session {} not found", session_id))?;
+        let session = pty_session
+            .session
+            .lock()
+            .map_err(|e| format!("Lock error: {}", e))?;
+        session.working_directory.clone()
+    };
+
+    let transcript_path = find_transcript_file(&working_directory)
+        .ok_or_else(|| "No JSONL transcript file found for this session".to_string())?;
+
+    let watcher_id = Uuid::new_v4().to_string();
+    let stop_flag = Arc::new(AtomicBool::new(false));
+
+    {
+        let mut watcher_state = transcript_watchers
+            .lock()
+            .map_err(|e| format!("Lock error: {}", e))?;
+        watcher_state
+            .watchers
+            .insert(watcher_id.clone(), Arc::clone(&stop_flag));
+    }
+
+    let watcher_id_clone = watcher_id.clone();
+    let session_id_clone = session_id.clone();
+    let app_clone = app.clone();
+
+    std::thread::spawn(move || {
+        let event_name = format!("transcript-event:{}", watcher_id_clone);
+
+        let file = match std::fs::File::open(&transcript_path) {
+            Ok(f) => f,
+            Err(e) => {
+                log::warn!(
+                    "Failed to open transcript file {}: {}",
+                    transcript_path.display(),
+                    e
+                );
+                return;
+            }
+        };
+
+        let mut reader = BufReader::new(file);
+
+        // Seek to end — we only want new lines
+        if let Err(e) = reader.seek(SeekFrom::End(0)) {
+            log::warn!("Failed to seek transcript file: {}", e);
+            return;
+        }
+
+        // Poll for new lines every 500ms
+        while !stop_flag.load(Ordering::Relaxed) {
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match reader.read_line(&mut line) {
+                    Ok(0) => break, // No more data right now
+                    Ok(_) => {
+                        let trimmed = line.trim();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+                        let events = parse_jsonl_line(trimmed, &session_id_clone);
+                        for event in events {
+                            let _ = app_clone.emit(&event_name, &event);
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!("Error reading transcript file: {}", e);
+                        break;
+                    }
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+
+        log::info!("Transcript watcher {} stopped", watcher_id_clone);
+    });
+
+    Ok(watcher_id)
+}
+
+#[tauri::command]
+pub fn stop_transcript_watcher(
+    transcript_watchers: State<'_, Mutex<TranscriptWatcherState>>,
+    watcher_id: String,
+) -> Result<(), String> {
+    let mut watcher_state = transcript_watchers
+        .lock()
+        .map_err(|e| format!("Lock error: {}", e))?;
+
+    if let Some(stop_flag) = watcher_state.watchers.remove(&watcher_id) {
+        stop_flag.store(true, Ordering::Relaxed);
+    }
+
+    Ok(())
+}
+
+/// Stop all transcript watchers for a given session.
+/// Called internally when a session is destroyed.
+#[allow(dead_code)]
+pub fn cleanup_session_watchers(
+    transcript_watchers: &Mutex<TranscriptWatcherState>,
+    _session_id: &str,
+) {
+    // Since we don't track session_id → watcher_id mapping in the watcher state,
+    // and watchers auto-stop when they detect the session is gone,
+    // this is a best-effort cleanup. The polling thread will exit on its own
+    // when the stop flag is set or the file becomes inaccessible.
+    // For a more targeted cleanup, we could add a session_id field to the watcher state.
+    let _ = transcript_watchers; // Currently a no-op; watchers stop on their own
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,9 @@ function AppContent() {
 
   // ── Plugin System ──
   const [activePluginPanel, setActivePluginPanel] = useState<string | null>(null);
+  const [activeBottomPanel, setActiveBottomPanel] = useState<string | null>(null);
+  const [bottomPanelHeight, setBottomPanelHeight] = useState(300);
+  const bottomPanelDragRef = useRef<{ startY: number; startHeight: number } | null>(null);
   const toastStore = useToastStore();
   const toastStoreRef = useRef(toastStore);
   toastStoreRef.current = toastStore;
@@ -133,11 +136,31 @@ function AppContent() {
         const s = stateRef.current;
         const id = s.activeSessionId;
         if (!id || !s.sessions[id]) return null;
-        return { id, name: s.sessions[id].label };
+        const sess = s.sessions[id];
+        return {
+          id,
+          name: sess.label,
+          phase: sess.phase ?? "unknown",
+          detected_agent: sess.detected_agent?.name ?? "unknown",
+          working_directory: sess.working_directory ?? "",
+          ai_provider: sess.ai_provider ?? undefined,
+          created_at: sess.created_at ? new Date(sess.created_at).getTime() : undefined,
+        };
       },
       onSessionsList: async () => {
         const s = stateRef.current;
-        return Object.entries(s.sessions).map(([id, sess]) => ({ id, name: sess.label }));
+        return Object.entries(s.sessions).map(([id, sess]) => ({
+          id,
+          name: sess.label,
+          phase: sess.phase ?? "unknown",
+          detected_agent: sess.detected_agent?.name ?? "unknown",
+          working_directory: sess.working_directory ?? "",
+          ai_provider: sess.ai_provider ?? undefined,
+          created_at: sess.created_at ? new Date(sess.created_at).getTime() : undefined,
+        }));
+      },
+      onSessionFocus: (sessionId: string) => {
+        setActive(sessionId);
       },
     });
     pluginRuntimeRef.current = runtime;
@@ -175,6 +198,7 @@ function AppContent() {
 
   // ── Emit plugin events: session created/closed ──
   const prevSessionIds = useRef(new Set<string>());
+  const prevSessionPhases = useRef(new Map<string, string>());
   useEffect(() => {
     const currentIds = new Set(Object.keys(state.sessions));
     for (const id of currentIds) {
@@ -187,8 +211,37 @@ function AppContent() {
         pluginRuntime.emitEvent("session.closed", id);
       }
     }
+    // Emit phase_changed events
+    for (const [id, sess] of Object.entries(state.sessions)) {
+      const prevPhase = prevSessionPhases.current.get(id);
+      if (prevPhase !== undefined && prevPhase !== sess.phase) {
+        pluginRuntime.emitEvent("session.phase_changed", {
+          sessionId: id,
+          previousPhase: prevPhase,
+          newPhase: sess.phase,
+        });
+      }
+      prevSessionPhases.current.set(id, sess.phase);
+    }
+    // Clean up phases for removed sessions
+    for (const id of prevSessionIds.current) {
+      if (!currentIds.has(id)) {
+        prevSessionPhases.current.delete(id);
+      }
+    }
     prevSessionIds.current = currentIds;
   }, [state.sessions, pluginRuntime]);
+
+  // ── Emit plugin events: session focus changed ──
+  const prevActiveSessionId = useRef<string | null>(state.activeSessionId);
+  useEffect(() => {
+    if (prevActiveSessionId.current !== state.activeSessionId) {
+      pluginRuntime.emitEvent("session.focus_changed", {
+        sessionId: state.activeSessionId,
+      });
+      prevActiveSessionId.current = state.activeSessionId;
+    }
+  }, [state.activeSessionId, pluginRuntime]);
 
   // When a built-in panel opens, close plugin panels
   useEffect(() => {
@@ -524,25 +577,31 @@ function AppContent() {
             tabs={[
               { id: "sessions", label: `Sessions (${fmt("{mod}B")})`, icon: SessionsIcon, badge: sessions.length || undefined },
               ...pluginPanels
-                .filter(p => p.side === "left" && !pluginSessionActions.some(a => a.panelId === p.id))
+                .filter(p => (p.side === "left" || p.side === "bottom") && !pluginSessionActions.some(a => a.panelId === p.id))
                 .map(p => ({
                   id: p.id,
                   label: p.name,
                   icon: <span dangerouslySetInnerHTML={{ __html: p.icon }} />,
                 })),
             ]}
-            activeTabId={activePluginPanel ?? (!ui.sessionListCollapsed ? "sessions" : null)}
+            activeTabId={activePluginPanel ?? activeBottomPanel ?? (!ui.sessionListCollapsed ? "sessions" : null)}
             onTabClick={(tabId) => {
               if (tabId === "sessions") {
                 setActivePluginPanel(null);
                 dispatch({ type: "TOGGLE_SIDEBAR" });
               } else {
-                // Plugin panel tab clicked
-                if (activePluginPanel === tabId) {
-                  setActivePluginPanel(null);
+                // Check if this is a bottom panel
+                const isBottom = pluginPanels.some(p => p.id === tabId && p.side === "bottom");
+                if (isBottom) {
+                  setActiveBottomPanel(activeBottomPanel === tabId ? null : tabId);
                 } else {
-                  setActivePluginPanel(tabId);
-                  dispatch({ type: "SET_LEFT_TAB", tab: "terminal" });
+                  // Left plugin panel
+                  if (activePluginPanel === tabId) {
+                    setActivePluginPanel(null);
+                  } else {
+                    setActivePluginPanel(tabId);
+                    dispatch({ type: "SET_LEFT_TAB", tab: "terminal" });
+                  }
                 }
               }
             }}
@@ -665,6 +724,48 @@ function AppContent() {
           />
         )}
       </div>
+
+      {/* Bottom plugin panels (e.g. Pixel Office) — independent of left sidebar */}
+      {activeBottomPanel && !ui.flowMode && (() => {
+        const panelMeta = pluginPanels.find(p => p.id === activeBottomPanel && p.side === "bottom");
+        if (!panelMeta) return null;
+        const PanelComponent = pluginRuntime.getPanelComponent(activeBottomPanel);
+        if (!PanelComponent) return null;
+        return (
+          <div style={{ height: bottomPanelHeight, minHeight: 120, maxHeight: "80vh", flexShrink: 0, overflow: "hidden", display: "flex", flexDirection: "column" }}>
+            {/* Drag handle */}
+            <div
+              style={{ height: 4, cursor: "row-resize", background: "var(--border)", flexShrink: 0 }}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                bottomPanelDragRef.current = { startY: e.clientY, startHeight: bottomPanelHeight };
+                const onMouseMove = (ev: MouseEvent) => {
+                  if (!bottomPanelDragRef.current) return;
+                  const delta = bottomPanelDragRef.current.startY - ev.clientY;
+                  const newHeight = Math.max(120, Math.min(window.innerHeight * 0.8, bottomPanelDragRef.current.startHeight + delta));
+                  setBottomPanelHeight(newHeight);
+                };
+                const onMouseUp = () => {
+                  bottomPanelDragRef.current = null;
+                  document.removeEventListener("mousemove", onMouseMove);
+                  document.removeEventListener("mouseup", onMouseUp);
+                  document.body.style.cursor = "";
+                  document.body.style.userSelect = "";
+                };
+                document.body.style.cursor = "row-resize";
+                document.body.style.userSelect = "none";
+                document.addEventListener("mousemove", onMouseMove);
+                document.addEventListener("mouseup", onMouseUp);
+              }}
+            />
+            <div style={{ flex: 1, overflow: "hidden" }}>
+              <PluginPanelHost pluginId={panelMeta.pluginId} panelId={activeBottomPanel} panelName={panelMeta.name}>
+                <PanelComponent pluginId={panelMeta.pluginId} panelId={activeBottomPanel} />
+              </PluginPanelHost>
+            </div>
+          </div>
+        );
+      })()}
 
       <StatusBar
         onOpenShortcuts={() => setShortcutsOpen(true)}

--- a/src/plugins/PluginAPI.ts
+++ b/src/plugins/PluginAPI.ts
@@ -1,5 +1,6 @@
-import type { Disposable, PluginSettingsSchema, HermesEvent } from "./types";
+import type { Disposable, PluginSettingsSchema, HermesEvent, SessionInfo, TranscriptEvent, AgentsAPI } from "./types";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
 
 // Props passed to plugin panel components via React context
@@ -51,9 +52,11 @@ export interface HermesPluginAPI {
 		openExternal(url: string): Promise<void>;
 	};
 	sessions: {
-		getActive(): Promise<{ id: string; name: string } | null>;
-		list(): Promise<{ id: string; name: string }[]>;
+		getActive(): Promise<SessionInfo | null>;
+		list(): Promise<SessionInfo[]>;
+		focus(sessionId: string): Promise<void>;
 	};
+	agents: AgentsAPI;
 	subscriptions: Disposable[];
 	/** @internal Used by PluginRuntime to forward UI settings changes to plugin listeners. */
 	_notifySettingChanged(key: string, value: string | number | boolean): void;
@@ -80,8 +83,9 @@ export interface PluginAPICallbacks {
 	onSettingChanged?: (pluginId: string, key: string, value: string | number | boolean) => void;
 	onEventSubscribe?: (event: HermesEvent, callback: (...args: unknown[]) => void) => Disposable;
 	onNotification?: (options: { title: string; body?: string }) => Promise<void>;
-	onSessionsGetActive?: () => Promise<{ id: string; name: string } | null>;
-	onSessionsList?: () => Promise<{ id: string; name: string }[]>;
+	onSessionsGetActive?: () => Promise<SessionInfo | null>;
+	onSessionsList?: () => Promise<SessionInfo[]>;
+	onSessionFocus?: (sessionId: string) => void;
 }
 
 export function createPluginAPI(
@@ -343,6 +347,38 @@ export function createPluginAPI(
 					return callbacks.onSessionsList();
 				}
 				return [];
+			},
+			async focus(sessionId: string) {
+				if (!permissions.has("sessions.read")) {
+					throw new PermissionDeniedError(pluginId, "sessions.read");
+				}
+				callbacks.onSessionFocus?.(sessionId);
+			},
+		},
+		agents: {
+			async watchTranscript(
+				sessionId: string,
+				callback: (event: TranscriptEvent) => void,
+			): Promise<Disposable> {
+				if (!permissions.has("sessions.read")) {
+					throw new PermissionDeniedError(pluginId, "sessions.read");
+				}
+				try {
+					const watcherId: string = await invoke("start_transcript_watcher", { sessionId });
+					const eventName = `transcript-event:${watcherId}`;
+					const unlisten = await listen<TranscriptEvent>(eventName, (event) => {
+						try { callback(event.payload); } catch { /* swallow plugin errors */ }
+					});
+					const dispose = () => {
+						unlisten();
+						invoke("stop_transcript_watcher", { watcherId }).catch(() => {});
+					};
+					subscriptions.push({ dispose });
+					return { dispose };
+				} catch (err) {
+					console.warn(`[Plugin:${pluginId}] Failed to watch transcript for session ${sessionId}:`, err);
+					return { dispose() {} };
+				}
 			},
 		},
 		subscriptions,

--- a/src/plugins/PluginPanelHost.tsx
+++ b/src/plugins/PluginPanelHost.tsx
@@ -53,7 +53,7 @@ export class PluginPanelHost extends Component<PluginPanelHostProps, PluginPanel
 			);
 		}
 		return (
-			<div className="plugin-panel-container" data-plugin-id={this.props.pluginId}>
+			<div className="plugin-panel-container" data-plugin-id={this.props.pluginId} style={{ width: "100%", height: "100%", position: "relative" }}>
 				{this.props.children}
 			</div>
 		);

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -41,7 +41,7 @@ export interface PluginCommandContribution {
 export interface PluginPanelContribution {
 	id: string;
 	name: string;
-	side: "left" | "right";
+	side: "left" | "right" | "bottom";
 	icon: string; // inline SVG string using currentColor
 }
 
@@ -134,9 +134,41 @@ export type HermesEvent =
 	| "theme.changed"
 	| "session.created"
 	| "session.closed"
+	| "session.phase_changed"
+	| "session.focus_changed"
 	| "window.focused"
 	| "window.blurred";
 
 export interface Disposable {
 	dispose(): void;
+}
+
+// ─── Plugin Session Info (rich session data for plugin API) ─────────
+
+export interface SessionInfo {
+	id: string;
+	name: string;
+	phase: string;
+	detected_agent: string;
+	working_directory: string;
+	ai_provider?: string;
+	branch?: string;
+	created_at?: number;
+}
+
+// ─── Transcript Watching (JSONL agent transcripts) ──────────────────
+
+export interface TranscriptEvent {
+	type: "tool_start" | "tool_end" | "text" | "thinking" | "turn_end";
+	tool_name?: string;
+	tool_input?: Record<string, unknown>;
+	timestamp: number;
+	session_id: string;
+}
+
+export interface AgentsAPI {
+	watchTranscript(
+		sessionId: string,
+		callback: (event: TranscriptEvent) => void,
+	): Promise<Disposable>;
 }


### PR DESCRIPTION
## Summary

- Extended `api.sessions.list()` and `getActive()` to return rich session data (phase, detected_agent, working_directory)
- Added `api.sessions.focus(sessionId)` to switch terminal focus from plugins
- Added `session.phase_changed` and `session.focus_changed` events
- Added `api.agents.watchTranscript()` for JSONL transcript watching (Claude Code)
- Added bottom panel support (`side: "bottom"`) with independent state from left sidebar
- Draggable resize handle for bottom panels
- `PluginPanelHost` properly sizes panels with `width/height/position`

## Rust backend

- New `transcript.rs` module: watches Claude Code JSONL files
- Polls for new lines every 500ms, parses tool events
- Emits Tauri events for real-time agent activity tracking

## Test plan

- [ ] Existing plugins still work unchanged
- [ ] Bottom panel renders below terminal area with resize handle
- [ ] `sessions.list()` returns phase and detected_agent
- [ ] `session.phase_changed` events fire correctly
- [ ] `cargo build` and `cargo clippy` pass clean