### PR TITLE
Show branch below project name and adopt Lucide icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "6.0.0",
+        "lucide-react": "^0.577.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
@@ -1771,6 +1772,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "6.0.0",
+    "lucide-react": "^0.577.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/src/components/ActivityBar.tsx
+++ b/src/components/ActivityBar.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Blocks, Settings } from "lucide-react";
 import "../styles/components/ActivityBar.css";
 
 export interface ActivityBarTab {
@@ -132,17 +133,6 @@ export const PlusIcon = (
   </svg>
 );
 
-export const PluginsIcon = (
-  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-    <rect x="3" y="7" width="12" height="9" rx="2" />
-    <path d="M6.5 7V5a1.5 1.5 0 1 1 1.5 1.5" />
-    <path d="M11.5 7V5a1.5 1.5 0 1 0-1.5 1.5" />
-  </svg>
-);
+export const PluginsIcon = <Blocks size={18} strokeWidth={1.5} />;
 
-export const SettingsIcon = (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
-    <circle cx="12" cy="12" r="3" />
-  </svg>
-);
+export const SettingsIcon = <Settings size={18} strokeWidth={1.5} />;

--- a/src/components/ScopeBar.tsx
+++ b/src/components/ScopeBar.tsx
@@ -64,15 +64,17 @@ export function ScopeBar({ sessionId }: ScopeBarProps) {
                 className="scope-pill-dot"
                 style={{ background: getLangColor(project) }}
               />
-              <span className="scope-pill-name">{project.name}</span>
-              {branchInfo && (
-                <span className="scope-pill-branch" title={branchInfo.branch}>
-                  <svg viewBox="0 0 16 16" fill="currentColor" width="10" height="10" aria-hidden="true">
-                    <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Z" />
-                  </svg>
-                  {branchInfo.branch}
-                </span>
-              )}
+              <span className="scope-pill-text">
+                <span className="scope-pill-name">{project.name}</span>
+                {branchInfo && (
+                  <span className="scope-pill-branch" title={branchInfo.branch}>
+                    <svg viewBox="0 0 16 16" fill="currentColor" width="9" height="9" aria-hidden="true">
+                      <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Z" />
+                    </svg>
+                    {branchInfo.branch}
+                  </span>
+                )}
+              </span>
               <span className="scope-pill-status" data-status={project.scan_status}>
                 {project.scan_status === "pending" ? "..." : ""}
               </span>

--- a/src/styles/components/ScopeBar.css
+++ b/src/styles/components/ScopeBar.css
@@ -25,7 +25,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-1);
-  padding: 1px 8px;
+  padding: 3px 8px;
   background: var(--bg-2);
   border: 1px solid var(--border);
   border-radius: var(--radius-pill);
@@ -40,6 +40,13 @@
   height: 6px;
   border-radius: 50%;
   flex-shrink: 0;
+  align-self: center;
+}
+
+.scope-pill-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
 }
 
 .scope-pill-name {
@@ -50,9 +57,10 @@
   display: inline-flex;
   align-items: center;
   gap: 2px;
-  font-size: var(--text-xs);
-  color: var(--text-3);
-  max-width: 120px;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--text-2);
+  max-width: 140px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -60,7 +68,6 @@
 
 .scope-pill-branch svg {
   flex-shrink: 0;
-  opacity: 0.7;
 }
 
 .scope-pill-status {


### PR DESCRIPTION
## Summary
- Branch name now appears on its own line below the project name in ScopeBar pills, making it more visible
- Replaced hand-drawn SVG icons for Plugins and Settings with Lucide icons (`Blocks` and `Settings`)
- Added `lucide-react` as a dependency for consistent, well-designed icons going forward

## Test plan
- [ ] Verify branch appears on a separate line below each project name in the scope bar
- [ ] Verify the plugins icon (Blocks) looks correct in the sidebar
- [ ] Verify the settings icon (gear) still looks correct in the sidebar
- [ ] Test with long branch names — should truncate with ellipsis