### PR TITLE
Add macOS microphone permission for voice input

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Hermes IDE needs microphone access for voice input features in AI coding assistants.</string>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,6 +42,7 @@
     ],
     "macOS": {
       "minimumSystemVersion": "13.0",
+      "entitlements": "Entitlements.plist",
       "dmg": {
         "background": "icons/dmg-background.png",
         "windowSize": {


### PR DESCRIPTION
## Summary
- Add `NSMicrophoneUsageDescription` to Info.plist so macOS shows a permission dialog when voice input is used
- Add `com.apple.security.device.audio-input` entitlement for microphone access
- Reference the entitlements file in tauri.conf.json

Fixes #168

## Platform notes
- **macOS**: Requires Info.plist entry + entitlement (this PR)
- **Windows**: No special permission needed — microphone access is granted at the OS level via Settings > Privacy > Microphone
- **Linux**: No manifest permission needed — PulseAudio/PipeWire handles access. Some distros may require the user to be in the `audio` group

## Test plan
- [ ] Build on macOS → open a Claude session → run `/voice` → macOS shows microphone permission dialog
- [ ] After granting permission, voice input works
- [ ] Other app functionality unaffected