### PR TITLE
Smart folder ordering and missing folder detection

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -508,7 +508,80 @@ impl Database {
                 })?;
         }
 
+        // Project usage tracking table (idempotent)
+        let _ = self.conn.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS project_usage (
+                project_id TEXT PRIMARY KEY,
+                session_count INTEGER NOT NULL DEFAULT 0,
+                last_opened_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+        ",
+        );
+
         Ok(())
+    }
+
+    // ─── Project Usage ──────────────────────────────────────────
+
+    pub fn upsert_project_usage(&self, project_id: &str) -> Result<(), String> {
+        self.conn
+            .execute(
+                "INSERT INTO project_usage (project_id, session_count, last_opened_at)
+                 VALUES (?1, 1, datetime('now'))
+                 ON CONFLICT(project_id) DO UPDATE SET
+                    session_count = session_count + 1,
+                    last_opened_at = datetime('now')",
+                params![project_id],
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    pub fn get_all_projects_ordered(&self) -> Result<Vec<crate::project::ProjectOrdered>, String> {
+        let mut stmt = self.conn.prepare(
+            "SELECT r.id, r.path, r.name, r.languages, r.frameworks, r.architecture, r.conventions,
+                    r.scan_status, r.last_scanned_at, r.created_at, r.updated_at,
+                    COALESCE(pu.session_count, 0) AS session_count,
+                    pu.last_opened_at
+             FROM realms r
+             LEFT JOIN project_usage pu ON pu.project_id = r.id
+             ORDER BY
+                COALESCE(pu.session_count, 0) DESC,
+                pu.last_opened_at DESC NULLS LAST,
+                r.name COLLATE NOCASE ASC"
+        ).map_err(|e| e.to_string())?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                let languages_str: String = row.get(3)?;
+                let frameworks_str: String = row.get(4)?;
+                let architecture_str: Option<String> = row.get(5)?;
+                let conventions_str: String = row.get(6)?;
+                Ok(crate::project::ProjectOrdered {
+                    id: row.get(0)?,
+                    path: row.get(1)?,
+                    name: row.get(2)?,
+                    languages: serde_json::from_str(&languages_str).unwrap_or_default(),
+                    frameworks: serde_json::from_str(&frameworks_str).unwrap_or_default(),
+                    architecture: architecture_str.and_then(|s| serde_json::from_str(&s).ok()),
+                    conventions: serde_json::from_str(&conventions_str).unwrap_or_default(),
+                    scan_status: row.get(7)?,
+                    last_scanned_at: row.get(8)?,
+                    created_at: row.get(9)?,
+                    updated_at: row.get(10)?,
+                    session_count: row.get(11)?,
+                    last_opened_at: row.get(12)?,
+                    path_exists: false, // filled in by the command handler
+                })
+            })
+            .map_err(|e| e.to_string())?;
+
+        let mut entries = Vec::new();
+        for row in rows {
+            entries.push(row.map_err(|e| e.to_string())?);
+        }
+        Ok(entries)
     }
 
     // ─── Session Operations ─────────────────────────────────────
