### PR TITLE
fix: cap execution_nodes per session to prevent unbounded growth

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1122,14 +1122,16 @@ impl Database {
         let rowid = self.conn.last_insert_rowid();
         // Keep the per-session row count bounded; silently ignore prune errors
         // so they never fail an otherwise-successful insert.
-        self.prune_execution_nodes(session_id, EXECUTION_NODES_MAX_PER_SESSION).ok();
+        self.prune_execution_nodes(session_id, EXECUTION_NODES_MAX_PER_SESSION)
+            .ok();
         Ok(rowid)
     }
 
     /// Delete all but the `keep` most-recent rows (by timestamp) for one session.
     pub fn prune_execution_nodes(&self, session_id: &str, keep: i64) -> Result<(), String> {
-        self.conn.execute(
-            "DELETE FROM execution_nodes
+        self.conn
+            .execute(
+                "DELETE FROM execution_nodes
              WHERE session_id = ?1
                AND id NOT IN (
                    SELECT id FROM execution_nodes
@@ -1137,24 +1139,25 @@ impl Database {
                    ORDER BY timestamp DESC
                    LIMIT ?2
                )",
-            params![session_id, keep],
-        ).map_err(|e| e.to_string())?;
+                params![session_id, keep],
+            )
+            .map_err(|e| e.to_string())?;
         Ok(())
     }
 
     /// Prune execution_nodes for every session — used at startup to clear
     /// pre-existing bloat.
     pub fn prune_all_execution_nodes(&self, keep: i64) -> Result<(), String> {
-        let session_ids: Vec<String> = {
-            let mut stmt = self
-                .conn
-                .prepare("SELECT DISTINCT session_id FROM execution_nodes")
-                .map_err(|e| e.to_string())?;
-            stmt.query_map([], |row| row.get(0))
-                .map_err(|e| e.to_string())?
-                .filter_map(|r| r.ok())
-                .collect()
-        };
+        let mut stmt = self
+            .conn
+            .prepare("SELECT DISTINCT session_id FROM execution_nodes")
+            .map_err(|e| e.to_string())?;
+        let session_ids: Vec<String> = stmt
+            .query_map([], |row| row.get(0))
+            .map_err(|e| e.to_string())?
+            .filter_map(|r| r.ok())
+            .collect();
+        drop(stmt);
         for sid in &session_ids {
             self.prune_execution_nodes(sid, keep)?;
         }
@@ -3310,8 +3313,7 @@ mod tests {
         }
         let count = db.get_execution_nodes_count(sid).unwrap();
         assert_eq!(
-            count,
-            EXECUTION_NODES_MAX_PER_SESSION,
+            count, EXECUTION_NODES_MAX_PER_SESSION,
             "table should be capped at {}",
             EXECUTION_NODES_MAX_PER_SESSION
         );

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -158,6 +158,10 @@ pub struct SshSavedHost {
     pub updated_at: String,
 }
 
+/// Maximum execution_nodes rows retained per session.  Rows beyond this cap
+/// (oldest by timestamp) are deleted immediately after each insert.
+pub const EXECUTION_NODES_MAX_PER_SESSION: i64 = 500;
+
 impl Database {
     pub fn new(path: &Path) -> Result<Self, String> {
         let conn = Connection::open(path).map_err(|e| format!("Failed to open database: {}", e))?;
@@ -1115,7 +1119,46 @@ impl Database {
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             params![session_id, timestamp, kind, input, output_summary, exit_code, working_dir, duration_ms, metadata],
         ).map_err(|e| e.to_string())?;
-        Ok(self.conn.last_insert_rowid())
+        let rowid = self.conn.last_insert_rowid();
+        // Keep the per-session row count bounded; silently ignore prune errors
+        // so they never fail an otherwise-successful insert.
+        self.prune_execution_nodes(session_id, EXECUTION_NODES_MAX_PER_SESSION).ok();
+        Ok(rowid)
+    }
+
+    /// Delete all but the `keep` most-recent rows (by timestamp) for one session.
+    pub fn prune_execution_nodes(&self, session_id: &str, keep: i64) -> Result<(), String> {
+        self.conn.execute(
+            "DELETE FROM execution_nodes
+             WHERE session_id = ?1
+               AND id NOT IN (
+                   SELECT id FROM execution_nodes
+                   WHERE session_id = ?1
+                   ORDER BY timestamp DESC
+                   LIMIT ?2
+               )",
+            params![session_id, keep],
+        ).map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    /// Prune execution_nodes for every session — used at startup to clear
+    /// pre-existing bloat.
+    pub fn prune_all_execution_nodes(&self, keep: i64) -> Result<(), String> {
+        let session_ids: Vec<String> = {
+            let mut stmt = self
+                .conn
+                .prepare("SELECT DISTINCT session_id FROM execution_nodes")
+                .map_err(|e| e.to_string())?;
+            stmt.query_map([], |row| row.get(0))
+                .map_err(|e| e.to_string())?
+                .filter_map(|r| r.ok())
+                .collect()
+        };
+        for sid in &session_ids {
+            self.prune_execution_nodes(sid, keep)?;
+        }
+        Ok(())
     }
 
     pub fn get_execution_nodes(

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -3255,6 +3255,82 @@ mod tests {
             plan
         );
     }
+
+    // ── execution_nodes pruning ────────────────────────────────────────
+
+    /// Helper: insert `count` execution nodes for `session_id` with sequential
+    /// timestamps 0..count so ordering is deterministic.
+    fn insert_exec_nodes(db: &Database, session_id: &str, count: i64) {
+        for i in 0..count {
+            // Bypass the auto-prune inside insert_execution_node by calling the
+            // SQL directly — we need predictable row counts for the prune tests.
+            db.conn.execute(
+                "INSERT INTO execution_nodes
+                 (session_id, timestamp, kind, input, output_summary, exit_code, working_dir, duration_ms, metadata)
+                 VALUES (?1, ?2, 'command', NULL, NULL, NULL, '/tmp', 0, NULL)",
+                params![session_id, i],
+            ).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_prune_execution_nodes_keeps_most_recent() {
+        let db = test_db();
+        let sid = "sess-prune-1";
+        insert_exec_nodes(&db, sid, 10);
+        db.prune_execution_nodes(sid, 3).unwrap();
+        assert_eq!(db.get_execution_nodes_count(sid).unwrap(), 3);
+        // The three kept rows must be the most recent (timestamps 7, 8, 9)
+        let kept = db.get_execution_nodes(sid, 10, 0).unwrap();
+        let timestamps: Vec<i64> = kept.iter().map(|n| n.timestamp).collect();
+        assert!(
+            timestamps.iter().all(|&t| t >= 7),
+            "kept rows should be most recent: {:?}",
+            timestamps
+        );
+    }
+
+    #[test]
+    fn test_prune_execution_nodes_noop_when_under_limit() {
+        let db = test_db();
+        let sid = "sess-prune-2";
+        insert_exec_nodes(&db, sid, 5);
+        db.prune_execution_nodes(sid, 10).unwrap();
+        assert_eq!(db.get_execution_nodes_count(sid).unwrap(), 5);
+    }
+
+    #[test]
+    fn test_insert_execution_node_auto_prunes() {
+        let db = test_db();
+        let sid = "sess-auto-prune";
+        // Insert more than the cap using the public API (which auto-prunes)
+        for i in 0..(EXECUTION_NODES_MAX_PER_SESSION + 10) {
+            db.insert_execution_node(sid, i, "ai_interaction", None, None, None, "/tmp", 0, None)
+                .unwrap();
+        }
+        let count = db.get_execution_nodes_count(sid).unwrap();
+        assert_eq!(
+            count,
+            EXECUTION_NODES_MAX_PER_SESSION,
+            "table should be capped at {}",
+            EXECUTION_NODES_MAX_PER_SESSION
+        );
+    }
+
+    #[test]
+    fn test_prune_all_execution_nodes() {
+        let db = test_db();
+        // Two sessions, each with 10 rows inserted directly (bypass auto-prune)
+        for sid in &["sess-all-a", "sess-all-b"] {
+            insert_exec_nodes(&db, sid, 10);
+        }
+        assert_eq!(db.get_execution_nodes_count("sess-all-a").unwrap(), 10);
+        assert_eq!(db.get_execution_nodes_count("sess-all-b").unwrap(), 10);
+        // Prune both down to 3
+        db.prune_all_execution_nodes(3).unwrap();
+        assert_eq!(db.get_execution_nodes_count("sess-all-a").unwrap(), 3);
+        assert_eq!(db.get_execution_nodes_count("sess-all-b").unwrap(), 3);
+    }
 }
 
 // ─── Settings Export / Import Commands ───────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -506,6 +506,11 @@ pub fn run() {
             // Clean up stale worktrees from previous sessions that no longer exist
             cleanup_stale_worktrees(app.handle(), &database);
 
+            // Prune execution_nodes for all sessions to cap per-session history
+            if let Err(e) = database.prune_all_execution_nodes(db::EXECUTION_NODES_MAX_PER_SESSION) {
+                log::warn!("Startup execution_nodes cleanup failed: {}", e);
+            }
+
             // Clean up stale shell integration temp files from previous sessions
             pty::shell_integration::cleanup_stale();
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -507,7 +507,8 @@ pub fn run() {
             cleanup_stale_worktrees(app.handle(), &database);
 
             // Prune execution_nodes for all sessions to cap per-session history
-            if let Err(e) = database.prune_all_execution_nodes(db::EXECUTION_NODES_MAX_PER_SESSION) {
+            if let Err(e) = database.prune_all_execution_nodes(db::EXECUTION_NODES_MAX_PER_SESSION)
+            {
                 log::warn!("Startup execution_nodes cleanup failed: {}", e);
             }
 


### PR DESCRIPTION
## Problem

The `execution_nodes` table grows without bound. Every AI interaction appends a row and nothing ever deletes them. After extended use the table accumulates hundreds to thousands of rows per session, causing the app to become progressively sluggish over time.

Measured on a real instance after ~2 days of use:
- 1,382 total rows (1,375 `ai_interaction`, 7 `command`)
- Single sessions with 500+ rows
- No DELETE or TTL anywhere in the codebase

The pattern matches the symptom exactly: starts fast, degrades gradually, worst toward the end of long sessions.

## Fix

Add `prune_execution_nodes(session_id, keep)` to `Database` — deletes all but the `keep` most-recent rows (by timestamp) for a session using the existing `idx_exec_nodes_session` index.

Wire it into `insert_execution_node` so the cap is enforced automatically on every write. The limit is 500 rows per session, consistent with the opinionated-over-configurable design principle.

Add `prune_all_execution_nodes(keep)` for startup cleanup, called once from `.setup()` to fix pre-existing bloat on first launch after upgrade.

## What was not changed

- `get_execution_nodes` already uses `LIMIT/OFFSET` — read path unchanged
- No new configuration options added
- No schema changes

## Tests

4 new tests in `db/mod.rs`:
- `test_prune_execution_nodes_keeps_most_recent` — correct rows retained
- `test_prune_execution_nodes_noop_when_under_limit` — no-op when under cap
- `test_insert_execution_node_auto_prunes` — inserts 510 rows via public API, asserts count == 500
- `test_prune_all_execution_nodes` — two sessions pruned independently