### PR TITLE
Add persistent resizing for settings and new session dialogs

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -2091,6 +2091,12 @@ const VALID_SETTING_KEYS: &[&str] = &[
     "window_height",
     "window_x",
     "window_y",
+    // Settings panel geometry
+    "settings_panel_width",
+    "settings_panel_height",
+    // New session creator modal geometry
+    "session_creator_panel_width",
+    "session_creator_panel_height",
     // Appearance
     "theme",
     "ui_scale",

--- a/src/components/SessionCreator.tsx
+++ b/src/components/SessionCreator.tsx
@@ -88,6 +88,23 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
   const aiStepRef = useRef<HTMLDivElement>(null);
   const labelRef = useRef<HTMLInputElement>(null);
 
+  // Live New Session box size state (persisted separately from the window size)
+  const [panelWidth, setPanelWidth] = useState<number>(480);
+  const [panelHeight, setPanelHeight] = useState<number>(620);
+  const latestPanelWidthRef = useRef(panelWidth);
+  const latestPanelHeightRef = useRef(panelHeight);
+  const resizingRef = useRef(false);
+  const panelPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resizeResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resizeListenersRef = useRef<{
+    onMove: (event: MouseEvent) => void;
+    onUp: () => void;
+  } | null>(null);
+  const resizeBodyStylesRef = useRef<{ cursor: string; userSelect: string }>({
+    cursor: "",
+    userSelect: "",
+  });
+
   // Project (group) assignment state
   const [selectedGroup, setSelectedGroup] = useState<string | null>(defaultGroup ?? null);
   const [newProjectName, setNewProjectName] = useState("");
@@ -238,6 +255,142 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
       })
       .catch((err) => console.warn("[SessionCreator] Failed to load sessions:", err));
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    latestPanelWidthRef.current = panelWidth;
+  }, [panelWidth]);
+
+  useEffect(() => {
+    latestPanelHeightRef.current = panelHeight;
+  }, [panelHeight]);
+
+  const detachResizeSideEffects = useCallback(() => {
+    if (resizeListenersRef.current) {
+      document.removeEventListener("mousemove", resizeListenersRef.current.onMove);
+      document.removeEventListener("mouseup", resizeListenersRef.current.onUp);
+      resizeListenersRef.current = null;
+    }
+
+    document.body.style.cursor = resizeBodyStylesRef.current.cursor;
+    document.body.style.userSelect = resizeBodyStylesRef.current.userSelect;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (panelPersistTimerRef.current) clearTimeout(panelPersistTimerRef.current);
+      if (resizeResetTimerRef.current) clearTimeout(resizeResetTimerRef.current);
+      detachResizeSideEffects();
+      resizingRef.current = false;
+    };
+  }, [detachResizeSideEffects]);
+
+  useEffect(() => {
+    // Restore persisted panel size (if available)
+    const read = async () => {
+      try {
+        const rawW = parseInt(await getSetting("session_creator_panel_width"), 10);
+        const rawH = parseInt(await getSetting("session_creator_panel_height"), 10);
+
+        const minW = 380;
+        const minH = 360;
+        const maxW = Math.max(minW, Math.floor(window.innerWidth * 0.92));
+        const maxH = Math.max(minH, Math.floor(window.innerHeight * 0.78));
+
+        if (!Number.isNaN(rawW) && rawW >= minW) setPanelWidth(Math.min(rawW, maxW));
+        if (!Number.isNaN(rawH) && rawH >= minH) setPanelHeight(Math.min(rawH, maxH));
+      } catch {
+        // ignore: settings may not exist yet
+      }
+    };
+    read();
+  }, []);
+
+  const persistPanelSize = useCallback((w: number, h: number) => {
+    if (panelPersistTimerRef.current) clearTimeout(panelPersistTimerRef.current);
+    panelPersistTimerRef.current = setTimeout(() => {
+      setSetting("session_creator_panel_width", String(Math.round(w))).catch(console.error);
+      setSetting("session_creator_panel_height", String(Math.round(h))).catch(console.error);
+    }, 120);
+  }, []);
+
+  const onResizeWidthStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    resizingRef.current = true;
+
+    const startX = e.clientX;
+    const startW = latestPanelWidthRef.current;
+    const minW = 380;
+    const maxW = Math.max(minW, Math.floor(window.innerWidth * 0.92));
+
+    detachResizeSideEffects();
+    resizeBodyStylesRef.current = {
+      cursor: document.body.style.cursor,
+      userSelect: document.body.style.userSelect,
+    };
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const onMove = (ev: MouseEvent) => {
+      const delta = ev.clientX - startX;
+      const nextW = Math.max(minW, Math.min(maxW, startW + delta));
+      setPanelWidth(nextW);
+    };
+
+    const onUp = () => {
+      const w = latestPanelWidthRef.current;
+      const h = latestPanelHeightRef.current;
+      persistPanelSize(w, h);
+      detachResizeSideEffects();
+
+      // Delay clearing so an "outside click" caused by mouseup doesn't close the overlay.
+      if (resizeResetTimerRef.current) clearTimeout(resizeResetTimerRef.current);
+      resizeResetTimerRef.current = setTimeout(() => { resizingRef.current = false; }, 80);
+    };
+
+    resizeListenersRef.current = { onMove, onUp };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  }, [detachResizeSideEffects, persistPanelSize]);
+
+  const onResizeHeightStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    resizingRef.current = true;
+
+    const startY = e.clientY;
+    const startH = latestPanelHeightRef.current;
+    const minH = 360;
+    const maxH = Math.max(minH, Math.floor(window.innerHeight * 0.78));
+
+    detachResizeSideEffects();
+    resizeBodyStylesRef.current = {
+      cursor: document.body.style.cursor,
+      userSelect: document.body.style.userSelect,
+    };
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
+
+    const onMove = (ev: MouseEvent) => {
+      const delta = ev.clientY - startY;
+      const nextH = Math.max(minH, Math.min(maxH, startH + delta));
+      setPanelHeight(nextH);
+    };
+
+    const onUp = () => {
+      const w = latestPanelWidthRef.current;
+      const h = latestPanelHeightRef.current;
+      persistPanelSize(w, h);
+      detachResizeSideEffects();
+
+      if (resizeResetTimerRef.current) clearTimeout(resizeResetTimerRef.current);
+      resizeResetTimerRef.current = setTimeout(() => { resizingRef.current = false; }, 80);
+    };
+
+    resizeListenersRef.current = { onMove, onUp };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  }, [detachResizeSideEffects, persistPanelSize]);
 
   // Discover tmux sessions when entering the tmux step.
   // If tmux is not installed, skip straight to confirm.
