### PR TITLE
fix: clippy warnings on v1.0.0 agent module

### DIFF
--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -198,6 +198,11 @@ pub fn update_hermes_state_file(session_id: &str, state: &serde_json::Value) -> 
 /// `permission_mode` accepts Claude's published values: `default`,
 /// `acceptEdits`, `plan`, `bypassPermissions`.  Any other value (or `None`)
 /// means we omit the flag and let Claude pick its own default.
+///
+/// The argument count is intentionally large — every flag Claude accepts is
+/// exposed here.  Reducing it would force callers to construct intermediate
+/// option structs that wouldn't add clarity.
+#[allow(clippy::too_many_arguments)]
 pub fn build_spawn_args(
     session_id: &str,
     working_dir: &str,
@@ -281,7 +286,11 @@ pub fn build_spawn_args(
 
 /// Spawn a Claude agent subprocess for `session_id`.  Returns the Claude session
 /// UUID we passed via `--session-id` so the frontend can track it for resume.
+///
+/// The argument list mirrors `build_spawn_args` plus the Tauri `State` and
+/// `AppHandle` — same justification: each is a real Claude flag.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn spawn_agent_session(
     state: State<'_, AgentState>,
     app: AppHandle,

--- a/src-tauri/src/pty/models.rs
+++ b/src-tauri/src/pty/models.rs
@@ -5,20 +5,15 @@ use std::collections::HashMap;
 
 /// How a session is run and rendered on the frontend.
 ///
-///  - `Terminal`: existing PTY/xterm flow.  All non-Claude sessions use this.
-///  - `Agent`:    `claude --print` stream-json subprocess driving an
-///                `<AgentSessionView>` chat surface.  Claude-only in 1.0.0.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+/// - `Terminal`: existing PTY/xterm flow.  All non-Claude sessions use this.
+/// - `Agent`: `claude --print` stream-json subprocess driving an
+///   `<AgentSessionView>` chat surface.  Claude-only in 1.0.0.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionMode {
+    #[default]
     Terminal,
     Agent,
-}
-
-impl Default for SessionMode {
-    fn default() -> Self {
-        SessionMode::Terminal
-    }
 }
 
 // ─── Session Phase State Machine ────────────────────────────────────


### PR DESCRIPTION
## Summary

Follows up #250 by fixing the four `clippy -- -D warnings` errors that were merged with a Clippy bypass.

- `build_spawn_args` (`src-tauri/src/agent/mod.rs`) — `clippy::too_many_arguments` suppressed with a doc-explained `#[allow]`. Each argument is one Claude CLI flag; grouping into intermediate option structs would not add clarity.
- `spawn_agent_session` — same justification, same `#[allow]`.
- `SessionMode` (`src-tauri/src/pty/models.rs`) — replaced manual `impl Default` with `#[derive(Default)]` + `#[default]` on `Terminal`. Same behaviour, satisfies `clippy::derivable_impls`.
- `SessionMode` doc — collapsed over-indented multi-line list item per `clippy::doc_overindented_list_items`.

## Test plan

- [x] `cd src-tauri && cargo clippy --lib -- -D warnings` — clean
- [x] `cd src-tauri && cargo fmt --all -- --check` — clean
- [x] `cd src-tauri && cargo test --lib` — 205 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm test -- --run` — 2945 passed