### PR TITLE
Move git branch indicator from status bar to project tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -602,14 +602,6 @@ function AppContent() {
             <>
               <span className="topbar-dot" style={{ background: activeSession.color }} />
               <span className="topbar-session-name">{activeSession.label}</span>
-              {activeGitSummary.branch && (
-                <span className="topbar-branch">
-                  <svg viewBox="0 0 16 16" fill="currentColor" width="10" height="10" aria-hidden="true">
-                    <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Z" />
-                  </svg>
-                  {activeGitSummary.branch}
-                </span>
-              )}
             </>
           ) : (
             <span className="topbar-title">HERMES-IDE</span>

--- a/src/components/ScopeBar.tsx
+++ b/src/components/ScopeBar.tsx
@@ -4,6 +4,7 @@ import { useSessionProjects, Project } from "../hooks/useSessionProjects";
 import { useSession } from "../state/SessionContext";
 import { nudgeProjectContext } from "../api/projects";
 import { ProjectPicker } from "./ProjectPicker";
+import { useSessionGitSummary } from "../hooks/useSessionGitSummary";
 
 const LANGUAGE_COLORS: Record<string, string> = {
   "JavaScript/TypeScript": "#f1e05a",
@@ -33,6 +34,7 @@ export function ScopeBar({ sessionId }: ScopeBarProps) {
   const activeSession = state.sessions[sessionId];
   const { projects, detach } = useSessionProjects(sessionId);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const { allBranches } = useSessionGitSummary(sessionId, true, activeSession?.working_directory);
 
   if (projects.length === 0 && !pickerOpen) {
     return (
@@ -54,26 +56,37 @@ export function ScopeBar({ sessionId }: ScopeBarProps) {
   return (
     <>
       <div className="scope-bar">
-        {projects.map((project) => (
-          <div key={project.id} className="scope-pill" title={project.path}>
-            <span
-              className="scope-pill-dot"
-              style={{ background: getLangColor(project) }}
-            />
-            <span className="scope-pill-name">{project.name}</span>
-            <span className="scope-pill-status" data-status={project.scan_status}>
-              {project.scan_status === "pending" ? "..." : ""}
-            </span>
-            <button
-              className="scope-pill-close"
-              onClick={() => detach(project.id).then(() => nudgeProjectContext(sessionId).catch(console.warn))}
-              title="Remove project"
-              aria-label="Remove project"
-            >
-              &times;
-            </button>
-          </div>
-        ))}
+        {projects.map((project) => {
+          const branchInfo = allBranches.find(b => b.projectName === project.name);
+          return (
+            <div key={project.id} className="scope-pill" title={project.path}>
+              <span
+                className="scope-pill-dot"
+                style={{ background: getLangColor(project) }}
+              />
+              <span className="scope-pill-name">{project.name}</span>
+              {branchInfo && (
+                <span className="scope-pill-branch" title={branchInfo.branch}>
+                  <svg viewBox="0 0 16 16" fill="currentColor" width="10" height="10" aria-hidden="true">
+                    <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Z" />
+                  </svg>
+                  {branchInfo.branch}
+                </span>
+              )}
+              <span className="scope-pill-status" data-status={project.scan_status}>
+                {project.scan_status === "pending" ? "..." : ""}
+              </span>
+              <button
+                className="scope-pill-close"
+                onClick={() => detach(project.id).then(() => nudgeProjectContext(sessionId).catch(console.warn))}
+                title="Remove project"
+                aria-label="Remove project"
+              >
+                &times;
+              </button>
+            </div>
+          );
+        })}
         {activeSession?.ai_provider && (
           <span className="scope-bar-provider">{activeSession.ai_provider}</span>
         )}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -7,8 +7,6 @@ import { PLATFORM, OS_VERSION } from "../utils/platform";
 import { useContextMenu, menuItem } from "../hooks/useContextMenu";
 import { fmt } from "../utils/platform";
 import { THEME_OPTIONS, applyTheme } from "../utils/themeManager";
-import { useSessionGitSummary } from "../hooks/useSessionGitSummary";
-import { isHermesWorktreePath } from "../utils/worktree";
 
 function formatTokens(n: number): string {
   if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
@@ -43,8 +41,6 @@ export function StatusBar({ onOpenShortcuts, updateAvailable, updateVersion, upd
   const { dispatch } = useSession();
   const mode = useExecutionMode(active?.id ?? null);
   const [, setTick] = useState(0);
-  const { branch: activeBranch, allBranches } = useSessionGitSummary(active?.id ?? null, !!active, active?.working_directory);
-  const isLinkedWorktree = active?.working_directory ? isHermesWorktreePath(active.working_directory) : false;
 
   const handleStatusBarAction = useCallback((actionId: string) => {
     switch (actionId) {
@@ -114,26 +110,6 @@ export function StatusBar({ onOpenShortcuts, updateAvailable, updateVersion, upd
               {active.detected_agent.model && <span className="status-bar-model"> ({active.detected_agent.model})</span>}
               {active.phase === "busy" && <span className="status-bar-busy">working</span>}
               {active.phase === "needs_input" && <span className="status-bar-needs-input">needs input</span>}
-            </span>
-          </>
-        )}
-        {activeBranch && (
-          <>
-            <span className="status-bar-divider" />
-            <span className="status-bar-branch" title={allBranches.length > 1
-              ? allBranches.map((b) => `${b.projectName}: ${b.branch}`).join('\n')
-              : isLinkedWorktree ? `${activeBranch} (linked worktree)\n${active?.working_directory}` : `${activeBranch} (main checkout)`}>
-              <svg viewBox="0 0 16 16" fill="currentColor" width="12" height="12" aria-hidden="true">
-                <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Z" />
-              </svg>
-              {allBranches.length > 1
-                ? allBranches.map((b) => b.branch).join(' / ')
-                : activeBranch}
-              {isLinkedWorktree && (
-                <svg className="status-bar-branch-link" viewBox="0 0 16 16" fill="currentColor" width="10" height="10" aria-hidden="true">
-                  <path d="M4.75 3.5a3.25 3.25 0 0 0 0 6.5h1.5a.75.75 0 0 1 0 1.5h-1.5a4.75 4.75 0 0 1 0-9.5h1.5a.75.75 0 0 1 0 1.5ZM11.25 3.5a4.75 4.75 0 0 1 0 9.5h-1.5a.75.75 0 0 1 0-1.5h1.5a3.25 3.25 0 0 0 0-6.5h-1.5a.75.75 0 0 1 0-1.5Zm-6 4.25a.75.75 0 0 0 0 1.5h5.5a.75.75 0 0 0 0-1.5Z" />
-                </svg>
-              )}
             </span>
           </>
         )}

--- a/src/styles/components/ScopeBar.css
+++ b/src/styles/components/ScopeBar.css
@@ -46,6 +46,23 @@
   font-weight: 500;
 }
 
+.scope-pill-branch {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: var(--text-xs);
+  color: var(--text-3);
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scope-pill-branch svg {
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
 .scope-pill-status {
   font-size: var(--text-xs);
   color: var(--text-3);


### PR DESCRIPTION
## Summary
- Shows the git branch next to each project name in the ScopeBar pills (e.g. `h-ide ⑂ main`)
- Removes the branch indicator from the bottom status bar
- Removes the branch from the top bar title area
- Each project now shows its own branch independently, which is clearer for multi-project sessions

## Test plan
- [ ] Verify each project pill in the ScopeBar shows the correct branch name
- [ ] Verify the branch is no longer shown in the bottom status bar
- [ ] Verify the branch is no longer shown in the top bar next to the session name
- [ ] Test with multiple projects attached — each should show its own branch
- [ ] Test with a project that is not a git repo — no branch should appear

Closes #160