### PR TITLE
Standardize plugin UI text and button sizes for global scaling

### DIFF
--- a/src/styles/components/ActivityBar.css
+++ b/src/styles/components/ActivityBar.css
@@ -118,7 +118,7 @@
 
 .activity-bar-label {
   font-family: var(--font-ui);
-  font-size: 11px;
+  font-size: var(--text-base);
   font-weight: 500;
   letter-spacing: 0.2px;
   color: var(--text-1);
@@ -140,7 +140,7 @@
   right: -4px;
   min-width: 14px;
   height: 14px;
-  font-size: 8px;
+  font-size: var(--text-xs);
   font-weight: 600;
   line-height: 14px;
   text-align: center;

--- a/src/styles/components/PluginManager.css
+++ b/src/styles/components/PluginManager.css
@@ -101,8 +101,8 @@
 
 .pm-btn-update-all {
   margin-left: auto;
-  font-size: var(--text-xs);
-  padding: 3px 10px;
+  font-size: var(--text-sm);
+  padding: 4px 12px;
 }
 .pm-btn-update-all + .pm-check-updates {
   margin-left: 4px;
@@ -200,10 +200,10 @@
   opacity: 0.5;
 }
 
-/* Row icon — smaller for compact mode */
+/* Row icon — scales with UI tokens */
 .pm-row-icon {
-  width: 26px;
-  height: 26px;
+  width: var(--btn-size);
+  height: var(--btn-size);
   flex-shrink: 0;
   display: flex;
   align-items: center;
@@ -214,8 +214,8 @@
   overflow: hidden;
 }
 .pm-row-icon svg {
-  width: 15px;
-  height: 15px;
+  width: var(--icon-size);
+  height: var(--icon-size);
   color: inherit;
   fill: none;
   stroke: currentColor;
@@ -235,7 +235,7 @@
 
 .pm-row-name {
   font-weight: 600;
-  font-size: var(--text-base);
+  font-size: var(--text-md);
   color: var(--text-0);
   white-space: nowrap;
   overflow: hidden;
@@ -273,7 +273,7 @@
 }
 
 .pm-badge {
-  font-size: 8px;
+  font-size: var(--text-xs);
   padding: 1px 5px;
   border-radius: var(--radius-sm);
   font-weight: 600;
@@ -304,7 +304,7 @@
 .pm-detail {
   background: var(--bg-2);
   border-radius: 0 0 var(--radius) var(--radius);
-  padding: 0 8px 10px 42px; /* 42px = icon(26) + gap(8) + padding(8) */
+  padding: 0 8px 10px calc(var(--btn-size) + var(--space-2) + var(--space-2));
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -364,7 +364,7 @@
 }
 
 .pm-detail-perm {
-  font-size: 8px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 0.3px;
   padding: 1px 5px;
@@ -427,8 +427,8 @@
   border-radius: var(--radius-sm);
   color: var(--text-2);
   font-family: var(--font-ui);
-  font-size: var(--text-xs);
-  padding: 3px 10px;
+  font-size: var(--text-sm);
+  padding: 4px 12px;
   cursor: pointer;
   white-space: nowrap;
   transition: background 0.1s, color 0.1s, border-color 0.1s;
@@ -477,8 +477,8 @@
 
 /* Small inline button for compact rows */
 .pm-btn-sm {
-  font-size: 8px;
-  padding: 2px 7px;
+  font-size: var(--text-xs);
+  padding: 2px 8px;
   text-transform: uppercase;
   letter-spacing: 0.3px;
   font-weight: 600;
@@ -499,8 +499,8 @@
 }
 .pm-spinner {
   display: inline-block;
-  width: 10px;
-  height: 10px;
+  width: var(--text-sm);
+  height: var(--text-sm);
   border: 1.5px solid var(--border-light);
   border-top-color: var(--accent);
   border-radius: 50%;
@@ -664,7 +664,7 @@
 }
 
 .pm-confirm-title {
-  font-size: var(--text-base);
+  font-size: var(--text-md);
   font-weight: 600;
   color: var(--text-0);
 }
@@ -712,7 +712,7 @@
 }
 
 .ps-label {
-  font-size: var(--text-sm);
+  font-size: var(--text-base);
   color: var(--text-1);
   font-weight: 500;
 }
@@ -735,8 +735,8 @@
   border-radius: var(--radius-sm);
   color: var(--text-0);
   font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  padding: 4px 8px;
+  font-size: var(--text-base);
+  padding: 5px 8px;
   outline: none;
   box-sizing: border-box;
 }
@@ -754,8 +754,8 @@
   border-radius: var(--radius-sm);
   color: var(--text-0);
   font-family: var(--font-ui);
-  font-size: var(--text-sm);
-  padding: 4px 8px;
+  font-size: var(--text-base);
+  padding: 5px 8px;
   outline: none;
   cursor: pointer;
   min-width: 120px;

--- a/src/styles/components/PluginUpdateBanner.css
+++ b/src/styles/components/PluginUpdateBanner.css
@@ -51,7 +51,7 @@
 
 .pub-text {
   flex: 1;
-  font-size: var(--text-sm);
+  font-size: var(--text-base);
   color: var(--text-1);
   white-space: nowrap;
   overflow: hidden;
@@ -71,8 +71,8 @@
   border-radius: var(--radius-sm);
   color: var(--text-2);
   font-family: var(--font-ui);
-  font-size: var(--text-xs);
-  padding: 2px 8px;
+  font-size: var(--text-sm);
+  padding: 3px 10px;
   cursor: pointer;
   white-space: nowrap;
   transition: background 0.1s, color 0.1s, border-color 0.1s;
@@ -96,8 +96,8 @@
 }
 
 .pub-btn-sm {
-  font-size: 8px;
-  padding: 1px 6px;
+  font-size: var(--text-xs);
+  padding: 2px 7px;
   text-transform: uppercase;
   letter-spacing: 0.3px;
   font-weight: 600;
@@ -221,8 +221,8 @@
 
 .pub-spinner {
   display: inline-block;
-  width: 10px;
-  height: 10px;
+  width: var(--text-sm);
+  height: var(--text-sm);
   border: 1.5px solid var(--border-light);
   border-top-color: var(--accent);
   border-radius: 50%;

--- a/src/styles/components/PluginUpdateConfirmDialog.css
+++ b/src/styles/components/PluginUpdateConfirmDialog.css
@@ -72,8 +72,8 @@
 }
 
 .puc-plugin-icon {
-  width: 20px;
-  height: 20px;
+  width: var(--icon-size);
+  height: var(--icon-size);
   flex-shrink: 0;
   color: var(--text-2);
 }
@@ -87,7 +87,7 @@
 }
 
 .puc-plugin-name {
-  font-size: var(--text-base);
+  font-size: var(--text-md);
   font-weight: 600;
   color: var(--text-0);
 }

--- a/src/utils/themeManager.ts
+++ b/src/utils/themeManager.ts
@@ -54,6 +54,7 @@ const BASE_TOKENS = {
   "--text-md": 12,
   "--text-lg": 13,
   "--text-xl": 15,
+  "--text-2xl": 18,
   "--space-1": 4,
   "--space-2": 8,
   "--space-3": 12,


### PR DESCRIPTION
## Summary
- Replace all hardcoded pixel values in plugin UI components with CSS variable tokens so they scale with the UI Scale setting (compact 90% through extra large 150%)
- Bump undersized text and buttons to match app-wide standards
- Add missing `--text-2xl` token to the theme manager's scaled token list

## Changes

**PluginManager.css:**
- `.pm-badge`, `.pm-detail-perm`, `.pm-btn-sm`: `8px` → `var(--text-xs)`
- `.pm-btn`, `.pm-btn-update-all`: `var(--text-xs)` → `var(--text-sm)`, increased padding
- `.pm-row-name`: `var(--text-base)` → `var(--text-md)` 
- `.pm-row-icon`: `26px/15px` → `var(--btn-size)/var(--icon-size)`
- `.pm-spinner`: `10px` → `var(--text-sm)`
- `.pm-detail`: hardcoded padding → `calc(var(--btn-size) + ...)`
- `.pm-confirm-title`: `var(--text-base)` → `var(--text-md)`
- `.ps-label`, `.ps-input`, `.ps-select`: bumped from `--text-sm` to `--text-base`

**PluginUpdateBanner.css:**
- `.pub-btn`: `var(--text-xs)` → `var(--text-sm)`, increased padding
- `.pub-btn-sm`: `8px` → `var(--text-xs)`
- `.pub-spinner`: `10px` → `var(--text-sm)`
- `.pub-text`: `var(--text-sm)` → `var(--text-base)`

**PluginUpdateConfirmDialog.css:**
- `.puc-plugin-icon`: `20px` → `var(--icon-size)`
- `.puc-plugin-name`: `var(--text-base)` → `var(--text-md)`

**ActivityBar.css:**
- `.activity-bar-label`: `11px` → `var(--text-base)`
- `.activity-bar-badge`: `8px` → `var(--text-xs)`

**themeManager.ts:**
- Added `--text-2xl: 18` to `BASE_TOKENS` so it scales with UI scale

## Test plan
- [ ] Open Plugin Manager — verify text and buttons are readable at default scale
- [ ] Switch to Compact (90%) — verify everything scales down proportionally
- [ ] Switch to Extra Large (150%) — verify everything scales up, no overflow/clipping
- [ ] Check plugin update banner and confirm dialog at different scales
- [ ] Verify Activity Bar labels and badges scale correctly

Closes #184