### PR TITLE
Fix AI CLI 'Not detected' for tool-manager installs (closes #239)

### DIFF
--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -136,14 +136,35 @@ pub const AI_CLI_PROVIDERS: &[(&str, &str)] = &[
 ///
 /// On macOS/Linux, GUI apps launched from Finder or Dock inherit a minimal
 /// PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that excludes Homebrew, nvm, cargo,
-/// and other user-installed tool directories.  To detect CLIs accurately we
-/// run the checks inside a **login shell** (`-l`) which sources the user's
-/// profile and picks up the real PATH.
+/// and other user-installed tool directories.
+///
+/// Detection layers (Unix), most accurate first:
+///
+///   1. **Interactive login shell** (`-l -i -c`). Sources both login files
+///      (`.zprofile` / `.bash_profile`) AND the interactive rc files
+///      (`.zshrc` / `.bashrc`) where most users put their PATH additions
+///      (nvm, volta, pnpm, npm-global). See issue #239 — a bare `-l -c`
+///      misses `.zshrc`, which is where `claude` gets added by the npm
+///      global install.
+///   2. **Well-known install directories**. If the shell check reports a
+///      provider as missing, scan common locations (`/opt/homebrew/bin`,
+///      `/usr/local/bin`, `~/.npm-global/bin`, `~/.volta/bin`,
+///      `~/.nvm/versions/node/*/bin`, `~/.local/bin`, `~/.cargo/bin`) as a
+///      last resort for users whose profile is misconfigured.
+///   3. **Bare `which`** on Windows or as a last fallback on Unix.
 pub fn check_ai_cli_availability() -> std::collections::HashMap<String, bool> {
-    // Try the login-shell approach first (Unix only).
     #[cfg(unix)]
     {
-        if let Some(results) = check_ai_cli_via_login_shell() {
+        if let Some(mut results) = check_ai_cli_via_login_shell() {
+            // Layer 2: upgrade any still-false entry if we find the binary
+            // sitting in a well-known install directory. Never downgrades a
+            // true hit — an empty/misconfigured profile can't mask a real
+            // install, but a correct profile can always find the binary.
+            for (id, cmd) in AI_CLI_PROVIDERS {
+                if results.get(*id).copied() == Some(false) && find_binary_in_well_known_dirs(cmd) {
+                    results.insert((*id).to_string(), true);
+                }
+            }
             return results;
         }
     }
@@ -156,15 +177,15 @@ pub fn check_ai_cli_availability() -> std::collections::HashMap<String, bool> {
         .collect()
 }
 
-/// Run all AI CLI checks in a single login-shell invocation so we pick up the
-/// user's full PATH.  Returns `None` if the shell fails to execute.
+/// Build the per-provider detection script fed to the login shell. Pure —
+/// extracted so tests can invoke it with a handcrafted shell environment.
 #[cfg(unix)]
-fn check_ai_cli_via_login_shell() -> Option<std::collections::HashMap<String, bool>> {
-    let shell = crate::pty::detect_shell();
-
-    // Build a script that prints "id=1" or "id=0" for each provider.
-    // `command -v` is POSIX and works in bash, zsh, and fish.
-    let script = AI_CLI_PROVIDERS
+fn build_detection_script() -> String {
+    // `command -v` is POSIX and works in bash, zsh, and fish. Each provider
+    // prints `id=1` or `id=0` on its own line. The parser only scans stdout
+    // for those markers, so prompt/banner noise from interactive init files
+    // doesn't affect the result.
+    AI_CLI_PROVIDERS
         .iter()
         .map(|(id, cmd)| {
             format!(
@@ -173,12 +194,41 @@ fn check_ai_cli_via_login_shell() -> Option<std::collections::HashMap<String, bo
             )
         })
         .collect::<Vec<_>>()
-        .join("; ");
+        .join("; ")
+}
+
+/// Parse the login-shell stdout into a provider-id → available map.
+#[cfg(unix)]
+fn parse_detection_output(stdout: &str) -> std::collections::HashMap<String, bool> {
+    AI_CLI_PROVIDERS
+        .iter()
+        .map(|(id, _)| {
+            let found = stdout.contains(&format!("{}=1", id));
+            ((*id).to_string(), found)
+        })
+        .collect()
+}
+
+/// Run all AI CLI checks in a single login+interactive shell invocation so
+/// we pick up the user's full PATH.  Returns `None` if the shell fails to
+/// execute. `-i` (interactive) is the critical flag — it's what forces the
+/// shell to read `.zshrc` / `.bashrc`, where most tool-manager PATH exports
+/// live on macOS.
+#[cfg(unix)]
+fn check_ai_cli_via_login_shell() -> Option<std::collections::HashMap<String, bool>> {
+    let shell = crate::pty::detect_shell();
+    let script = build_detection_script();
 
     let output = std::process::Command::new(&shell)
-        .args(["-l", "-c", &script])
+        .args(["-l", "-i", "-c", &script])
         .stdin(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
+        // Defensive env overrides: keep interactive shells from touching
+        // terminal state or writing to history during a headless invocation.
+        .env("PS1", "")
+        .env("PROMPT", "")
+        .env("RPROMPT", "")
+        .env("HISTFILE", "/dev/null")
         .output()
         .ok()?;
 
@@ -187,15 +237,55 @@ fn check_ai_cli_via_login_shell() -> Option<std::collections::HashMap<String, bo
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    Some(
-        AI_CLI_PROVIDERS
-            .iter()
-            .map(|(id, _)| {
-                let found = stdout.contains(&format!("{}=1", id));
-                (id.to_string(), found)
-            })
-            .collect(),
-    )
+    Some(parse_detection_output(&stdout))
+}
+
+/// Directories to probe as the last-resort fallback. Covers the common
+/// macOS/Linux install locations for CLIs managed by Homebrew, nvm, volta,
+/// pnpm, pip user installs, cargo, and npm global.
+#[cfg(unix)]
+fn well_known_path_dirs() -> Vec<std::path::PathBuf> {
+    let mut dirs: Vec<std::path::PathBuf> = vec![
+        std::path::PathBuf::from("/opt/homebrew/bin"),
+        std::path::PathBuf::from("/usr/local/bin"),
+        std::path::PathBuf::from("/usr/bin"),
+        std::path::PathBuf::from("/bin"),
+    ];
+    if let Some(home) = home_dir() {
+        dirs.push(home.join(".npm-global").join("bin"));
+        dirs.push(home.join(".volta").join("bin"));
+        dirs.push(home.join(".local").join("bin"));
+        dirs.push(home.join(".cargo").join("bin"));
+        dirs.push(home.join("Library").join("pnpm"));
+        // Expand `~/.nvm/versions/node/*/bin` — node version directories are
+        // per-install, so we enumerate rather than guess.
+        if let Ok(entries) = std::fs::read_dir(home.join(".nvm").join("versions").join("node")) {
+            for entry in entries.flatten() {
+                let bin = entry.path().join("bin");
+                if bin.is_dir() {
+                    dirs.push(bin);
+                }
+            }
+        }
+    }
+    dirs
+}
+
+/// True if an executable file named `name` exists in any well-known dir.
+#[cfg(unix)]
+fn find_binary_in_well_known_dirs(name: &str) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    for dir in well_known_path_dirs() {
+        let candidate = dir.join(name);
+        if let Ok(meta) = std::fs::metadata(&candidate) {
+            // is_file() with any execute bit set — mirrors what `which`
+            // accepts, excludes broken symlinks and non-executable shims.
+            if meta.is_file() && meta.permissions().mode() & 0o111 != 0 {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 #[cfg(test)]
@@ -311,6 +401,213 @@ mod tests {
             );
         }
     }
+
+    // ── Interactive-rc regression (issue #239) ─────────────────────────
+
+    /// Directly validates the flag-selection fix for issue #239.
+    ///
+    /// Zsh (the default shell on macOS since Catalina) only sources
+    /// `.zshrc` when it's invoked as an **interactive** shell. `zsh -l -c`
+    /// is login-but-non-interactive: it reads `.zprofile` / `.zlogin` but
+    /// *not* `.zshrc`. Most macOS users put their tool-manager PATH
+    /// exports (nvm, volta, pnpm, npm-global — which is where `claude`
+    /// lives) in `.zshrc`, so the old detection path silently misses
+    /// them. Adding `-i` forces interactive mode and `.zshrc` is read.
+    ///
+    /// The test stages an isolated HOME and asserts the observable
+    /// behavior shift: old flags miss, new flags find.
+    #[cfg(unix)]
+    #[test]
+    fn interactive_login_shell_sources_zshrc_for_path_exports() {
+        if !command_exists("zsh") {
+            // Ubuntu CI runners don't ship zsh by default. Skip rather
+            // than silently pass — the eprintln makes it visible in logs
+            // when developers/CI want to confirm zsh coverage.
+            eprintln!(
+                "zsh not available — skipping .zshrc rc-sourcing regression test. \
+                 Install zsh to exercise the issue #239 fix locally."
+            );
+            return;
+        }
+
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "hermes_rc_regression_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let bin_dir = tmp.join("mybin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let fake_name = "hermes_rc_sentinel_bin";
+        let fake_bin = bin_dir.join(fake_name);
+        std::fs::write(&fake_bin, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&fake_bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // `.zshrc` (interactive-only rc) adds the binary dir to PATH.
+        // `.zprofile` (login-only rc) is intentionally empty — mirrors
+        // the real-world config that triggers #239.
+        std::fs::write(
+            tmp.join(".zshrc"),
+            format!("export PATH=\"{}:$PATH\"\n", bin_dir.display()),
+        )
+        .unwrap();
+        std::fs::write(tmp.join(".zprofile"), "# intentionally empty\n").unwrap();
+
+        let script = format!(
+            "command -v {} >/dev/null 2>&1 && echo FOUND || echo MISSING",
+            fake_name
+        );
+
+        let invoke = |flags: &[&str]| -> String {
+            let output = std::process::Command::new("zsh")
+                .args(flags)
+                .arg("-c")
+                .arg(&script)
+                .env_clear()
+                .env("HOME", &tmp)
+                // Override ZDOTDIR so zsh looks in our staged HOME for rc
+                // files rather than the developer/CI user's real ones.
+                .env("ZDOTDIR", &tmp)
+                .env("PATH", "/usr/bin:/bin")
+                .env("PS1", "")
+                .env("PROMPT", "")
+                .stdin(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .output()
+                .expect("zsh invocation failed");
+            String::from_utf8_lossy(&output.stdout).to_string()
+        };
+
+        // Old behavior (`-l` only) MUST miss the .zshrc export. If this
+        // ever passes, the fixture has drifted and the test no longer
+        // reproduces #239.
+        let old = invoke(&["-l"]);
+        assert!(
+            old.contains("MISSING"),
+            "fixture broken: `zsh -l -c` unexpectedly found the binary. stdout={:?}",
+            old
+        );
+
+        // New behavior (`-l -i`) MUST find it — this is the fix.
+        let new = invoke(&["-l", "-i"]);
+        assert!(
+            new.contains("FOUND"),
+            "regression: `zsh -l -i -c` failed to source .zshrc PATH export. stdout={:?}",
+            new
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The well-known-paths fallback must find an executable we drop into
+    /// one of the scanned directories (via HOME override). Locks in the
+    /// secondary hardening layer described in issue #239.
+    #[cfg(unix)]
+    #[test]
+    fn well_known_paths_fallback_finds_binary_by_home() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "hermes_wkp_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let target_dir = tmp.join(".npm-global").join("bin");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let fake_name = "hermes_wkp_sentinel_bin";
+        let fake_bin = target_dir.join(fake_name);
+        std::fs::write(&fake_bin, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&fake_bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // The public `home_dir()` is backed by the `dirs` crate, which on
+        // Unix honors $HOME. Temporarily overriding it scopes the fallback
+        // to our staged directory tree.
+        //
+        // Using `unsafe` to set env vars at runtime is required by Rust
+        // 2024 edition and acceptable here: the test is serial w.r.t. this
+        // env key, and we restore the prior value below.
+        let prev_home = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", &tmp);
+        }
+
+        let found = find_binary_in_well_known_dirs(fake_name);
+
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(
+            found,
+            "well-known-paths fallback should have found `{}` in ~/.npm-global/bin",
+            fake_name
+        );
+
+        // Non-existent binary name must still return false — verifies the
+        // fallback does not spuriously report every provider as installed.
+        let prev_home = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", &tmp);
+        }
+        let not_found = find_binary_in_well_known_dirs("__hermes_wkp_nonexistent__");
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        assert!(!not_found);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The well-known-paths layer must never DOWNGRADE a true hit. Probes
+    /// the contract documented at the call site: the secondary layer only
+    /// upgrades `false → true`, never the other way.
+    #[cfg(unix)]
+    #[test]
+    fn check_availability_does_not_downgrade_true_hits() {
+        // Indirect: we can only observe the combined result. Build a map
+        // mirroring what `check_ai_cli_via_login_shell` returns, hand-set
+        // one entry to true for a guaranteed-missing binary name, and
+        // verify that running the well-known-paths upgrade pass against an
+        // inert HOME leaves the true value intact.
+        let mut results: std::collections::HashMap<String, bool> = AI_CLI_PROVIDERS
+            .iter()
+            .map(|(id, _)| ((*id).to_string(), false))
+            .collect();
+        // Force one provider to pretend-true.
+        results.insert("claude".to_string(), true);
+
+        for (id, cmd) in AI_CLI_PROVIDERS {
+            if results.get(*id).copied() == Some(false) && find_binary_in_well_known_dirs(cmd) {
+                results.insert((*id).to_string(), true);
+            }
+        }
+
+        assert_eq!(
+            results.get("claude").copied(),
+            Some(true),
+            "well-known-paths upgrade pass must not clobber an existing true"
+        );
+    }
+
+    // ── Script generation & parsing ────────────────────────────────────
 
     /// The login-shell script must not be injectable.  Provider IDs and
     /// command names are compile-time constants, but verify the script is


### PR DESCRIPTION
## Summary
- Closes #239: Claude Code (and any CLI installed via nvm / volta / npm-global / pnpm) shows "Not detected" on macOS even when installed and working.
- Root cause: `check_ai_cli_via_login_shell` ran `<shell> -l -c` — login but non-interactive. Zsh only sources `.zshrc` in interactive mode, and `.zshrc` is where every major Node tool manager puts its PATH export.
- Fix: add `-i` → `<shell> -l -i -c`. Zsh with `-l -i` sources both login files AND `.zshrc`.
- Hardening: well-known-paths fallback scans common install dirs if the shell-based check still reports a provider missing.

## Why this matched the reporter's symptoms
The session PTY gives zsh a tty, so zsh auto-detects interactive mode and sources `.zshrc` — which is why Claude **launches** fine inside a session. Only the detection path, running a non-tty subshell, missed `.zshrc`. Exactly what @MMJM observed.

## What changed
- `src-tauri/src/platform.rs`
  - `check_ai_cli_via_login_shell` now uses `["-l", "-i", "-c", &script]` + env overrides (`PS1`, `PROMPT`, `RPROMPT`, `HISTFILE=/dev/null`) to silence noise from interactive init.
  - Extracted `build_detection_script` / `parse_detection_output` as pure helpers.
  - New `find_binary_in_well_known_dirs` + `well_known_path_dirs` helpers; scanned dirs: `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, `/bin`, `~/.npm-global/bin`, `~/.volta/bin`, `~/.local/bin`, `~/.cargo/bin`, `~/Library/pnpm`, `~/.nvm/versions/node/*/bin`.
  - `check_ai_cli_availability` upgrades any `false` result from the shell pass to `true` if the binary exists in a well-known dir. Never downgrades.

## Tests
- `interactive_login_shell_sources_zshrc_for_path_exports` — stages an isolated `HOME` with `.zshrc` PATH export, asserts **old** `zsh -l -c` misses and **new** `zsh -l -i -c` finds. Skips with an `eprintln` when zsh isn't installed (e.g. default Ubuntu CI), so the test still runs cleanly everywhere.
- `well_known_paths_fallback_finds_binary_by_home` — drops a fake binary in `$HOME/.npm-global/bin`, asserts the fallback finds it; also asserts unknown names still return false.
- `check_availability_does_not_downgrade_true_hits` — locks the upgrade-only contract (fallback can only flip `false → true`).

### Test plan
- [x] `cargo test --lib` → 163 passed, 0 failed (3 ignored).
- [x] `cargo clippy --lib --bins --tests --benches -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `npx tsc --noEmit` clean.
- [ ] Manual: on macOS with Claude installed via `npm install -g @anthropic-ai/claude-code`, open a new session and confirm Claude no longer shows "Not detected".