### PR TITLE
Add 'Update All' button to Plugin Manager

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -879,6 +879,21 @@ function AppContent() {
               }]);
             }
           }}
+          onConfirmPluginUpdateAll={(plugins) => {
+            const infos = plugins.map((plugin) => {
+              const info = pluginUpdater.updatesAvailable.find((u) => u.id === plugin.id);
+              return info ?? {
+                id: plugin.id,
+                name: plugin.name,
+                currentVersion: "",
+                newVersion: plugin.version,
+                downloadUrl: plugin.downloadUrl,
+                changelog: plugin.changelog,
+                icon: plugin.icon,
+              };
+            });
+            setPendingUpdatePlugins(infos);
+          }}
         />
       )}
 
@@ -896,10 +911,8 @@ function AppContent() {
           onConfirm={() => {
             const plugins = pendingUpdatePlugins;
             setPendingUpdatePlugins(null);
-            if (plugins.length === 1) {
-              pluginUpdater.updatePlugin(plugins[0]);
-            } else {
-              pluginUpdater.updateAll();
+            for (const p of plugins) {
+              pluginUpdater.updatePlugin(p);
             }
           }}
           onCancel={() => setPendingUpdatePlugins(null)}

--- a/src/components/PluginManager.tsx
+++ b/src/components/PluginManager.tsx
@@ -62,10 +62,11 @@ const PackageIcon = () => (
 interface PluginManagerProps {
 	runtime?: PluginRuntime;
 	onConfirmUpdate?: (plugin: RegistryPlugin) => void;
+	onConfirmUpdateAll?: (plugins: RegistryPlugin[]) => void;
 	refreshTrigger?: number;
 }
 
-export function PluginManager({ runtime, onConfirmUpdate, refreshTrigger }: PluginManagerProps) {
+export function PluginManager({ runtime, onConfirmUpdate, onConfirmUpdateAll, refreshTrigger }: PluginManagerProps) {
 	const [installed, setInstalled] = useState<PluginEntry[]>([]);
 	const [registry, setRegistry] = useState<RegistryPlugin[]>([]);
 	const [pluginsDir, setPluginsDir] = useState("");
@@ -632,6 +633,15 @@ export function PluginManager({ runtime, onConfirmUpdate, refreshTrigger }: Plug
 						<span className="pm-tab-badge">{availablePlugins.length}</span>
 					)}
 				</button>
+				{updatablePlugins.length > 0 && onConfirmUpdateAll && (
+					<button
+						className="pm-btn pm-btn-update pm-btn-update-all"
+						onClick={() => onConfirmUpdateAll(updatablePlugins)}
+						disabled={!!installingId}
+					>
+						Update All ({updatablePlugins.length})
+					</button>
+				)}
 				<button
 					className="pm-check-updates"
 					onClick={handleCheckForUpdates}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -23,10 +23,11 @@ interface SettingsProps {
   initialTab?: string;
   pluginRuntime?: import("../plugins/PluginRuntime").PluginRuntime;
   onConfirmPluginUpdate?: (plugin: import("../plugins/types").RegistryPlugin) => void;
+  onConfirmPluginUpdateAll?: (plugins: import("../plugins/types").RegistryPlugin[]) => void;
   pluginRefreshTrigger?: number;
 }
 
-export function Settings({ onClose, initialTab, pluginRuntime, onConfirmPluginUpdate, pluginRefreshTrigger }: SettingsProps) {
+export function Settings({ onClose, initialTab, pluginRuntime, onConfirmPluginUpdate, onConfirmPluginUpdateAll, pluginRefreshTrigger }: SettingsProps) {
   const [settings, setSettings] = useState<SettingsMap>({});
   const [shells, setShells] = useState<{ name: string; path: string }[]>([]);
   const [activeTab, setActiveTab] = useState(initialTab || "general");
@@ -761,7 +762,7 @@ export function Settings({ onClose, initialTab, pluginRuntime, onConfirmPluginUp
                     </p>
                   </div>
                 </div>
-                <PluginManager runtime={pluginRuntime} onConfirmUpdate={onConfirmPluginUpdate} refreshTrigger={pluginRefreshTrigger} />
+                <PluginManager runtime={pluginRuntime} onConfirmUpdate={onConfirmPluginUpdate} onConfirmUpdateAll={onConfirmPluginUpdateAll} refreshTrigger={pluginRefreshTrigger} />
               </>
             )}
 

--- a/src/styles/components/PluginManager.css
+++ b/src/styles/components/PluginManager.css
@@ -97,6 +97,17 @@
   color: var(--green);
 }
 
+/* ─── Update All Button ─────────────────────────────────── */
+
+.pm-btn-update-all {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  padding: 3px 10px;
+}
+.pm-btn-update-all + .pm-check-updates {
+  margin-left: 4px;
+}
+
 /* ─── Check for Updates Button ──────────────────────────── */
 
 .pm-check-updates {


### PR DESCRIPTION
## Summary
- Adds a green "Update All (N)" button to the Plugin Manager tab bar when updates are available
- Clicking opens the existing update confirmation dialog with all updatable plugins and changelogs
- Confirming updates each plugin sequentially via `pluginUpdater.updatePlugin()`
- Button is hidden when no updates are available and disabled during active installs

Closes #179