@@ -509,12 +662,20 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
   };
 
   return (
-    <div className="command-palette-overlay" onClick={onClose} role="dialog" aria-modal="true">
+    <div
+      className="command-palette-overlay"
+      onClick={() => { if (resizingRef.current) return; onClose(); }}
+      role="dialog"
+      aria-modal="true"
+    >
       <div
         className="session-creator"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={handleKeyDown}
+        style={{ width: panelWidth, height: panelHeight }}
       >
+        <div className="session-creator-resize-handle" onMouseDown={onResizeWidthStart} />
+        <div className="session-creator-resize-handle-bottom" onMouseDown={onResizeHeightStart} />
         {/* Header */}
         <div className="session-creator-header">
           <span className="session-creator-title">New Session</span>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -39,6 +39,22 @@ export function Settings({ onClose, initialTab, pluginRuntime, onConfirmPluginUp
   // Live window size state (separate from DB settings)
   const [winWidth, setWinWidth] = useState("");
   const [winHeight, setWinHeight] = useState("");
+  // Live settings panel size state (persisted separately from the window size)
+  const [panelWidth, setPanelWidth] = useState<number>(560);
+  const [panelHeight, setPanelHeight] = useState<number>(520);
+  const resizingRef = useRef(false);
+  const panelPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resizeResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestPanelWidthRef = useRef(panelWidth);
+  const latestPanelHeightRef = useRef(panelHeight);
+  const resizeListenersRef = useRef<{
+    onMove: (event: MouseEvent) => void;
+    onUp: () => void;
+  } | null>(null);
+  const resizeBodyStylesRef = useRef<{ cursor: string; userSelect: string }>({
+    cursor: "",
+    userSelect: "",
+  });
   const resizeUnlisten = useRef<(() => void) | null>(null);
   const programmaticResize = useRef(false);
   const applyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -56,7 +72,25 @@ export function Settings({ onClose, initialTab, pluginRuntime, onConfirmPluginUp
 
   useEffect(() => {
     getSettings()
-      .then((s) => setSettings(s))
+      .then((s) => {
+        setSettings(s);
+
+        const parsedW = parseInt(s.settings_panel_width || "", 10);
+        const parsedH = parseInt(s.settings_panel_height || "", 10);
+
+        // Keep within reasonable bounds even if settings were edited externally.
+        const minW = 420;
+        const minH = 360;
+        const maxW = Math.max(minW, Math.floor((typeof window !== "undefined" ? window.innerWidth : 1440) * 0.9));
+        const maxH = Math.max(minH, Math.floor((typeof window !== "undefined" ? window.innerHeight : 900) * 0.7));
+
+        if (!Number.isNaN(parsedW) && parsedW >= minW) {
+          setPanelWidth(Math.min(parsedW, maxW));
+        }
+        if (!Number.isNaN(parsedH) && parsedH >= minH) {
+          setPanelHeight(Math.min(parsedH, maxH));
+        }
+      })
       .catch(console.error);
 
     invoke<{ name: string; path: string }[]>("get_available_shells")
@@ -86,6 +120,122 @@ export function Settings({ onClose, initialTab, pluginRuntime, onConfirmPluginUp
       if (applyTimer.current) clearTimeout(applyTimer.current);
     };
   }, []);
+
+  useEffect(() => {
+    latestPanelWidthRef.current = panelWidth;
+  }, [panelWidth]);
+
+  useEffect(() => {
+    latestPanelHeightRef.current = panelHeight;
+  }, [panelHeight]);
+
+  const detachResizeSideEffects = useCallback(() => {
+    if (resizeListenersRef.current) {
+      document.removeEventListener("mousemove", resizeListenersRef.current.onMove);
+      document.removeEventListener("mouseup", resizeListenersRef.current.onUp);
+      resizeListenersRef.current = null;
+    }
+
+    document.body.style.cursor = resizeBodyStylesRef.current.cursor;
+    document.body.style.userSelect = resizeBodyStylesRef.current.userSelect;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (panelPersistTimerRef.current) clearTimeout(panelPersistTimerRef.current);
+      if (resizeResetTimerRef.current) clearTimeout(resizeResetTimerRef.current);
+      detachResizeSideEffects();
+      resizingRef.current = false;
+    };
+  }, [detachResizeSideEffects]);
+
+  const persistPanelSize = useCallback((w: number, h: number) => {
+    if (panelPersistTimerRef.current) clearTimeout(panelPersistTimerRef.current);
+    panelPersistTimerRef.current = setTimeout(() => {
+      setSetting("settings_panel_width", String(Math.round(w))).catch(console.error);
+      setSetting("settings_panel_height", String(Math.round(h))).catch(console.error);
+    }, 120);
+  }, []);
+
+  const onResizeWidthStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    resizingRef.current = true;
+    const startX = e.clientX;
+    const startW = latestPanelWidthRef.current;
+    const minW = 420;
+    const maxW = Math.max(minW, Math.floor(window.innerWidth * 0.9));
+
+    detachResizeSideEffects();
+    resizeBodyStylesRef.current = {
+      cursor: document.body.style.cursor,
+      userSelect: document.body.style.userSelect,
+    };
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const onMove = (ev: MouseEvent) => {
+      const delta = ev.clientX - startX;
+      const nextW = Math.max(minW, Math.min(maxW, startW + delta));
+      setPanelWidth(nextW);
+    };
+
+    const onUp = () => {
+      const w = latestPanelWidthRef.current;
+      const h = latestPanelHeightRef.current;
+      persistPanelSize(w, h);
+      detachResizeSideEffects();
+
+      // Delay clearing so that an "outside click" caused by the mouseup
+      // doesn't close the overlay right after the resize ends.
+      if (resizeResetTimerRef.current) clearTimeout(resizeResetTimerRef.current);
+      resizeResetTimerRef.current = setTimeout(() => { resizingRef.current = false; }, 80);
+    };
+
+    resizeListenersRef.current = { onMove, onUp };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  }, [detachResizeSideEffects, persistPanelSize]);
+
+  const onResizeHeightStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    resizingRef.current = true;
+    const startY = e.clientY;
+    const startH = latestPanelHeightRef.current;
+    const minH = 360;
+    const maxH = Math.max(minH, Math.floor(window.innerHeight * 0.7));
+
+    detachResizeSideEffects();
+    resizeBodyStylesRef.current = {
+      cursor: document.body.style.cursor,
+      userSelect: document.body.style.userSelect,
+    };
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
+
+    const onMove = (ev: MouseEvent) => {
+      const delta = ev.clientY - startY;
+      const nextH = Math.max(minH, Math.min(maxH, startH + delta));
+      setPanelHeight(nextH);
+    };
+
+    const onUp = () => {
+      const w = latestPanelWidthRef.current;
+      const h = latestPanelHeightRef.current;
+      persistPanelSize(w, h);
+      detachResizeSideEffects();
+
+      // Delay clearing so that an "outside click" caused by the mouseup
+      // doesn't close the overlay right after the resize ends.
+      if (resizeResetTimerRef.current) clearTimeout(resizeResetTimerRef.current);
+      resizeResetTimerRef.current = setTimeout(() => { resizingRef.current = false; }, 80);
+    };
+
+    resizeListenersRef.current = { onMove, onUp };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  }, [detachResizeSideEffects, persistPanelSize]);
 
   const AUTONOMOUS_KEYS: Record<string, string> = {
     auto_command_min_frequency: "commandMinFrequency",
@@ -174,8 +324,16 @@ export function Settings({ onClose, initialTab, pluginRuntime, onConfirmPluginUp
   ];
 
   return (
-    <div className="settings-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-label="Settings">
-      <div className="settings-panel" onClick={(e) => e.stopPropagation()}>
+    <div
+      className="settings-overlay"
+      onClick={() => { if (resizingRef.current) return; onClose(); }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Settings"
+    >
+      <div className="settings-panel" onClick={(e) => e.stopPropagation()} style={{ width: panelWidth, height: panelHeight }}>
+        <div className="settings-resize-handle" onMouseDown={onResizeWidthStart} />
+        <div className="settings-resize-handle-bottom" onMouseDown={onResizeHeightStart} />
         <div className="settings-header">
           <span className="settings-title">Settings</span>
           <button className="close-btn settings-close" onClick={onClose} aria-label="Close">&times;</button>

--- a/src/styles/components/SessionCreator.css
+++ b/src/styles/components/SessionCreator.css
@@ -9,6 +9,38 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  position: relative;
+}
+
+/* ─── Session Creator Resize Handles ───────────────────────────── */
+.session-creator-resize-handle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 2;
+  background: transparent;
+}
+
+.session-creator-resize-handle:hover {
+  background: var(--accent-dim);
+}
+
+.session-creator-resize-handle-bottom {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 6px;
+  cursor: row-resize;
+  z-index: 2;
+  background: transparent;
+}
+
+.session-creator-resize-handle-bottom:hover {
+  background: var(--accent-dim);
 }
 
 .session-creator-header {

--- a/src/styles/components/Settings.css
+++ b/src/styles/components/Settings.css
@@ -17,11 +17,43 @@
   border-radius: var(--radius-lg);
   width: 560px;
   max-height: 70vh;
+  position: relative;
   display: flex;
   flex-direction: column;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   overflow: hidden;
   animation: paletteIn 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* ─── Settings Panel Resize Handles ───────────────────────────────── */
+.settings-resize-handle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 2;
+  background: transparent;
+}
+
+.settings-resize-handle:hover {
+  background: var(--accent-dim);
+}
+
+.settings-resize-handle-bottom {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 6px;
+  cursor: row-resize;
+  z-index: 2;
+  background: transparent;
+}
+
+.settings-resize-handle-bottom:hover {
+  background: var(--accent-dim);
 }
 
 .settings-header {


### PR DESCRIPTION
Let users resize the Settings and New Session dialogs and keep their preferred size between openings. Also clean up resize listeners and cursor state safely if a dialog closes mid-drag.

## What does this PR do?

This PR lets users resize the Settings and New Session dialogs by dragging their edges. The chosen width and height are persisted and restored the next time each dialog is opened. It also safely cleans up resize listeners and cursor/body state if a dialog is closed mid-drag.

## Related Issue

Closes #103

Closes #

## Type of Change

- [ ] Bug fix
- [ ] Performance improvement
- [X] New feature (approved in discussion)
- [ ] Documentation
- [ ] Refactoring (no behavior change)

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [X] `npx tsc --noEmit` passes
- [ ] `npm run test` passes
- [ ] I have signed the [CLA](../CLA.md)
