### PR TITLE
Add plugin file handler API and fix shell.exec serde

### DIFF
--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -371,6 +371,7 @@ pub async fn plugin_exec_command(
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PluginExecResult {
     pub stdout: String,
     pub stderr: String,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -727,12 +727,19 @@ function AppContent() {
           <div className="terminal-and-timeline">
             {ui.filePreview && state.activeSessionId ? (
               <div className="file-preview-main-container">
-                <FilePreviewPanel
-                  sessionId={state.activeSessionId}
-                  realmId={ui.filePreview.realmId}
-                  filePath={ui.filePreview.filePath}
-                  onBack={() => dispatch({ type: "CLOSE_FILE_PREVIEW" })}
-                />
+                {(() => {
+                  const handler = pluginRuntime?.getFileHandler(ui.filePreview.filePath);
+                  return (
+                    <FilePreviewPanel
+                      sessionId={state.activeSessionId}
+                      realmId={ui.filePreview.realmId}
+                      filePath={ui.filePreview.filePath}
+                      onBack={() => dispatch({ type: "CLOSE_FILE_PREVIEW" })}
+                      fileHandler={handler?.component}
+                      fileHandlerPluginId={handler?.pluginId}
+                    />
+                  );
+                })()}
               </div>
             ) : (
             <div className="terminal-container">

--- a/src/components/FilePreviewPanel.tsx
+++ b/src/components/FilePreviewPanel.tsx
@@ -6,11 +6,15 @@ import { getSetting } from "../api/settings";
 import { useSession } from "../state/SessionContext";
 import type { FileContent } from "../types/git";
 
+import type { FileHandlerProps } from "../plugins/types";
+
 interface FilePreviewPanelProps {
   sessionId: string;
   realmId: string;
   filePath: string;
   onBack: () => void;
+  fileHandler?: React.ComponentType<FileHandlerProps>;
+  fileHandlerPluginId?: string;
 }
 
 // ─── Lightweight syntax highlighter ─────────────────────────────────
@@ -152,7 +156,7 @@ function utf8ToBase64(str: string): string {
 
 const MAX_DISPLAY_SIZE = 1_048_576;
 
-export function FilePreviewPanel({ sessionId, realmId, filePath, onBack }: FilePreviewPanelProps) {
+export function FilePreviewPanel({ sessionId, realmId, filePath, onBack, fileHandler: FileHandler, fileHandlerPluginId }: FilePreviewPanelProps) {
   const { state } = useSession();
   const isSSH = realmId === "__ssh__";
   const sshInfo = isSSH ? state.sessions[sessionId]?.ssh_info : null;
@@ -255,6 +259,19 @@ export function FilePreviewPanel({ sessionId, realmId, filePath, onBack }: FileP
   }
 
   if (!file) return null;
+
+  // Delegate to plugin file handler if registered
+  if (FileHandler && file.content != null && fileHandlerPluginId) {
+    return (
+      <FileHandler
+        pluginId={fileHandlerPluginId}
+        filePath={filePath}
+        content={file.content}
+        sessionId={sessionId}
+        onBack={onBack}
+      />
+    );
+  }
 
   const isTooLarge = file.size > MAX_DISPLAY_SIZE && !file.content;
 

--- a/src/plugins/PluginAPI.ts
+++ b/src/plugins/PluginAPI.ts
@@ -1,4 +1,4 @@
-import type { Disposable, PluginSettingsSchema, HermesEvent, SessionInfo, TranscriptEvent, AgentsAPI } from "./types";
+import type { Disposable, PluginSettingsSchema, HermesEvent, SessionInfo, TranscriptEvent, AgentsAPI, FileHandlerProps } from "./types";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
@@ -19,6 +19,7 @@ export interface HermesPluginAPI {
 		showToast(message: string, options?: { type?: "info" | "success" | "warning" | "error"; duration?: number }): void;
 		updateStatusBarItem(itemId: string, update: { text?: string; tooltip?: string; visible?: boolean }): void;
 		updateSessionActionBadge(actionId: string, badge: { text?: string; count?: number }): void;
+		registerFileHandler(extensions: string[], component: React.ComponentType<FileHandlerProps>): Disposable;
 	};
 	commands: {
 		register(commandId: string, handler: () => void | Promise<void>): Disposable;
@@ -87,6 +88,7 @@ export interface PluginAPICallbacks {
 	onSessionsGetActive?: () => Promise<SessionInfo | null>;
 	onSessionsList?: () => Promise<SessionInfo[]>;
 	onSessionFocus?: (sessionId: string) => void;
+	onFileHandlerRegistered?: () => void;
 }
 
 export function createPluginAPI(
@@ -96,6 +98,7 @@ export function createPluginAPI(
 	callbacks: PluginAPICallbacks,
 	commandHandlers: Map<string, () => void | Promise<void>>,
 	panelComponents: Map<string, React.ComponentType<PluginPanelProps>>,
+	fileHandlers?: Map<string, { pluginId: string; component: React.ComponentType<FileHandlerProps> }>,
 ): HermesPluginAPI {
 	const subscriptions: Disposable[] = [];
 	const schema = settingsSchema ?? {};
@@ -139,6 +142,21 @@ export function createPluginAPI(
 			},
 			updateSessionActionBadge(actionId: string, badge: { text?: string; count?: number }) {
 				callbacks.onSessionActionBadgeUpdate?.(actionId, badge);
+			},
+			registerFileHandler(extensions: string[], component: React.ComponentType<FileHandlerProps>): Disposable {
+				if (!fileHandlers) return { dispose() {} };
+				const normalized = extensions.map(e => e.toLowerCase().replace(/^\./, ""));
+				for (const ext of normalized) {
+					fileHandlers.set(ext, { pluginId, component });
+				}
+				callbacks.onFileHandlerRegistered?.();
+				return {
+					dispose() {
+						for (const ext of normalized) {
+							fileHandlers?.delete(ext);
+						}
+					},
+				};
 			},
 		},
 		commands: {

--- a/src/plugins/PluginRuntime.ts
+++ b/src/plugins/PluginRuntime.ts
@@ -1,4 +1,4 @@
-import type { PluginManifest, PluginCommandContribution, PluginPanelContribution, PluginStatusBarItem, PluginSessionActionContribution, HermesEvent } from "./types";
+import type { PluginManifest, PluginCommandContribution, PluginPanelContribution, PluginStatusBarItem, PluginSessionActionContribution, HermesEvent, FileHandlerProps } from "./types";
 import { createPluginAPI, type HermesPluginAPI, type PluginPanelProps, type PluginAPICallbacks } from "./PluginAPI";
 import { invoke } from "@tauri-apps/api/core";
 
@@ -29,6 +29,7 @@ export class PluginRuntime {
 	private plugins = new Map<string, PluginEntry>();
 	private commandHandlers = new Map<string, () => void | Promise<void>>();
 	private panelComponents = new Map<string, React.ComponentType<PluginPanelProps>>();
+	private fileHandlers = new Map<string, { pluginId: string; component: React.ComponentType<FileHandlerProps> }>();
 	private statusBarOverrides = new Map<string, { text?: string; tooltip?: string; visible?: boolean }>();
 	private sessionActionBadges = new Map<string, { text?: string; count?: number }>();
 	private changeListeners = new Set<() => void>();
@@ -91,6 +92,9 @@ export class PluginRuntime {
 				onEventSubscribe: (event: HermesEvent, callback: (...args: unknown[]) => void) => {
 					return this.subscribeEvent(event, callback);
 				},
+				onFileHandlerRegistered: () => {
+					this.notify();
+				},
 			};
 			const api = createPluginAPI(
 				pluginId,
@@ -99,6 +103,7 @@ export class PluginRuntime {
 				fullCallbacks,
 				this.commandHandlers,
 				this.panelComponents,
+				this.fileHandlers,
 			);
 			entry.api = api;
 			await entry.module.activate(api);
@@ -255,6 +260,12 @@ export class PluginRuntime {
 
 	getPanelComponent(panelId: string): React.ComponentType<PluginPanelProps> | undefined {
 		return this.panelComponents.get(panelId);
+	}
+
+	getFileHandler(filePath: string): { pluginId: string; component: React.ComponentType<FileHandlerProps> } | undefined {
+		const ext = filePath.split(".").pop()?.toLowerCase();
+		if (!ext) return undefined;
+		return this.fileHandlers.get(ext);
 	}
 
 	getAllStatusBarItems(): RuntimeStatusBarItem[] {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -45,6 +45,14 @@ export interface PluginPanelContribution {
 	icon: string; // inline SVG string using currentColor
 }
 
+export interface FileHandlerProps {
+	pluginId: string;
+	filePath: string;
+	content: string;
+	sessionId: string;
+	onBack: () => void;
+}
+
 export interface PluginStatusBarItem {
 	id: string;
 	text: string;


### PR DESCRIPTION
## Summary
- New `registerFileHandler()` plugin API allows plugins to register as handlers for specific file extensions, rendering custom UI in the main file preview area
- `FilePreviewPanel` delegates to registered plugin handlers instead of default syntax highlighting
- Fix `PluginExecResult` serde serialization to use camelCase — `exit_code` was arriving as-is to JS while the API contract expects `exitCode`, breaking all `shell.exec` consumers

## Test plan
- [ ] Open a `.md` file from file explorer → markdown preview renders in main area (with markdown plugin installed)
- [ ] Open a `.ts` file → default syntax highlighting still works
- [ ] Verify `shell.exec` returns `exitCode` (not `exit_code`) to plugins
- [ ] Edit markdown in edit mode → stays in edit mode without resetting
- [ ] Cmd/Ctrl+S saves from edit mode