@@ -1634,6 +1707,12 @@ impl Database {
             self.conn
                 .execute(
                     "DELETE FROM realm_conventions WHERE realm_id = ?1",
+                    params![id],
+                )
+                .map_err(|e| e.to_string())?;
+            self.conn
+                .execute(
+                    "DELETE FROM project_usage WHERE project_id = ?1",
                     params![id],
                 )
                 .map_err(|e| e.to_string())?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -574,6 +574,7 @@ pub fn run() {
             // Projects
             project::create_project,
             project::get_registered_projects,
+            project::get_projects_ordered,
             project::get_project,
             project::delete_project,
             project::attach_session_project,

--- a/src-tauri/src/project/mod.rs
+++ b/src-tauri/src/project/mod.rs
@@ -38,6 +38,24 @@ pub struct Project {
     pub updated_at: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectOrdered {
+    pub id: String,
+    pub path: String,
+    pub name: String,
+    pub languages: Vec<String>,
+    pub frameworks: Vec<String>,
+    pub architecture: Option<ArchitectureInfo>,
+    pub conventions: Vec<Convention>,
+    pub scan_status: String,
+    pub last_scanned_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub session_count: i64,
+    pub last_opened_at: Option<String>,
+    pub path_exists: bool,
+}
+
 // ─── IPC Commands ────────────────────────────────────────────────────
 
 #[tauri::command]
@@ -159,6 +177,22 @@ pub fn create_project(
 pub fn get_registered_projects(state: State<'_, AppState>) -> Result<Vec<Project>, String> {
     let db = state.db.lock().map_err(|e| e.to_string())?;
     db.get_all_projects()
+}
+
+#[tauri::command]
+pub fn get_projects_ordered(state: State<'_, AppState>) -> Result<Vec<ProjectOrdered>, String> {
+    let db = state.db.lock().map_err(|e| e.to_string())?;
+    let mut projects = db.get_all_projects_ordered()?;
+
+    // Check which paths exist on disk
+    for project in &mut projects {
+        project.path_exists = std::path::Path::new(&project.path).is_dir();
+    }
+
+    // Stable sort: existing folders first (preserving score order), missing folders last
+    projects.sort_by(|a, b| b.path_exists.cmp(&a.path_exists));
+
+    Ok(projects)
 }
 
 #[tauri::command]

--- a/src-tauri/src/pty/commands.rs
+++ b/src-tauri/src/pty/commands.rs
@@ -1453,6 +1453,8 @@ pub fn create_session(
             for proj_id in ids {
                 db.attach_session_project(&session_id, proj_id, "primary")
                     .ok();
+                // Track project usage for smart ordering
+                db.upsert_project_usage(proj_id).ok();
             }
             // Write context file so AI agents can read project info
             // (only for local sessions — the file isn't accessible over SSH)

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { Project } from "../types/project";
+import type { Project, ProjectOrdered } from "../types/project";
 import type { ProjectContextInfo } from "../types/context";
 
 export function getProjects(): Promise<Project[]> {
@@ -19,6 +19,12 @@ export function createProject(path: string, name: string | null): Promise<Projec
 
 export function deleteProject(id: string): Promise<void> {
   return invoke("delete_project", { id });
+}
+
+export function getProjectsOrdered(): Promise<ProjectOrdered[]> {
+  return invoke<ProjectOrdered[]>("get_projects_ordered").then((projects) =>
+    projects.filter((p) => !isWorktreePath(p.path))
+  );
 }
 
 export function getSessionProjects(sessionId: string): Promise<Project[]> {

--- a/src/components/ProjectPicker.tsx
+++ b/src/components/ProjectPicker.tsx
@@ -1,8 +1,9 @@
 import "../styles/components/ProjectPicker.css";
 import { useState, useEffect, useRef, useMemo } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { Project, useSessionProjects } from "../hooks/useSessionProjects";
-import { getProjects, createProject, deleteProject, nudgeProjectContext } from "../api/projects";
+import { useSessionProjects } from "../hooks/useSessionProjects";
+import { getProjectsOrdered, createProject, deleteProject, nudgeProjectContext } from "../api/projects";
+import type { ProjectOrdered } from "../types/project";
 import { LANG_COLORS } from "../utils/langColors";
 
 interface ProjectPickerProps {
@@ -12,7 +13,7 @@ interface ProjectPickerProps {
 
 export function ProjectPicker({ sessionId, onClose }: ProjectPickerProps) {
   const { projects: attachedProjects, attach, detach } = useSessionProjects(sessionId);
-  const [allProjects, setAllProjects] = useState<Project[]>([]);
+  const [allProjects, setAllProjects] = useState<ProjectOrdered[]>([]);
   const [query, setQuery] = useState("");
   const [scanPath, setScanPath] = useState("");
   const [scanning, setScanning] = useState(false);
@@ -20,7 +21,7 @@ export function ProjectPicker({ sessionId, onClose }: ProjectPickerProps) {
   const changed = useRef(false);
 
   useEffect(() => {
-    getProjects()
+    getProjectsOrdered()
       .then((r) => setAllProjects(r))
       .catch((err) => console.warn("[ProjectPicker] Failed to load projects:", err));
     inputRef.current?.focus();
@@ -52,7 +53,7 @@ export function ProjectPicker({ sessionId, onClose }: ProjectPickerProps) {
     );
   }, [query, allProjects]);
 
-  const toggleProject = async (project: Project) => {
+  const toggleProject = async (project: ProjectOrdered) => {
     if (attachedIds.has(project.id)) {
       await detach(project.id);
     } else {
@@ -60,7 +61,7 @@ export function ProjectPicker({ sessionId, onClose }: ProjectPickerProps) {
     }
     changed.current = true;
     // Refresh all projects in case of updates
-    getProjects()
+    getProjectsOrdered()
       .then((r) => {
         setAllProjects(r);
         inputRef.current?.focus();
@@ -86,7 +87,8 @@ export function ProjectPicker({ sessionId, onClose }: ProjectPickerProps) {
         }
       } else {
         const project = await createProject(normalized, null);
-        setAllProjects((prev) => [project, ...prev.filter((r) => r.id !== project.id)]);
+        const ordered: ProjectOrdered = { ...project, session_count: 0, last_opened_at: null, path_exists: true };
+        setAllProjects((prev) => [ordered, ...prev.filter((r) => r.id !== project.id)]);
         await attach(project.id);
         changed.current = true;
       }
@@ -162,11 +164,16 @@ export function ProjectPicker({ sessionId, onClose }: ProjectPickerProps) {
           {filtered.map((project) => (
             <div
               key={project.id}
-              className={`project-picker-item ${attachedIds.has(project.id) ? "project-picker-item-attached" : ""}`}
-              onClick={() => toggleProject(project)}
+              className={`project-picker-item ${attachedIds.has(project.id) ? "project-picker-item-attached" : ""} ${"path_exists" in project && !project.path_exists ? "project-picker-item-missing" : ""}`}
+              onClick={() => {
+                if ("path_exists" in project && !project.path_exists) return;
+                toggleProject(project);
+              }}
             >
               <span className="project-picker-check">
-                {attachedIds.has(project.id) ? "[x]" : "[ ]"}
+                {"path_exists" in project && !project.path_exists
+                  ? "(!)"
+                  : attachedIds.has(project.id) ? "[x]" : "[ ]"}
               </span>
               <div className="project-picker-info">
                 <div className="project-picker-name">
@@ -176,6 +183,9 @@ export function ProjectPicker({ sessionId, onClose }: ProjectPickerProps) {
                   </span>
                 </div>
                 <div className="project-picker-path">{shortPath(project.path)}</div>
+                {"path_exists" in project && !project.path_exists && (
+                  <div className="project-picker-missing-label">Folder not found</div>
+                )}
                 <div className="project-picker-tags">
                   {project.languages.map((lang) => (
                     <span

--- a/src/components/SessionCreator.tsx
+++ b/src/components/SessionCreator.tsx
@@ -2,9 +2,9 @@ import "../styles/components/SessionCreator.css";
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useResizablePanel } from "../hooks/useResizablePanel";
 import { open } from "@tauri-apps/plugin-dialog";
-import { Project } from "../hooks/useSessionProjects";
 import { CreateSessionOpts } from "../state/SessionContext";
-import { getProjects, createProject, deleteProject } from "../api/projects";
+import { getProjectsOrdered, createProject, deleteProject } from "../api/projects";
+import type { ProjectOrdered } from "../types/project";
 import { getSessions, sshListTmuxSessions } from "../api/sessions";
 import { getSetting, setSetting } from "../api/settings";
 import { listSshSavedHosts, upsertSshSavedHost, type SshSavedHost } from "../api/ssh";
@@ -81,7 +81,7 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
   const [aiProvider, setAiProvider] = useState<string | null>(null);
   const [label, setLabel] = useState("");
   const [description, setDescription] = useState("");
-  const [allProjects, setAllProjects] = useState<Project[]>([]);
+  const [allProjects, setAllProjects] = useState<ProjectOrdered[]>([]);
   const [query, setQuery] = useState("");
   const [scanPath, setScanPath] = useState("");
   const [scanning, setScanning] = useState(false);
@@ -225,7 +225,7 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
   }, [step, orderedSteps]);
 
   useEffect(() => {
-    getProjects()
+    getProjectsOrdered()
       .then((r) => setAllProjects(r))
       .catch((err) => console.warn("[SessionCreator] Failed to load projects:", err));
     getSetting(SSH_HISTORY_KEY)
@@ -392,7 +392,8 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
     setScanning(true);
     try {
       const project = await createProject(path.trim(), null);
-      setAllProjects((prev) => [project, ...prev.filter((r) => r.id !== project.id)]);
+      const ordered: ProjectOrdered = { ...project, session_count: 0, last_opened_at: null, path_exists: true };
+      setAllProjects((prev) => [ordered, ...prev.filter((r) => r.id !== project.id)]);
       setSelectedProjectIds((prev) =>
         prev.includes(project.id) ? prev : (isShellOnly ? [project.id] : [...prev, project.id])
       );
@@ -725,13 +726,18 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
               {filtered.map((project, idx) => (
                 <div
                   key={project.id}
-                  className={`project-picker-item ${selectedProjectIds.includes(project.id) ? "project-picker-item-attached" : ""} ${highlightedIndex === idx ? "session-creator-highlighted" : ""}`}
-                  onClick={() => toggleProject(project.id)}
+                  className={`project-picker-item ${selectedProjectIds.includes(project.id) ? "project-picker-item-attached" : ""} ${highlightedIndex === idx ? "session-creator-highlighted" : ""} ${"path_exists" in project && !project.path_exists ? "project-picker-item-missing" : ""}`}
+                  onClick={() => {
+                    if ("path_exists" in project && !project.path_exists) return;
+                    toggleProject(project.id);
+                  }}
                 >
                   <span className="project-picker-check">
-                    {isShellOnly
-                      ? (selectedProjectIds.includes(project.id) ? "(*)" : "( )")
-                      : (selectedProjectIds.includes(project.id) ? "[x]" : "[ ]")}
+                    {"path_exists" in project && !project.path_exists
+                      ? "(!)"
+                      : isShellOnly
+                        ? (selectedProjectIds.includes(project.id) ? "(*)" : "( )")
+                        : (selectedProjectIds.includes(project.id) ? "[x]" : "[ ]")}
                   </span>
                   <div className="project-picker-info">
                     <div className="project-picker-name">
@@ -741,6 +747,9 @@ export function SessionCreator({ onClose, onCreate, defaultGroup }: SessionCreat
                       )}
                     </div>
                     <div className="project-picker-path">{shortPath(project.path)}</div>
+                    {"path_exists" in project && !project.path_exists && (
+                      <div className="project-picker-missing-label">Folder not found</div>
+                    )}
                     {(project.languages.length > 0 || project.frameworks.length > 0) && (
                       <div className="project-picker-tags">
                         {project.languages.map((lang) => (

--- a/src/styles/components/ProjectPicker.css
+++ b/src/styles/components/ProjectPicker.css
@@ -212,3 +212,30 @@
   color: var(--red);
   border-color: var(--red);
 }
+
+/* ─── Missing Folder Indicator ───────────────────────────── */
+
+.project-picker-item-missing {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.project-picker-item-missing .project-picker-check {
+  color: var(--red);
+}
+
+.project-picker-item-missing .project-picker-name {
+  color: var(--red);
+}
+
+.project-picker-item-missing .project-picker-path {
+  color: var(--red);
+  opacity: 0.8;
+}
+
+.project-picker-missing-label {
+  font-size: var(--text-sm);
+  color: var(--red);
+  font-weight: 500;
+  margin-top: 2px;
+}

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -17,3 +17,9 @@ export interface Project {
   created_at: string;
   updated_at: string;
 }
+
+export interface ProjectOrdered extends Project {
+  session_count: number;
+  last_opened_at: string | null;
+  path_exists: boolean;
+}


### PR DESCRIPTION
## Summary
- Folders in session creator and project picker are now ordered by usage frequency (most-used first), falling back to alphabetical when no usage data exists
- Folders whose paths no longer exist on disk are shown in red with a "Folder not found" label and pushed to the bottom of the list
- Usage is tracked automatically when sessions are created with project attachments

## Changes
- **Backend**: New `project_usage` SQLite table tracking `session_count` and `last_opened_at` per project. New `get_projects_ordered` Tauri command that joins projects with usage data, checks `fs::exists()` for each path, and returns sorted results
- **Frontend**: `SessionCreator` and `ProjectPicker` now use the ordered API. Missing folders are visually distinguished (red, non-clickable) with a clear label
- **CSS**: Added `.project-picker-item-missing` and `.project-picker-missing-label` styles

## Test plan
- [ ] Open session creator with existing projects — verify alphabetical order on first use
- [ ] Create a few sessions with different projects, reopen creator — verify most-used projects appear first
- [ ] Delete a project folder from disk, reopen creator — verify it appears in red at the bottom with "Folder not found"
- [ ] Try clicking a missing folder — verify it's not selectable
- [ ] Delete a missing folder from the list — verify it's removed
- [ ] Open project picker from an active session — verify same ordering and missing folder behavior

Closes #182