### PR TITLE
Auto-install default plugins on fresh installs

### DIFF
--- a/src/components/PluginManager.tsx
+++ b/src/components/PluginManager.tsx
@@ -7,7 +7,8 @@ import { hasUpdate, meetsMinVersion } from "../plugins/semver";
 import { PluginLoader } from "../plugins/PluginLoader";
 import type { PluginRuntime } from "../plugins/PluginRuntime";
 import { PluginSettingsForm } from "./PluginSettingsForm";
-import { REGISTRY_URL } from "../plugins/constants";
+import { REGISTRY_URL, DEFAULT_PLUGINS } from "../plugins/constants";
+import { getSetting, setSetting } from "../api/settings";
 
 const PERMISSION_DESCRIPTIONS: Record<string, string> = {
 	"storage": "Read and write persistent data on your device",
@@ -165,6 +166,19 @@ export function PluginManager({ runtime, onConfirmUpdate, refreshTrigger }: Plug
 			await invoke("cleanup_plugin_data", { pluginId });
 		} catch {
 			// DB cleanup is best-effort
+		}
+		// Track explicit uninstall so default plugins don't get reinstalled
+		if (DEFAULT_PLUGINS.includes(pluginId)) {
+			try {
+				const json = (await getSetting("plugin_explicitly_uninstalled")) || "[]";
+				const list: string[] = JSON.parse(json);
+				if (!list.includes(pluginId)) {
+					list.push(pluginId);
+					await setSetting("plugin_explicitly_uninstalled", JSON.stringify(list));
+				}
+			} catch {
+				// best-effort
+			}
 		}
 		setExpandedId(null);
 		await loadPlugins();

--- a/src/hooks/usePluginUpdateChecker.ts
+++ b/src/hooks/usePluginUpdateChecker.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { RegistryPlugin, ChangelogEntry } from "../plugins/types";
-import { REGISTRY_URL } from "../plugins/constants";
+import { REGISTRY_URL, DEFAULT_PLUGINS } from "../plugins/constants";
 import { hasUpdate, meetsMinVersion } from "../plugins/semver";
 import { getSetting, setSetting } from "../api/settings";
 import { downloadAndInstallPlugin } from "../plugins/pluginInstaller";
@@ -171,6 +171,37 @@ export function usePluginUpdateChecker(
           }
         })
         .filter((p): p is NonNullable<typeof p> => p !== null);
+
+      // Auto-install default plugins that are missing and not explicitly uninstalled
+      const installedIds = new Set(installedPlugins.map((p) => p.id));
+      let uninstalledJson = "";
+      try {
+        uninstalledJson = (await getSetting("plugin_explicitly_uninstalled")) || "[]";
+      } catch { /* ok */ }
+      let explicitlyUninstalled: string[] = [];
+      try {
+        explicitlyUninstalled = JSON.parse(uninstalledJson);
+      } catch { /* ok */ }
+      const uninstalledSet = new Set(explicitlyUninstalled);
+
+      let installedDefaults = false;
+      for (const defaultId of DEFAULT_PLUGINS) {
+        if (installedIds.has(defaultId) || uninstalledSet.has(defaultId)) continue;
+        const registryEntry = registryPlugins.find((rp) => rp.id === defaultId);
+        if (!registryEntry) continue;
+        // Check app version compatibility
+        const appVersion = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "0.0.0";
+        if (registryEntry.minAppVersion && !meetsMinVersion(appVersion, registryEntry.minAppVersion)) continue;
+        try {
+          await downloadAndInstallPlugin(registryEntry.downloadUrl);
+          installedDefaults = true;
+        } catch {
+          // Silent — network issue, etc.
+        }
+      }
+      if (installedDefaults) {
+        await hotLoadPlugins();
+      }
 
       // Find updates
       let updates = findUpdates(installedPlugins, registryPlugins);

--- a/src/plugins/constants.ts
+++ b/src/plugins/constants.ts
@@ -1,1 +1,6 @@
 export const REGISTRY_URL = "https://raw.githubusercontent.com/hermes-hq/plugins/main/registry/index.json";
+
+/** Plugins installed automatically on fresh installs or upgrades (unless explicitly uninstalled). */
+export const DEFAULT_PLUGINS = [
+	"hermes-hq.markdown-preview",
+];


### PR DESCRIPTION
## Summary
- New `DEFAULT_PLUGINS` list in constants defines plugins that ship with the IDE
- On startup, missing default plugins are automatically installed from the registry
- When a user explicitly uninstalls a default plugin, it's recorded in settings (`plugin_explicitly_uninstalled`) and never reinstalled
- Currently the only default plugin is Markdown Preview

## How it works
1. During the startup update check, the registry is fetched (already happens)
2. For each default plugin: if not installed AND not explicitly uninstalled → auto-install
3. On uninstall in PluginManager: if plugin is a default, its ID is added to the exclusion list

## Test plan
- [ ] Fresh install (delete plugins dir) → markdown-preview auto-installs on startup
- [ ] Uninstall markdown-preview → it does NOT reinstall on next startup
- [ ] Reinstall markdown-preview manually → works normally
- [ ] Non-default plugins are unaffected