### PR TITLE
Fix interactive tools + redesign session timeline (per-theme archetype paint)

### DIFF
--- a/src-tauri/bridge/canUseToolHelpers.mjs
+++ b/src-tauri/bridge/canUseToolHelpers.mjs
@@ -1,0 +1,42 @@
+/**
+ * Pure helpers for the bridge's `canUseTool` callback.
+ *
+ * Extracted into a separate module so the host-decision normalization
+ * has a unit test (the bridge entry point is not directly importable —
+ * it has top-level argv parsing and an `await main()`).
+ *
+ * Background — the SDK's Zod schema requires the `allow` decision
+ * shape to be `{ behavior: "allow", updatedInput: <record> }`.  When
+ * the host approves WITHOUT editing the tool input, the bridge must
+ * echo the ORIGINAL input back as `updatedInput` — otherwise the SDK
+ * throws `ZodError("expected record, received undefined")` and the
+ * tool call silently fails (this was the v1 plan-mode "Send does
+ * nothing" bug).
+ */
+
+/**
+ * Normalize a decision returned by the host into the exact shape the
+ * SDK's canUseTool callback expects.
+ *
+ * @param {unknown} decision           Raw value the host wrote on stdin.
+ * @param {unknown} originalInput      The tool's original input (echoed
+ *                                     when the host approves without edits).
+ * @returns {{behavior: "allow", updatedInput: unknown} | {behavior: "deny", message: string}}
+ */
+export function normalizeBridgeAllowDecision(decision, originalInput) {
+  if (!decision || typeof decision !== "object") {
+    return { behavior: "deny", message: "host returned invalid decision" };
+  }
+  const d = /** @type {Record<string, unknown>} */ (decision);
+  if (d.behavior === "allow") {
+    const updatedInput =
+      d.updatedInput && typeof d.updatedInput === "object"
+        ? d.updatedInput
+        : originalInput;
+    return { behavior: "allow", updatedInput };
+  }
+  return {
+    behavior: "deny",
+    message: typeof d.message === "string" ? d.message : "user declined",
+  };
+}

--- a/src-tauri/bridge/hermes-claude-bridge.mjs
+++ b/src-tauri/bridge/hermes-claude-bridge.mjs
@@ -64,6 +64,7 @@ import { argv, exit, stdin, stdout, stderr } from "node:process";
 import { createInterface } from "node:readline";
 import { readFileSync, existsSync } from "node:fs";
 import { z } from "zod";
+import { normalizeBridgeAllowDecision } from "./canUseToolHelpers.mjs";
 
 // ─── 1. Parse CLI args ──────────────────────────────────────────────
 
@@ -414,9 +415,19 @@ const sdkOptions = {
   // unconditionally; tools no-op gracefully when no `--hermes-state-path`
   // was passed (back-compat with tests / external callers).
   mcpServers: { hermes: buildHermesMcpServer() },
-  // Always allow Claude to call our Hermes tools without per-call permission
-  // prompts.  Other tools still go through `canUseTool` / settings allowlist.
-  allowedTools: ["mcp__hermes__*"],
+  // Auto-allow only tools that have NO interactive UI to render —
+  //   * mcp__hermes__*  : our IDE-context MCP tools, never destructive
+  //   * TodoWrite       : produces a side-panel UI, no permission UX
+  //
+  // AskUserQuestion / ExitPlanMode / EnterPlanMode are intentionally
+  // routed through `canUseTool` so the bridge fires a perm-request the
+  // host turns into a native card.  The host's allow/deny response IS
+  // the user's answer/decision.  Auto-allowing these would cause Claude
+  // to execute the tool with empty `answers` (the previous bug).
+  allowedTools: [
+    "mcp__hermes__*",
+    "TodoWrite",
+  ],
   // Inject IDE state on session start, resume, and after compactions.
   // Invisible to the transcript; the user never sees this in the chat.
   // UserPromptSubmit re-injects the runtime line on every turn so the
@@ -449,18 +460,7 @@ const sdkOptions = {
       input,
     }) + "\n");
     const decision = await promise;
-    if (!decision || typeof decision !== "object") {
-      return { behavior: "deny", message: "host returned invalid decision" };
-    }
-    if (decision.behavior === "allow") {
-      return decision.updatedInput
-        ? { behavior: "allow", updatedInput: decision.updatedInput }
-        : { behavior: "allow" };
-    }
-    return {
-      behavior: "deny",
-      message: typeof decision.message === "string" ? decision.message : "user declined",
-    };
+    return normalizeBridgeAllowDecision(decision, input);
   },
   // Forward bridge stderr-by-line so SDK panics surface to Rust.
   stderr: (data) => stderr.write(data),
@@ -498,11 +498,37 @@ async function main() {
         && (message.subtype === "init" || message.subtype === "session_started")
       ) {
         if (message.session_id) canonicalSessionId = message.session_id;
+        // Detect drift in the runtime values vs. what the host UI is
+        // currently showing.  When Claude flips permission_mode via
+        // EnterPlanMode/ExitPlanMode, or when the user runs `/model`,
+        // the SDK reports the new value here — we fan it out to the
+        // host so the picker chips update.  Skip the emit when nothing
+        // actually changed (avoids respawn ping-pong).
+        const before = {
+          model: liveRuntime.reportedModel,
+          permissionMode: liveRuntime.reportedPermissionMode,
+        };
         if (typeof message.model === "string") {
           liveRuntime.reportedModel = message.model;
         }
         if (typeof message.permissionMode === "string") {
           liveRuntime.reportedPermissionMode = message.permissionMode;
+        }
+        const changed =
+          liveRuntime.reportedModel !== before.model
+          || liveRuntime.reportedPermissionMode !== before.permissionMode;
+        if (changed) {
+          stdout.write(JSON.stringify({
+            type: "_hermes_state_changed",
+            session_id: canonicalSessionId,
+            ...(liveRuntime.reportedModel
+              ? { model: liveRuntime.reportedModel }
+              : {}),
+            ...(liveRuntime.reportedPermissionMode
+              ? { permissionMode: liveRuntime.reportedPermissionMode }
+              : {}),
+            uuid: globalThis.crypto?.randomUUID?.() ?? `evt-${Date.now()}`,
+          }) + "\n");
         }
         // Unblock any UserPromptSubmit hook waiting for the first init.
         initSeen.resolve();

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -198,6 +198,11 @@ pub fn update_hermes_state_file(session_id: &str, state: &serde_json::Value) -> 
 /// `permission_mode` accepts Claude's published values: `default`,
 /// `acceptEdits`, `plan`, `bypassPermissions`.  Any other value (or `None`)
 /// means we omit the flag and let Claude pick its own default.
+///
+/// The argument count is intentionally large — every flag Claude accepts is
+/// exposed here.  Reducing it would force callers to construct intermediate
+/// option structs that wouldn't add clarity.
+#[allow(clippy::too_many_arguments)]
 pub fn build_spawn_args(
     session_id: &str,
     working_dir: &str,
@@ -281,7 +286,11 @@ pub fn build_spawn_args(
 
 /// Spawn a Claude agent subprocess for `session_id`.  Returns the Claude session
 /// UUID we passed via `--session-id` so the frontend can track it for resume.
+///
+/// The argument list mirrors `build_spawn_args` plus the Tauri `State` and
+/// `AppHandle` — same justification: each is a real Claude flag.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn spawn_agent_session(
     state: State<'_, AgentState>,
     app: AppHandle,

--- a/src-tauri/src/pty/models.rs
+++ b/src-tauri/src/pty/models.rs
@@ -5,20 +5,15 @@ use std::collections::HashMap;
 
 /// How a session is run and rendered on the frontend.
 ///
-///  - `Terminal`: existing PTY/xterm flow.  All non-Claude sessions use this.
-///  - `Agent`:    `claude --print` stream-json subprocess driving an
-///                `<AgentSessionView>` chat surface.  Claude-only in 1.0.0.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+/// - `Terminal`: existing PTY/xterm flow.  All non-Claude sessions use this.
+/// - `Agent`: `claude --print` stream-json subprocess driving an
+///   `<AgentSessionView>` chat surface.  Claude-only in 1.0.0.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionMode {
+    #[default]
     Terminal,
     Agent,
-}
-
-impl Default for SessionMode {
-    fn default() -> Self {
-        SessionMode::Terminal
-    }
 }
 
 // ─── Session Phase State Machine ────────────────────────────────────

--- a/src/__tests__/ask-user-question.test.tsx
+++ b/src/__tests__/ask-user-question.test.tsx
@@ -1,25 +1,28 @@
 // @vitest-environment jsdom
 /**
- * M1a — AskUserQuestion native modal.
+ * M1a — AskUserQuestion native card.
  *
  * Spec: docs/internal/v1-tui-parity-plan.md §2 (M1a) + §7.3.
  * Visual: §8.2.
  *
  * AskUserQuestion is the SDK's interactive-prompt tool.  Claude calls it
  * with a `questions` array; the host (Hermes) renders UI, captures the
- * user's selection, and writes back a `tool_result` envelope on stdin.
- * Without our card, the question shows as a plain tool block and the
- * conversation stalls.
+ * user's selection, and answers the SDK's `canUseTool` callback with an
+ * `updatedInput` that carries the user's `answers` (and optional
+ * `annotations`).  The SDK then formats its own `tool_result` block.
+ *
+ * The card MUST NOT write a `tool_result` envelope itself — that was
+ * the v1 bug: the SDK was waiting on canUseTool's promise, not on a
+ * user message, so the answers were silently dropped.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
 import {
   isAskUserQuestionToolUse,
-  buildAskAnswerEnvelope,
+  buildAskAnswersUpdatedInput,
   type AskUserQuestionInput,
-  type AskAnswer,
 } from "../utils/askUserQuestion";
 import { AskUserQuestionCard } from "../components/AskUserQuestionCard";
 
@@ -65,51 +68,120 @@ describe("isAskUserQuestionToolUse", () => {
   it("aq-1-c: returns false for non-tool_use blocks", () => {
     expect(isAskUserQuestionToolUse({ type: "text", text: "hi" } as never)).toBe(false);
   });
+
+  it("aq-1-d: returns false for null/undefined", () => {
+    expect(isAskUserQuestionToolUse(null)).toBe(false);
+    expect(isAskUserQuestionToolUse(undefined)).toBe(false);
+  });
 });
 
-describe("buildAskAnswerEnvelope (aq-6, aq-10)", () => {
-  it("aq-6: composes tool_result envelope with correct shape", () => {
-    const env = buildAskAnswerEnvelope("tu_1", [
-      { question: "Q1", selected: ["Option A"] },
+// ─── buildAskAnswersUpdatedInput — SDK Zod schema parity ────────────
+
+describe("buildAskAnswersUpdatedInput (aq-6, aq-10) — SDK shape", () => {
+  it("aq-6: single-select answer keyed by question text → option label", () => {
+    const updated = buildAskAnswersUpdatedInput(SAMPLE_INPUT, [
+      { question: "Which approach should we take?", selected: ["Option A"] },
     ]);
-    expect(env).toMatchObject({
-      type: "user",
-      message: {
-        role: "user",
-        content: [
-          {
-            type: "tool_result",
-            tool_use_id: "tu_1",
-            content: expect.any(String),
-          },
-        ],
+    expect(updated).toMatchObject({
+      questions: SAMPLE_INPUT.questions,
+      answers: {
+        "Which approach should we take?": "Option A",
       },
     });
-    // The content is the JSON-stringified answers — Claude reads it back.
-    const parsed = JSON.parse(
-      (env.message.content[0] as { content: string }).content,
-    );
-    expect(parsed.answers[0].selected).toEqual(["Option A"]);
   });
 
-  it("aq-10: serializes answers as [{question, selected, notes?}]", () => {
-    const env = buildAskAnswerEnvelope("tu_1", [
-      { question: "Q1", selected: ["A"], notes: "freeform" },
+  it("aq-6-b: multi-select answers comma-joined per the SDK contract", () => {
+    const input: AskUserQuestionInput = {
+      questions: [
+        {
+          ...SAMPLE_INPUT.questions[0],
+          multiSelect: true,
+        },
+      ],
+    };
+    const updated = buildAskAnswersUpdatedInput(input, [
+      {
+        question: "Which approach should we take?",
+        selected: ["Option A", "Option B"],
+      },
     ]);
-    const parsed = JSON.parse(
-      (env.message.content[0] as { content: string }).content,
-    );
-    expect(parsed.answers).toEqual([
-      { question: "Q1", selected: ["A"], notes: "freeform" },
-    ]);
+    expect(updated.answers).toEqual({
+      "Which approach should we take?": "Option A, Option B",
+    });
   });
 
-  it("aq-9: cancel envelope sets cancelled flag", () => {
-    const env = buildAskAnswerEnvelope("tu_1", [], { cancelled: true });
-    const parsed = JSON.parse(
-      (env.message.content[0] as { content: string }).content,
-    );
-    expect(parsed.cancelled).toBe(true);
+  it("aq-10-a: 'Other' answer surfaces typed notes text, not the literal 'Other'", () => {
+    const updated = buildAskAnswersUpdatedInput(SAMPLE_INPUT, [
+      {
+        question: "Which approach should we take?",
+        selected: ["Other"],
+        notes: "use a different framework",
+      },
+    ]);
+    expect(updated.answers).toEqual({
+      "Which approach should we take?": "use a different framework",
+    });
+    // Whitespace-only notes are NOT used as the answer — fall back to "Other".
+    expect((updated as { annotations?: unknown }).annotations).toBeUndefined();
+  });
+
+  it("aq-10-b: 'Other' with empty notes falls back to literal 'Other'", () => {
+    const updated = buildAskAnswersUpdatedInput(SAMPLE_INPUT, [
+      { question: "Q?", selected: ["Other"], notes: "   " },
+    ]);
+    expect((updated.answers as Record<string, string>)["Q?"]).toBe("Other");
+  });
+
+  it("aq-10-c: notes alongside a selection are emitted as annotations[q].notes", () => {
+    const updated = buildAskAnswersUpdatedInput(SAMPLE_INPUT, [
+      {
+        question: "Q?",
+        selected: ["Option A"],
+        notes: "I'd also accept Option C",
+      },
+    ]);
+    expect((updated as { annotations?: Record<string, { notes: string }> }).annotations).toEqual({
+      "Q?": { notes: "I'd also accept Option C" },
+    });
+  });
+
+  it("aq-14-b: multi-question input keys answers by each question text", () => {
+    const input: AskUserQuestionInput = {
+      questions: [
+        { question: "first?", header: "Q1", multiSelect: false, options: [{ label: "A", description: "" }] },
+        { question: "second?", header: "Q2", multiSelect: true, options: [
+          { label: "X", description: "" },
+          { label: "Y", description: "" },
+        ] },
+      ],
+    };
+    const updated = buildAskAnswersUpdatedInput(input, [
+      { question: "first?", selected: ["A"] },
+      { question: "second?", selected: ["X", "Y"] },
+    ]);
+    expect(updated.answers).toEqual({
+      "first?": "A",
+      "second?": "X, Y",
+    });
+  });
+
+  it("aq-21-a: result has no `cancelled` key — denial goes through perm-response, not updatedInput", () => {
+    const updated = buildAskAnswersUpdatedInput(SAMPLE_INPUT, [
+      { question: "Q?", selected: ["Option A"] },
+    ]);
+    expect(updated).not.toHaveProperty("cancelled");
+  });
+
+  it("aq-21-b: original input keys are preserved (questions array passes through)", () => {
+    const input: AskUserQuestionInput = {
+      ...SAMPLE_INPUT,
+      // @ts-expect-error allow extra keys on input pass-through
+      metadata: { source: "remember" },
+    };
+    const updated = buildAskAnswersUpdatedInput(input, [
+      { question: "Which approach should we take?", selected: ["Option A"] },
+    ]);
+    expect((updated as { metadata?: { source: string } }).metadata).toEqual({ source: "remember" });
   });
 });
 
@@ -121,10 +193,9 @@ describe("AskUserQuestionCard — render (aq-2, aq-3, aq-4, aq-5)", () => {
   it("aq-2: single-select renders as radios with auto Other option", () => {
     render(
       <AskUserQuestionCard
-        toolUseId="tu_1"
         input={SAMPLE_INPUT}
-        onSubmit={() => {}}
-        onCancel={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     expect(screen.getByRole("radio", { name: /Option A/i })).toBeInTheDocument();
@@ -135,7 +206,6 @@ describe("AskUserQuestionCard — render (aq-2, aq-3, aq-4, aq-5)", () => {
   it("aq-3: multi-select renders as checkboxes", () => {
     render(
       <AskUserQuestionCard
-        toolUseId="tu_1"
         input={{
           questions: [
             {
@@ -144,8 +214,8 @@ describe("AskUserQuestionCard — render (aq-2, aq-3, aq-4, aq-5)", () => {
             },
           ],
         }}
-        onSubmit={() => {}}
-        onCancel={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     expect(screen.getByRole("checkbox", { name: /Option A/i })).toBeInTheDocument();
@@ -153,13 +223,11 @@ describe("AskUserQuestionCard — render (aq-2, aq-3, aq-4, aq-5)", () => {
   });
 
   it("aq-4: 'Other' reveals textarea on selection; submit blocked when empty", () => {
-    const onSubmit = vi.fn();
     render(
       <AskUserQuestionCard
-        toolUseId="tu_1"
         input={SAMPLE_INPUT}
-        onSubmit={onSubmit}
-        onCancel={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     const otherRadio = screen.getByRole("radio", { name: /Other/i });
@@ -167,7 +235,6 @@ describe("AskUserQuestionCard — render (aq-2, aq-3, aq-4, aq-5)", () => {
     const textarea = screen.getByRole("textbox");
     expect(textarea).toBeInTheDocument();
 
-    // Submit should be disabled until textarea has content.
     const submit = screen.getByRole("button", { name: /send/i });
     expect(submit).toBeDisabled();
 
@@ -178,7 +245,6 @@ describe("AskUserQuestionCard — render (aq-2, aq-3, aq-4, aq-5)", () => {
   it("aq-5: option with preview renders preview pane when focused", () => {
     render(
       <AskUserQuestionCard
-        toolUseId="tu_1"
         input={{
           questions: [
             {
@@ -192,41 +258,57 @@ describe("AskUserQuestionCard — render (aq-2, aq-3, aq-4, aq-5)", () => {
             },
           ],
         }}
-        onSubmit={() => {}}
-        onCancel={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     fireEvent.click(screen.getByRole("radio", { name: /L1/i }));
     expect(screen.getByTestId("aq-preview-pane")).toHaveTextContent("A");
   });
+
+  it("renders dialogId as data-dialog-id for tracing", () => {
+    const { container } = render(
+      <AskUserQuestionCard
+        dialogId="perm-42"
+        input={SAMPLE_INPUT}
+        onAllow={() => {}}
+        onDeny={() => {}}
+      />,
+    );
+    expect(container.querySelector('[data-dialog-id="perm-42"]')).not.toBeNull();
+  });
 });
 
-describe("AskUserQuestionCard — submit (aq-6, aq-7, aq-9)", () => {
+// ─── Submit / cancel ─────────────────────────────────────────────────
+
+describe("AskUserQuestionCard — submit invokes onAllow with SDK-shaped updatedInput", () => {
   afterEach(() => cleanup());
 
-  it("aq-6: submit fires onSubmit with composed answers (single-select)", () => {
-    const onSubmit = vi.fn();
+  it("aq-6: single-select calls onAllow with answers Record keyed by question text", () => {
+    const onAllow = vi.fn();
     render(
       <AskUserQuestionCard
-        toolUseId="tu_1"
         input={SAMPLE_INPUT}
-        onSubmit={onSubmit}
-        onCancel={() => {}}
+        onAllow={onAllow}
+        onDeny={() => {}}
       />,
     );
     fireEvent.click(screen.getByRole("radio", { name: /Option A/i }));
     fireEvent.click(screen.getByRole("button", { name: /send/i }));
-    expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit.mock.calls[0][0]).toEqual([
-      { question: "Which approach should we take?", selected: ["Option A"] },
-    ]);
+
+    expect(onAllow).toHaveBeenCalledTimes(1);
+    const updatedInput = onAllow.mock.calls[0][0] as Record<string, unknown>;
+    expect(updatedInput.answers).toEqual({
+      "Which approach should we take?": "Option A",
+    });
+    // Original input keys are preserved.
+    expect(updatedInput.questions).toEqual(SAMPLE_INPUT.questions);
   });
 
-  it("aq-6-b: submit collects multi-select answers", () => {
-    const onSubmit = vi.fn();
+  it("aq-6-b: multi-select submits comma-joined labels", () => {
+    const onAllow = vi.fn();
     render(
       <AskUserQuestionCard
-        toolUseId="tu_1"
         input={{
           questions: [
             {
@@ -235,38 +317,69 @@ describe("AskUserQuestionCard — submit (aq-6, aq-7, aq-9)", () => {
             },
           ],
         }}
-        onSubmit={onSubmit}
-        onCancel={() => {}}
+        onAllow={onAllow}
+        onDeny={() => {}}
       />,
     );
     fireEvent.click(screen.getByRole("checkbox", { name: /Option A/i }));
     fireEvent.click(screen.getByRole("checkbox", { name: /Option B/i }));
     fireEvent.click(screen.getByRole("button", { name: /send/i }));
-    const answers = onSubmit.mock.calls[0][0] as AskAnswer[];
-    expect(answers[0].selected).toEqual(["Option A", "Option B"]);
+
+    const updated = onAllow.mock.calls[0][0] as { answers: Record<string, string> };
+    expect(updated.answers["Which approach should we take?"]).toBe("Option A, Option B");
   });
 
-  it("aq-9: Esc fires onCancel", () => {
-    const onCancel = vi.fn();
+  it("aq-7: 'Other' with typed text submits the typed text as the answer", () => {
+    const onAllow = vi.fn();
     render(
       <AskUserQuestionCard
-        toolUseId="tu_1"
         input={SAMPLE_INPUT}
-        onSubmit={() => {}}
-        onCancel={onCancel}
+        onAllow={onAllow}
+        onDeny={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /Other/i }));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "freeform answer" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    const updated = onAllow.mock.calls[0][0] as { answers: Record<string, string> };
+    expect(updated.answers["Which approach should we take?"]).toBe("freeform answer");
+  });
+
+  it("aq-9: Esc fires onDeny", () => {
+    const onDeny = vi.fn();
+    render(
+      <AskUserQuestionCard
+        input={SAMPLE_INPUT}
+        onAllow={() => {}}
+        onDeny={onDeny}
       />,
     );
     fireEvent.keyDown(window, { key: "Escape" });
-    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onDeny).toHaveBeenCalledTimes(1);
+  });
+
+  it("aq-9-b: cancel button fires onDeny", () => {
+    const onDeny = vi.fn();
+    render(
+      <AskUserQuestionCard
+        input={SAMPLE_INPUT}
+        onAllow={() => {}}
+        onDeny={onDeny}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onDeny).toHaveBeenCalledTimes(1);
   });
 
   it("submit disabled when no selection made (validation guard)", () => {
     render(
       <AskUserQuestionCard
-        toolUseId="tu_1"
         input={SAMPLE_INPUT}
-        onSubmit={() => {}}
-        onCancel={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     expect(screen.getByRole("button", { name: /send/i })).toBeDisabled();
@@ -278,23 +391,21 @@ describe("AskUserQuestionCard — submit (aq-6, aq-7, aq-9)", () => {
 describe("AskUserQuestionCard — failure modes (aq-13..aq-21)", () => {
   afterEach(() => cleanup());
 
-  it("aq-13: empty questions array → onCancel auto-fires (degenerate input)", () => {
-    const onCancel = vi.fn();
+  it("aq-13: empty questions array → onDeny auto-fires (degenerate input)", () => {
+    const onDeny = vi.fn();
     render(
       <AskUserQuestionCard
-        toolUseId="tu_1"
         input={{ questions: [] }}
-        onSubmit={() => {}}
-        onCancel={onCancel}
+        onAllow={() => {}}
+        onDeny={onDeny}
       />,
     );
-    expect(onCancel).toHaveBeenCalled();
+    expect(onDeny).toHaveBeenCalled();
   });
 
   it("aq-14: 3-question input renders all three (legend + question text per question)", () => {
     render(
       <AskUserQuestionCard
-        toolUseId="tu_1"
         input={{
           questions: [
             { question: "first?", header: "Q1", multiSelect: false, options: [{ label: "A", description: "" }] },
@@ -302,8 +413,8 @@ describe("AskUserQuestionCard — failure modes (aq-13..aq-21)", () => {
             { question: "third?", header: "Q3", multiSelect: false, options: [{ label: "A", description: "" }] },
           ],
         }}
-        onSubmit={() => {}}
-        onCancel={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     expect(screen.getByText("Q1")).toBeInTheDocument();
@@ -317,7 +428,6 @@ describe("AskUserQuestionCard — failure modes (aq-13..aq-21)", () => {
   it("aq-17: empty multi-select submit blocked (no selection, no Other content)", () => {
     render(
       <AskUserQuestionCard
-        toolUseId="tu_1"
         input={{
           questions: [
             {
@@ -326,35 +436,30 @@ describe("AskUserQuestionCard — failure modes (aq-13..aq-21)", () => {
             },
           ],
         }}
-        onSubmit={() => {}}
-        onCancel={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     expect(screen.getByRole("button", { name: /send/i })).toBeDisabled();
   });
 
-  it("aq-21: tool_result envelope round-trips (snapshot-pinned shape)", () => {
-    const env = buildAskAnswerEnvelope("tu_42", [
-      { question: "Q1", selected: ["A"] },
-      { question: "Q2", selected: ["X", "Y"], notes: "freeform" },
+  it("aq-21: full multi-question round-trip produces SDK-canonical Record<string,string>", () => {
+    const input: AskUserQuestionInput = {
+      questions: [
+        { question: "a?", header: "A", multiSelect: false, options: [{ label: "x", description: "" }] },
+        { question: "b?", header: "B", multiSelect: true, options: [
+          { label: "y", description: "" },
+          { label: "z", description: "" },
+        ] },
+      ],
+    };
+    const updated = buildAskAnswersUpdatedInput(input, [
+      { question: "a?", selected: ["x"] },
+      { question: "b?", selected: ["y", "z"] },
     ]);
-    expect(env).toEqual({
-      type: "user",
-      message: {
-        role: "user",
-        content: [
-          {
-            type: "tool_result",
-            tool_use_id: "tu_42",
-            content: JSON.stringify({
-              answers: [
-                { question: "Q1", selected: ["A"] },
-                { question: "Q2", selected: ["X", "Y"], notes: "freeform" },
-              ],
-            }),
-          },
-        ],
-      },
+    expect(updated.answers).toEqual({
+      "a?": "x",
+      "b?": "y, z",
     });
   });
 });

--- a/src/__tests__/bridge-can-use-tool.test.ts
+++ b/src/__tests__/bridge-can-use-tool.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Bridge `canUseTool` decision normalization.
+ *
+ * Regression coverage for the v1 plan-mode "Send does nothing" bug:
+ *
+ *   The SDK's Zod schema for the `canUseTool` callback's allow
+ *   response requires `updatedInput` to be a record on every call.
+ *   When the host approves WITHOUT editing input (e.g. accepting a
+ *   plan or answering an AskUserQuestion via the perm-response
+ *   channel), the bridge must ECHO the original input back as
+ *   `updatedInput`.  Skipping the echo throws
+ *
+ *     ZodError: "expected record, received undefined"
+ *
+ *   and the tool call silently fails — the user sees nothing happen
+ *   when they click Send.
+ *
+ * The helper is in plain ESM (.mjs) so vitest can import it directly.
+ */
+import { describe, it, expect } from "vitest";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error — JS module, no .d.ts file
+import { normalizeBridgeAllowDecision } from "../../src-tauri/bridge/canUseToolHelpers.mjs";
+
+describe("normalizeBridgeAllowDecision (REGRESSION: SDK ZodError on allow without updatedInput)", () => {
+  const ORIG_INPUT = { questions: [{ question: "Q?", header: "H", multiSelect: false, options: [] }] };
+
+  it("echoes original input as updatedInput when host approves without edits", () => {
+    const result = normalizeBridgeAllowDecision({ behavior: "allow" }, ORIG_INPUT);
+    expect(result).toEqual({ behavior: "allow", updatedInput: ORIG_INPUT });
+  });
+
+  it("uses the host-supplied updatedInput when present (AskUserQuestion answers flow)", () => {
+    const edited = { ...ORIG_INPUT, answers: { "Q?": "yes" } };
+    const result = normalizeBridgeAllowDecision(
+      { behavior: "allow", updatedInput: edited },
+      ORIG_INPUT,
+    );
+    expect(result).toEqual({ behavior: "allow", updatedInput: edited });
+  });
+
+  it("falls back to original input when updatedInput is null", () => {
+    const result = normalizeBridgeAllowDecision(
+      { behavior: "allow", updatedInput: null },
+      ORIG_INPUT,
+    );
+    expect(result).toEqual({ behavior: "allow", updatedInput: ORIG_INPUT });
+  });
+
+  it("falls back to original input when updatedInput is a non-object (string/number)", () => {
+    const r1 = normalizeBridgeAllowDecision(
+      { behavior: "allow", updatedInput: "garbage" },
+      ORIG_INPUT,
+    );
+    expect(r1).toEqual({ behavior: "allow", updatedInput: ORIG_INPUT });
+
+    const r2 = normalizeBridgeAllowDecision(
+      { behavior: "allow", updatedInput: 42 },
+      ORIG_INPUT,
+    );
+    expect(r2).toEqual({ behavior: "allow", updatedInput: ORIG_INPUT });
+  });
+
+  it("deny → behavior=deny + custom message (ExitPlanMode reject feedback flow)", () => {
+    const result = normalizeBridgeAllowDecision(
+      { behavior: "deny", message: "rethink the migration" },
+      ORIG_INPUT,
+    );
+    expect(result).toEqual({ behavior: "deny", message: "rethink the migration" });
+  });
+
+  it("deny without message → defaults to 'user declined'", () => {
+    const result = normalizeBridgeAllowDecision({ behavior: "deny" }, ORIG_INPUT);
+    expect(result).toEqual({ behavior: "deny", message: "user declined" });
+  });
+
+  it("deny with non-string message → safely defaults", () => {
+    const result = normalizeBridgeAllowDecision(
+      { behavior: "deny", message: 12345 },
+      ORIG_INPUT,
+    );
+    expect(result).toEqual({ behavior: "deny", message: "user declined" });
+  });
+
+  it("invalid decision (null/string/wrong type) → deny with safe message", () => {
+    expect(normalizeBridgeAllowDecision(null, ORIG_INPUT)).toEqual({
+      behavior: "deny",
+      message: "host returned invalid decision",
+    });
+    expect(normalizeBridgeAllowDecision("garbage", ORIG_INPUT)).toEqual({
+      behavior: "deny",
+      message: "host returned invalid decision",
+    });
+    expect(normalizeBridgeAllowDecision(undefined, ORIG_INPUT)).toEqual({
+      behavior: "deny",
+      message: "host returned invalid decision",
+    });
+  });
+
+  it("decision with unknown behavior → coerced to deny (defensive)", () => {
+    const result = normalizeBridgeAllowDecision({ behavior: "ask" }, ORIG_INPUT);
+    expect(result.behavior).toBe("deny");
+  });
+
+  it("does NOT mutate the original input", () => {
+    const input = { questions: [{ question: "Q?" }] };
+    const before = JSON.stringify(input);
+    normalizeBridgeAllowDecision({ behavior: "allow" }, input);
+    expect(JSON.stringify(input)).toBe(before);
+  });
+});

--- a/src/__tests__/exit-plan-mode.test.tsx
+++ b/src/__tests__/exit-plan-mode.test.tsx
@@ -6,15 +6,20 @@
  * Visual: §8.3.
  *
  * Approve / Reject only — no Modify (locked decision §0.4, TUI parity).
+ *
+ * The card responds via the `canUseTool` permission channel:
+ *   - Approve  →  onAllow()                 (SDK runs the tool, mode flips)
+ *   - Reject   →  onDeny(feedback || "")    (SDK ends turn with deny msg)
+ *
+ * The host wraps these into `_hermes_perm_response` envelopes — see
+ * permissionRequest.ts.  No tool_result envelope is ever written by
+ * the host for ExitPlanMode (that was the v1 silent-drop bug).
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
-import {
-  isExitPlanModeToolUse,
-  buildExitPlanResult,
-} from "../utils/exitPlanMode";
+import { isExitPlanModeToolUse } from "../utils/exitPlanMode";
 import { ExitPlanModeCard } from "../components/ExitPlanModeCard";
 
 const SAMPLE_INPUT = {
@@ -28,23 +33,9 @@ describe("isExitPlanModeToolUse (ep-1)", () => {
   it("returns false for other tool names", () => {
     expect(isExitPlanModeToolUse({ type: "tool_use", id: "tu", name: "Bash", input: {} })).toBe(false);
   });
-});
-
-describe("buildExitPlanResult (ep-4, ep-5)", () => {
-  it("ep-4: approve → tool_result {accept: true}", () => {
-    const env = buildExitPlanResult("tu_1", { accept: true });
-    const parsed = JSON.parse((env.message.content[0] as { content: string }).content);
-    expect(parsed).toEqual({ accept: true });
-  });
-  it("ep-5: reject with feedback", () => {
-    const env = buildExitPlanResult("tu_1", { accept: false, feedback: "rethink" });
-    const parsed = JSON.parse((env.message.content[0] as { content: string }).content);
-    expect(parsed).toEqual({ accept: false, feedback: "rethink" });
-  });
-  it("ep-11: reject without feedback (empty allowed)", () => {
-    const env = buildExitPlanResult("tu_1", { accept: false });
-    const parsed = JSON.parse((env.message.content[0] as { content: string }).content);
-    expect(parsed).toEqual({ accept: false });
+  it("returns false for null/undefined", () => {
+    expect(isExitPlanModeToolUse(null)).toBe(false);
+    expect(isExitPlanModeToolUse(undefined)).toBe(false);
   });
 });
 
@@ -54,10 +45,10 @@ describe("ExitPlanModeCard — render (ep-2, ep-3, ep-7)", () => {
   it("ep-2: renders the plan content (markdown text visible)", () => {
     render(
       <ExitPlanModeCard
-        toolUseId="tu_1"
         input={SAMPLE_INPUT}
         permissionMode="plan"
-        onSubmit={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     expect(screen.getByText(/update foo/i)).toBeInTheDocument();
@@ -67,10 +58,10 @@ describe("ExitPlanModeCard — render (ep-2, ep-3, ep-7)", () => {
   it("ep-3: shows Approve and Reject buttons; NO Modify button (TUI parity)", () => {
     render(
       <ExitPlanModeCard
-        toolUseId="tu_1"
         input={SAMPLE_INPUT}
         permissionMode="plan"
-        onSubmit={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     expect(screen.getByRole("button", { name: /approve/i })).toBeInTheDocument();
@@ -81,10 +72,10 @@ describe("ExitPlanModeCard — render (ep-2, ep-3, ep-7)", () => {
   it("ep-7: PLAN MODE banner shown when permissionMode=plan", () => {
     render(
       <ExitPlanModeCard
-        toolUseId="tu_1"
         input={SAMPLE_INPUT}
         permissionMode="plan"
-        onSubmit={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     expect(screen.getByText(/plan mode/i)).toBeInTheDocument();
@@ -93,63 +84,117 @@ describe("ExitPlanModeCard — render (ep-2, ep-3, ep-7)", () => {
   it("ep-7-b: no banner when permissionMode=default", () => {
     render(
       <ExitPlanModeCard
-        toolUseId="tu_1"
         input={SAMPLE_INPUT}
         permissionMode="default"
-        onSubmit={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     expect(screen.queryByText(/plan mode/i)).toBeNull();
   });
-});
 
-describe("ExitPlanModeCard — submit (ep-4, ep-5)", () => {
-  afterEach(() => cleanup());
-
-  it("ep-4: clicking Approve fires onSubmit({accept: true})", () => {
-    const onSubmit = vi.fn();
-    render(
+  it("renders dialogId as data-dialog-id for tracing", () => {
+    const { container } = render(
       <ExitPlanModeCard
-        toolUseId="tu_1"
+        dialogId="perm-99"
         input={SAMPLE_INPUT}
         permissionMode="plan"
-        onSubmit={onSubmit}
+        onAllow={() => {}}
+        onDeny={() => {}}
+      />,
+    );
+    expect(container.querySelector('[data-dialog-id="perm-99"]')).not.toBeNull();
+  });
+});
+
+describe("ExitPlanModeCard — approve / deny (ep-4, ep-5)", () => {
+  afterEach(() => cleanup());
+
+  it("ep-4: clicking Approve fires onAllow", () => {
+    const onAllow = vi.fn();
+    const onDeny = vi.fn();
+    render(
+      <ExitPlanModeCard
+        input={SAMPLE_INPUT}
+        permissionMode="plan"
+        onAllow={onAllow}
+        onDeny={onDeny}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /approve/i }));
-    expect(onSubmit).toHaveBeenCalledWith({ accept: true });
+    expect(onAllow).toHaveBeenCalledTimes(1);
+    expect(onDeny).not.toHaveBeenCalled();
   });
 
-  it("ep-5: clicking Reject opens feedback box; submitting fires onSubmit({accept: false, feedback})", () => {
-    const onSubmit = vi.fn();
+  it("ep-5: clicking Reject opens feedback box; submitting fires onDeny(feedback)", () => {
+    const onAllow = vi.fn();
+    const onDeny = vi.fn();
     render(
       <ExitPlanModeCard
-        toolUseId="tu_1"
         input={SAMPLE_INPUT}
         permissionMode="plan"
-        onSubmit={onSubmit}
+        onAllow={onAllow}
+        onDeny={onDeny}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /reject/i }));
     const textarea = screen.getByPlaceholderText(/why are you rejecting/i);
     fireEvent.change(textarea, { target: { value: "needs more research" } });
     fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
-    expect(onSubmit).toHaveBeenCalledWith({ accept: false, feedback: "needs more research" });
+    expect(onDeny).toHaveBeenCalledWith("needs more research");
+    expect(onAllow).not.toHaveBeenCalled();
   });
 
-  it("ep-5-b: confirming reject without feedback also fires (empty allowed per ep-11)", () => {
-    const onSubmit = vi.fn();
+  it("ep-5-b: confirming reject without feedback fires onDeny('') (empty string allowed)", () => {
+    const onDeny = vi.fn();
     render(
       <ExitPlanModeCard
-        toolUseId="tu_1"
         input={SAMPLE_INPUT}
         permissionMode="plan"
-        onSubmit={onSubmit}
+        onAllow={() => {}}
+        onDeny={onDeny}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /reject/i }));
     fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
-    expect(onSubmit).toHaveBeenCalledWith({ accept: false });
+    expect(onDeny).toHaveBeenCalledWith("");
+  });
+
+  it("ep-5-c: rejecting trims whitespace from feedback", () => {
+    const onDeny = vi.fn();
+    render(
+      <ExitPlanModeCard
+        input={SAMPLE_INPUT}
+        permissionMode="plan"
+        onAllow={() => {}}
+        onDeny={onDeny}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reject/i }));
+    fireEvent.change(screen.getByPlaceholderText(/why are you rejecting/i), {
+      target: { value: "   needs work   " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+    expect(onDeny).toHaveBeenCalledWith("needs work");
+  });
+
+  it("cancel button on the reject form returns to the approve/reject screen", () => {
+    const onAllow = vi.fn();
+    const onDeny = vi.fn();
+    render(
+      <ExitPlanModeCard
+        input={SAMPLE_INPUT}
+        permissionMode="plan"
+        onAllow={onAllow}
+        onDeny={onDeny}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reject/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    // Back to the approve/reject screen.
+    expect(screen.getByRole("button", { name: /approve/i })).toBeInTheDocument();
+    expect(onAllow).not.toHaveBeenCalled();
+    expect(onDeny).not.toHaveBeenCalled();
   });
 });
 
@@ -159,10 +204,10 @@ describe("ExitPlanModeCard — failure modes (ep-9, ep-10)", () => {
   it("ep-10: empty plan → renders 'no plan provided' message", () => {
     render(
       <ExitPlanModeCard
-        toolUseId="tu_1"
         input={{ plan: "" }}
         permissionMode="default"
-        onSubmit={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     expect(screen.getByText(/no plan provided/i)).toBeInTheDocument();
@@ -171,10 +216,10 @@ describe("ExitPlanModeCard — failure modes (ep-9, ep-10)", () => {
   it("ep-9: HTML in markdown is escaped (no XSS)", () => {
     const { container } = render(
       <ExitPlanModeCard
-        toolUseId="tu_1"
         input={{ plan: "<script>alert(1)</script>raw text" }}
         permissionMode="default"
-        onSubmit={() => {}}
+        onAllow={() => {}}
+        onDeny={() => {}}
       />,
     );
     expect(container.querySelector("script")).toBeNull();

--- a/src/__tests__/generic-tool-block.test.tsx
+++ b/src/__tests__/generic-tool-block.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+/**
+ * GenericToolBlock — fallback renderer.
+ *
+ * The previous renderer dumped pretty-printed JSON inside an
+ * unbounded `<pre>` element with no collapse affordance.  The
+ * redesigned version surfaces a one-line summary inline with the
+ * tool name; the full payload is hidden behind a disclosure that
+ * mounts a syntax-highlighted CodeFence on demand.
+ *
+ * These tests pin: (a) the summary chip surfaces the right hint
+ * given the tool's input shape, (b) the JSON code fence is NOT in
+ * the DOM until the user clicks "input", (c) long results get
+ * their own disclosure rather than rendering inline.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+import { GenericToolBlock } from "../agent/blocks/GenericToolBlock";
+import type { ToolResultBlockData, ToolUseBlockData } from "../agent/types";
+
+function tu(name: string, input: unknown): ToolUseBlockData {
+  return {
+    type: "tool_use",
+    id: "tu_test",
+    name,
+    input: input as Record<string, unknown>,
+  };
+}
+
+function tr(content: string | ToolResultBlockData["content"], isError = false): ToolResultBlockData {
+  return {
+    type: "tool_result",
+    tool_use_id: "tu_test",
+    content,
+    is_error: isError,
+  };
+}
+
+describe("GenericToolBlock — input summary chip", () => {
+  afterEach(() => cleanup());
+
+  it("surfaces a `command:` hint when input has a Bash-like shape", () => {
+    render(<GenericToolBlock block={tu("MystTool", { command: "ls -la" })} result={undefined} />);
+    expect(screen.getByText(/command: ls -la/)).toBeInTheDocument();
+  });
+
+  it("surfaces just the path when input has a file_path shape", () => {
+    render(<GenericToolBlock block={tu("MystTool", { file_path: "/etc/hosts" })} result={undefined} />);
+    expect(screen.getByText("/etc/hosts")).toBeInTheDocument();
+  });
+
+  it("falls back to key count on generic shapes", () => {
+    render(<GenericToolBlock block={tu("MystTool", { a: 1, b: 2 })} result={undefined} />);
+    expect(screen.getByText(/^2 keys · /)).toBeInTheDocument();
+  });
+
+  it("renders empty marker for an empty input object", () => {
+    render(<GenericToolBlock block={tu("MystTool", {})} result={undefined} />);
+    expect(screen.getByText(/empty object/i)).toBeInTheDocument();
+  });
+});
+
+describe("GenericToolBlock — input disclosure", () => {
+  afterEach(() => cleanup());
+
+  it("does NOT render the code fence until the user clicks `input`", () => {
+    render(
+      <GenericToolBlock
+        block={tu("MystTool", { command: "ls" })}
+        result={undefined}
+      />,
+    );
+    // No <code> element with hljs class in the initial render.
+    expect(document.querySelector(".hljs")).toBeNull();
+  });
+
+  it("clicking the toggle reveals the highlighted JSON fence", () => {
+    render(
+      <GenericToolBlock
+        block={tu("MystTool", { command: "ls" })}
+        result={undefined}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /show tool input|hide tool input/i }));
+    // After click, the toggle says "hide" and the JSON fence is mounted.
+    expect(screen.getByRole("button", { name: /hide tool input/i })).toBeInTheDocument();
+    expect(document.querySelector(".agent-tool-generic-input-body .agent-code-fence")).not.toBeNull();
+  });
+
+  it("clicking again collapses the fence back", () => {
+    render(
+      <GenericToolBlock
+        block={tu("MystTool", { command: "ls" })}
+        result={undefined}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /show tool input/i });
+    fireEvent.click(btn);
+    fireEvent.click(screen.getByRole("button", { name: /hide tool input/i }));
+    expect(document.querySelector(".agent-tool-generic-input-body")).toBeNull();
+  });
+
+  it("aria-expanded stays in sync with disclosure state", () => {
+    render(
+      <GenericToolBlock
+        block={tu("MystTool", { command: "ls" })}
+        result={undefined}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /input/i });
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-expanded", "true");
+  });
+});
+
+describe("GenericToolBlock — result rendering", () => {
+  afterEach(() => cleanup());
+
+  it("short result renders inline without a disclosure", () => {
+    render(
+      <GenericToolBlock
+        block={tu("MystTool", { command: "ls" })}
+        result={tr("ok")}
+      />,
+    );
+    expect(screen.getByText("ok")).toBeInTheDocument();
+    expect(screen.queryByText(/result · /)).toBeNull();
+  });
+
+  it("long result (>240 chars) is wrapped in a <details> with a `result · N lines` summary", () => {
+    const longResult = "line\n".repeat(20) + "x".repeat(300);
+    render(
+      <GenericToolBlock
+        block={tu("MystTool", { command: "ls" })}
+        result={tr(longResult)}
+      />,
+    );
+    // Disclosure summary present.
+    expect(screen.getByText(/result · \d+ lines/)).toBeInTheDocument();
+  });
+
+  it("running tool (no result yet) shows data-status=running", () => {
+    const { container } = render(
+      <GenericToolBlock block={tu("MystTool", {})} result={undefined} />,
+    );
+    expect(container.querySelector('[data-status="running"]')).not.toBeNull();
+  });
+
+  it("error result sets data-status=error", () => {
+    const { container } = render(
+      <GenericToolBlock
+        block={tu("MystTool", {})}
+        result={tr("boom", true)}
+      />,
+    );
+    expect(container.querySelector('[data-status="error"]')).not.toBeNull();
+  });
+
+  it("success result sets data-status=success", () => {
+    const { container } = render(
+      <GenericToolBlock
+        block={tu("MystTool", {})}
+        result={tr("ok")}
+      />,
+    );
+    expect(container.querySelector('[data-status="success"]')).not.toBeNull();
+  });
+});

--- a/src/__tests__/json-summary.test.ts
+++ b/src/__tests__/json-summary.test.ts
@@ -1,0 +1,142 @@
+/**
+ * `summarizeJsonInput` — tool-input micro-summary helper.
+ *
+ * The agent timeline used to dump pretty-printed JSON in an
+ * unbounded `<pre>` whenever a tool input didn't match a known
+ * family.  The summary helper replaces that with a one-line hint;
+ * the full payload is one disclosure click away.
+ *
+ * These tests pin the formatting so callers can rely on the inline
+ * label staying readable across upgrades.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  summarizeJsonInput,
+  prettyJson,
+  formatBytes,
+} from "../utils/jsonSummary";
+
+describe("summarizeJsonInput — primitives", () => {
+  it("null / undefined → '(empty)'", () => {
+    expect(summarizeJsonInput(null).text).toBe("(empty)");
+    expect(summarizeJsonInput(undefined).text).toBe("(empty)");
+  });
+
+  it("string → quoted, truncated past 64 chars", () => {
+    expect(summarizeJsonInput("hello").text).toBe('"hello"');
+    expect(summarizeJsonInput("").text).toBe("(empty string)");
+    const long = "x".repeat(120);
+    const out = summarizeJsonInput(long).text;
+    // wrapped in quotes; truncated body inside ends with ellipsis.
+    expect(out.length).toBeLessThan(70);
+    expect(out.startsWith('"')).toBe(true);
+    expect(out.endsWith('"')).toBe(true);
+    expect(out.includes('…')).toBe(true);
+  });
+
+  it("number / boolean → stringified", () => {
+    expect(summarizeJsonInput(42).text).toBe("42");
+    expect(summarizeJsonInput(true).text).toBe("true");
+    expect(summarizeJsonInput(false).text).toBe("false");
+  });
+});
+
+describe("summarizeJsonInput — arrays", () => {
+  it("empty array → marker", () => {
+    expect(summarizeJsonInput([]).text).toBe("[ ] (empty array)");
+  });
+
+  it("single item / multi item plurals", () => {
+    expect(summarizeJsonInput([1]).text).toMatch(/^\[1 item\]/);
+    expect(summarizeJsonInput([1, 2, 3]).text).toMatch(/^\[3 items\]/);
+  });
+
+  it("includes byte size hint", () => {
+    const out = summarizeJsonInput([1, 2, 3]).text;
+    expect(out).toMatch(/· \d+ B$/);
+  });
+});
+
+describe("summarizeJsonInput — objects (smart shapes)", () => {
+  it("`command` shape is surfaced verbatim (Bash-like)", () => {
+    expect(summarizeJsonInput({ command: "git status -s" }).text).toBe(
+      "command: git status -s",
+    );
+  });
+
+  it("`file_path` shape shows the path only (Read/Edit-like)", () => {
+    expect(summarizeJsonInput({ file_path: "/tmp/foo.ts" }).text).toBe("/tmp/foo.ts");
+  });
+
+  it("`pattern` shape shows the pattern (Grep-like)", () => {
+    expect(summarizeJsonInput({ pattern: "TODO\\(.*\\)" }).text).toBe(
+      "pattern: TODO\\(.*\\)",
+    );
+  });
+
+  it("`url` shape surfaces the URL (Fetch-like)", () => {
+    expect(summarizeJsonInput({ url: "https://example.com/api" }).text).toBe(
+      "https://example.com/api",
+    );
+  });
+
+  it("generic object → key count + size", () => {
+    const out = summarizeJsonInput({ a: 1, b: 2, c: 3 }).text;
+    expect(out).toMatch(/^3 keys · /);
+  });
+
+  it("single-key object uses singular noun", () => {
+    const out = summarizeJsonInput({ foo: { nested: true } }).text;
+    expect(out).toMatch(/^1 key · /);
+  });
+
+  it("empty object → marker", () => {
+    expect(summarizeJsonInput({}).text).toBe("{ } (empty object)");
+  });
+
+  it("smart-shape value gets truncated when too long", () => {
+    const longCmd = "echo " + "x".repeat(200);
+    const out = summarizeJsonInput({ command: longCmd }).text;
+    expect(out.length).toBeLessThan(80);
+    expect(out.startsWith("command: echo ")).toBe(true);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it("non-string command field falls through to generic key-count", () => {
+    expect(summarizeJsonInput({ command: 42, extra: 1 }).text).toMatch(
+      /^2 keys · /,
+    );
+  });
+});
+
+describe("formatBytes", () => {
+  it("under 1024 → bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(523)).toBe("523 B");
+  });
+  it("kilobytes with decimal under 100 KB", () => {
+    expect(formatBytes(2048)).toBe("2.0 KB");
+    expect(formatBytes(50000)).toBe("48.8 KB");
+  });
+  it("integer kilobytes between 100–1024 KB", () => {
+    expect(formatBytes(200_000)).toBe("195 KB");
+  });
+  it("megabytes past 1 MB", () => {
+    expect(formatBytes(2_000_000)).toBe("1.9 MB");
+  });
+});
+
+describe("prettyJson", () => {
+  it("indents with 2 spaces", () => {
+    expect(prettyJson({ a: 1 })).toBe('{\n  "a": 1\n}');
+  });
+
+  it("falls back gracefully on circular references", () => {
+    const a: Record<string, unknown> = {};
+    a.self = a;
+    // Should NOT throw — falls back to String(input).
+    const out = prettyJson(a);
+    expect(typeof out).toBe("string");
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/permission-modal.test.tsx
+++ b/src/__tests__/permission-modal.test.tsx
@@ -47,11 +47,49 @@ describe("buildPermResponse (pm-4, pm-5)", () => {
       decision: { behavior: "allow", updatedInput: edited },
     });
   });
-  it("pm-5: deny → behavior=deny + message", () => {
+  it("pm-5: deny → behavior=deny + default message", () => {
     expect(buildPermResponse("req_1", { kind: "deny" })).toEqual({
       type: "_hermes_perm_response",
       id: "req_1",
       decision: { behavior: "deny", message: "user declined" },
+    });
+  });
+
+  it("pm-5-b: deny with custom message (ExitPlanMode rejection feedback flow)", () => {
+    expect(
+      buildPermResponse("req_1", { kind: "deny", message: "rethink the migration step" }),
+    ).toEqual({
+      type: "_hermes_perm_response",
+      id: "req_1",
+      decision: { behavior: "deny", message: "rethink the migration step" },
+    });
+  });
+
+  it("pm-5-c: deny with empty/whitespace message falls back to 'user declined'", () => {
+    expect(
+      buildPermResponse("req_1", { kind: "deny", message: "   " }),
+    ).toEqual({
+      type: "_hermes_perm_response",
+      id: "req_1",
+      decision: { behavior: "deny", message: "user declined" },
+    });
+  });
+
+  it("pm-4-c: REGRESSION (zod-error fix) — allow ALWAYS includes updatedInput when supplied", () => {
+    // The bridge's canUseTool callback fails Zod validation if it
+    // returns `{behavior: "allow"}` without an `updatedInput` record.
+    // The host echoes the original input when not editing.  This
+    // builder must support both shapes losslessly.
+    const noEdit = buildPermResponse("req_2", { kind: "allow" });
+    expect(noEdit.decision).toEqual({ behavior: "allow" });
+
+    const edited = buildPermResponse("req_3", {
+      kind: "allow",
+      updatedInput: { questions: [], answers: { "q?": "yes" } },
+    });
+    expect(edited.decision).toEqual({
+      behavior: "allow",
+      updatedInput: { questions: [], answers: { "q?": "yes" } },
     });
   });
 });

--- a/src/__tests__/theme-archetype-tokens.test.ts
+++ b/src/__tests__/theme-archetype-tokens.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Archetype paint tokens — every theme either inherits the default
+ * paper-cards archetype or sets its own archetype tokens cleanly.
+ *
+ * This test parses themes.css and asserts:
+ *   1. The 30 expected themes are all defined.
+ *   2. Themes that opt INTO an archetype set ALL the tokens of that
+ *      archetype (no half-applied paint).
+ *   3. The bespoke per-theme touches reference real tokens (no
+ *      `var(--undefined)` references).
+ *
+ * The goal isn't pixel-level visual coverage — it's protection
+ * against the kind of token-drift regression that would silently
+ * give a single theme broken chrome.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+let themesCss = "";
+let tokensCss = "";
+
+beforeAll(() => {
+  themesCss = readFileSync(resolve(__dirname, "../styles/themes.css"), "utf8");
+  tokensCss = readFileSync(resolve(__dirname, "../styles/tokens.css"), "utf8");
+});
+
+const EXPECTED_THEMES = [
+  "80s", "amber", "cobalt", "corporate", "data", "designer", "duel",
+  "evergreen", "frosted-dark", "frosted-light", "hacker", "lavender",
+  "light", "macchiato", "midnight", "minimal-dark", "mint", "neon-sunset",
+  "nightowl", "polar", "rainbow", "reactor", "rose", "sand", "shibuya",
+  "solarized", "solarized-dark", "transilvania", "tron",
+];
+
+describe("themes.css — archetype paint coverage", () => {
+  it("every expected theme has at least one rule defined", () => {
+    for (const t of EXPECTED_THEMES) {
+      const re = new RegExp(`html\\[data-theme=["']${t}["']\\]`);
+      expect(themesCss).toMatch(re);
+    }
+  });
+
+  it("tokens.css defines the four core archetype tokens with default values", () => {
+    expect(tokensCss).toMatch(/--tool-card-bg:\s*var\(--bg-1\)/);
+    expect(tokensCss).toMatch(/--tool-card-border:\s*1px solid var\(--rule-strong/);
+    expect(tokensCss).toMatch(/--tool-card-radius:\s*var\(--radius\)/);
+    expect(tokensCss).toMatch(/--tool-card-shadow:\s*none/);
+    expect(tokensCss).toMatch(/--tool-card-backdrop:\s*none/);
+  });
+
+  it("glass-cards family (nightowl, frosted-*) sets backdrop blur", () => {
+    const glassSection = themesCss.match(
+      /html\[data-theme=["']nightowl["']\][\s\S]*?--tool-card-backdrop:\s*blur/,
+    );
+    expect(glassSection).not.toBeNull();
+  });
+
+  it("hairline-rules family (minimal-dark) zeroes out card chrome", () => {
+    const block = themesCss.match(
+      /html\[data-theme=["']minimal-dark["']\][\s\S]*?--tool-card-bg:\s*transparent/,
+    );
+    expect(block).not.toBeNull();
+  });
+
+  it("CRT-blocks family (hacker, 80s, midnight) uses sharp corners", () => {
+    const crtBlock = themesCss.match(
+      /html\[data-theme=["']hacker["'][\s\S]{0,600}?--tool-card-radius:\s*0/,
+    );
+    expect(crtBlock).not.toBeNull();
+  });
+});
+
+describe("themes.css — bespoke per-theme touches", () => {
+  it("hacker theme adds scanline gradient on tool cards", () => {
+    expect(themesCss).toMatch(
+      /html\[data-theme=["']hacker["']\][\s\S]*?repeating-linear-gradient/,
+    );
+  });
+
+  it("designer theme adds an SVG noise paper grain", () => {
+    expect(themesCss).toMatch(
+      /html\[data-theme=["']designer["']\][\s\S]*?feTurbulence/,
+    );
+  });
+
+  it("tron theme adds a pulsing rail keyframe animation", () => {
+    expect(themesCss).toMatch(/@keyframes\s+tron-rail-pulse/);
+  });
+
+  it("rainbow theme adds a gradient rail animation", () => {
+    expect(themesCss).toMatch(/@keyframes\s+rainbow-rail-shift/);
+  });
+
+  it("animations respect prefers-reduced-motion", () => {
+    // Every keyframe-driven theme must opt-out under reduced motion —
+    // this catches a future contributor adding an animation without
+    // the corresponding @media guard.
+    const animationKeyframes = themesCss.match(/@keyframes\s+(tron-rail-pulse|rainbow-rail-shift)/g) ?? [];
+    expect(animationKeyframes.length).toBeGreaterThan(0);
+    const reducedMotionGuards = themesCss.match(/@media \(prefers-reduced-motion: reduce\)/g) ?? [];
+    expect(reducedMotionGuards.length).toBeGreaterThanOrEqual(animationKeyframes.length);
+  });
+});
+
+describe("themes.css — defensive token usage", () => {
+  it("no archetype rule references an undefined custom property", () => {
+    // Pull every var(--…) reference inside the archetype block and
+    // verify each token is defined SOMEWHERE in either tokens.css or
+    // themes.css.  Catches a typo like `var(--tool-card-redius)`.
+    const archetypeStart = themesCss.indexOf("Agent Timeline · Archetype Paint");
+    expect(archetypeStart).toBeGreaterThan(0);
+    const archetypeBlock = themesCss.slice(archetypeStart);
+    const refs = Array.from(archetypeBlock.matchAll(/var\(--([a-z0-9-]+)\b/gi))
+      .map((m) => m[1]);
+    expect(refs.length).toBeGreaterThan(0);
+    const definedTokens = new Set<string>();
+    for (const css of [tokensCss, themesCss]) {
+      for (const m of css.matchAll(/--([a-z0-9-]+):/gi)) {
+        definedTokens.add(m[1]);
+      }
+    }
+    const undef = refs.filter((r) => !definedTokens.has(r));
+    expect(undef).toEqual([]);
+  });
+});

--- a/src/__tests__/theme-archetype-tokens.test.ts
+++ b/src/__tests__/theme-archetype-tokens.test.ts
@@ -103,6 +103,53 @@ describe("themes.css — bespoke per-theme touches", () => {
   });
 });
 
+describe("themes.css — round 2 whole-timeline distinction", () => {
+  it("brass remap selectors target every non-warm theme", () => {
+    // The user-message left bar tracks each theme's accent so every
+    // theme reads as its identity, not the same warm sandstone.
+    // Themes that keep the warm sandstone (designer / sand / rose)
+    // are NOT in this remap.
+    const block = themesCss.match(
+      /Brass remap[\s\S]*?--brass:\s*var\(--accent\)/,
+    );
+    expect(block).not.toBeNull();
+  });
+
+  it("every CRT theme paints scanlines on the conversation surface, not just tool cards", () => {
+    // The repeating-linear-gradient for CRT scanlines must appear
+    // on .agent-session-scroll (the whole conversation surface),
+    // proving the round-2 widening landed.
+    const scope = themesCss.match(
+      /\.agent-session-scroll[\s\S]{0,400}repeating-linear-gradient/,
+    );
+    expect(scope).not.toBeNull();
+  });
+
+  it("editorial-margin family paints paper grain on the conversation surface", () => {
+    const scope = themesCss.match(
+      /\.agent-session-scroll[\s\S]{0,1000}feTurbulence/,
+    );
+    expect(scope).not.toBeNull();
+  });
+
+  it("masthead sweep animation has a reduced-motion guard", () => {
+    expect(themesCss).toMatch(/@keyframes\s+masthead-sweep/);
+    // Reduced-motion guard exists somewhere after the keyframe.
+    const idx = themesCss.indexOf("@keyframes masthead-sweep");
+    expect(idx).toBeGreaterThan(0);
+    const tail = themesCss.slice(idx);
+    expect(tail).toMatch(/prefers-reduced-motion: reduce/);
+  });
+
+  it("turn separators vary per family (CRT thickens, glass fades, editorial softens)", () => {
+    // Each family's turn-rule override targets the .agent-message +
+    // .agent-message[data-role="user"] selector.
+    expect(themesCss).toMatch(/hacker[\s\S]*?\.agent-message \+ \.agent-message\[data-role="user"\]/);
+    expect(themesCss).toMatch(/designer[\s\S]*?\.agent-message \+ \.agent-message\[data-role="user"\]/);
+    expect(themesCss).toMatch(/nightowl[\s\S]*?\.agent-message \+ \.agent-message\[data-role="user"\]/);
+  });
+});
+
 describe("themes.css — defensive token usage", () => {
   it("no archetype rule references an undefined custom property", () => {
     // Pull every var(--…) reference inside the archetype block and

--- a/src/__tests__/use-agent-init.test.ts
+++ b/src/__tests__/use-agent-init.test.ts
@@ -62,4 +62,49 @@ describe("reduceInit", () => {
     const ev: AgentEvent = { type: "result", subtype: "success", is_error: false };
     expect(reduceInit(null, ev)).toBeNull();
   });
+
+  // ─── two-way picker sync (state-changed) ───────────────────────────
+  //
+  // The bridge emits `_hermes_state_changed` whenever its live model /
+  // permissionMode drifts mid-session (EnterPlanMode flips perm mode
+  // without spawning a new init).  reduceInit must patch the cached
+  // init so the composer's chip pickers reflect Claude's reality
+  // without waiting for a respawn.
+
+  it("state-changed: patches permissionMode on existing init (EnterPlanMode flow)", () => {
+    const seeded = makeInit({ permissionMode: "default", model: "claude-opus-4-7" });
+    const next = reduceInit(seeded, {
+      type: "_hermes_state_changed",
+      session_id: "abc",
+      permissionMode: "plan",
+    });
+    expect(next).not.toBe(seeded);
+    expect(next?.permissionMode).toBe("plan");
+    expect(next?.model).toBe("claude-opus-4-7");
+  });
+
+  it("state-changed: patches model when /model is invoked mid-session", () => {
+    const seeded = makeInit({ model: "claude-sonnet-4-6", permissionMode: "default" });
+    const next = reduceInit(seeded, {
+      type: "_hermes_state_changed",
+      model: "claude-opus-4-7",
+    });
+    expect(next?.model).toBe("claude-opus-4-7");
+    expect(next?.permissionMode).toBe("default");
+  });
+
+  it("state-changed: ignored when no prior init exists (don't fabricate one)", () => {
+    const next = reduceInit(null, {
+      type: "_hermes_state_changed",
+      permissionMode: "plan",
+    });
+    expect(next).toBeNull();
+  });
+
+  it("state-changed: omitted fields don't overwrite their existing values", () => {
+    const seeded = makeInit({ model: "x", permissionMode: "default" });
+    const next = reduceInit(seeded, { type: "_hermes_state_changed" });
+    expect(next?.model).toBe("x");
+    expect(next?.permissionMode).toBe("default");
+  });
 });

--- a/src/agent/AgentSessionView.tsx
+++ b/src/agent/AgentSessionView.tsx
@@ -446,16 +446,23 @@ function AgentHeader({ state, sessionId, workspacePathCount }: AgentHeaderProps)
 
   const cwdLabel = cwd ? cwd.split("/").pop() ?? cwd : null;
 
+  // Three-zone grid: [status] [title] [meta].  Title is the only
+  // flexible cell; it truncates with ellipsis on narrow panes so the
+  // meta zone (cost · STOP) never gets pushed off-screen.  STOP lives
+  // in the meta zone — far from the title's growth axis.
+  const showCwdFull = cwd && workspacePathCount <= 1;
   return (
     <div className="agent-session-header">
-      <div className="agent-session-header-left">
+      <div className="agent-session-header-status">
         <span
           className="agent-session-status-dot"
           data-state={dotState}
           aria-hidden="true"
         />
         <span className="agent-session-flag">AGENT</span>
-        <span className="agent-session-flag-sep" aria-hidden="true">·</span>
+      </div>
+
+      <div className="agent-session-header-title">
         {isWorking ? (
           <>
             <span className="agent-session-ticker">{tickerLabel}</span>
@@ -465,23 +472,6 @@ function AgentHeader({ state, sessionId, workspacePathCount }: AgentHeaderProps)
                 <ElapsedCounter since={activity.since} />
               </>
             ) : null}
-            {/* Stop button — sends a soft interrupt via the bridge's
-                control protocol.  Bridge stays alive; just cancels the
-                current turn.  Available whenever Claude is doing something
-                we'd want to be able to cancel. */}
-            <button
-              type="button"
-              className="agent-session-stop"
-              onClick={() => {
-                softInterruptAgent(sessionId).catch((err) =>
-                  console.warn("[agent] soft-interrupt failed:", err),
-                );
-              }}
-              title="Stop this turn (Esc)"
-              aria-label="Stop the current turn"
-            >
-              ◼ STOP
-            </button>
           </>
         ) : (
           <>
@@ -500,24 +490,40 @@ function AgentHeader({ state, sessionId, workspacePathCount }: AgentHeaderProps)
             )}
           </>
         )}
+        {showCwdFull ? (
+          <span className="agent-session-cwd" title={cwd}>{cwd}</span>
+        ) : null}
       </div>
-      <div className="agent-session-header-right">
+
+      <div className="agent-session-header-meta">
         {state.cumulativeCostUsd > 0 || state.cumulativeOutputTokens > 0 ? (
           <span
             className="agent-session-cost"
             title={`Session cost: $${state.cumulativeCostUsd.toFixed(4)}\nOutput tokens: ${state.cumulativeOutputTokens.toLocaleString()}`}
             aria-label={`session cost ${state.cumulativeCostUsd.toFixed(2)} dollars`}
           >
-            {`$${formatCost(state.cumulativeCostUsd)}`}
+            <span className="agent-session-cost-amount">{`$${formatCost(state.cumulativeCostUsd)}`}</span>
             <span className="agent-session-cost-sep" aria-hidden="true"> · </span>
-            {`${formatTokens(state.cumulativeOutputTokens)} out`}
+            <span className="agent-session-cost-tokens">{`${formatTokens(state.cumulativeOutputTokens)} out`}</span>
           </span>
         ) : null}
         {showRateNotice ? (
           <span className="agent-rate-notice">Rate limit · {rate!.status}</span>
         ) : null}
-        {cwd && workspacePathCount <= 1 ? (
-          <span className="agent-session-cwd" title={cwd}>{cwd}</span>
+        {isWorking ? (
+          <button
+            type="button"
+            className="agent-session-stop"
+            onClick={() => {
+              softInterruptAgent(sessionId).catch((err) =>
+                console.warn("[agent] soft-interrupt failed:", err),
+              );
+            }}
+            title="Stop this turn (Esc)"
+            aria-label="Stop the current turn"
+          >
+            ◼ STOP
+          </button>
         ) : null}
       </div>
     </div>

--- a/src/agent/AgentSessionView.tsx
+++ b/src/agent/AgentSessionView.tsx
@@ -27,16 +27,8 @@ import { ExitPlanModeCard } from "../components/ExitPlanModeCard";
 import { PermissionRequestModal } from "../components/PermissionRequestModal";
 import { PlanModeBanner } from "../components/PlanModeBanner";
 import { TodoPanel } from "../components/TodoPanel";
-import {
-  isAskUserQuestionToolUse,
-  buildAskAnswerEnvelope,
-  type AskUserQuestionInput,
-} from "../utils/askUserQuestion";
-import {
-  isExitPlanModeToolUse,
-  buildExitPlanResult,
-  type ExitPlanModeInput,
-} from "../utils/exitPlanMode";
+import type { AskUserQuestionInput } from "../utils/askUserQuestion";
+import type { ExitPlanModeInput } from "../utils/exitPlanMode";
 import {
   isPermRequest,
   buildPermResponse,
@@ -179,13 +171,12 @@ export function AgentSessionView({ sessionId, workspacePathCount }: AgentSession
           ),
         ));
 
-  // ─── Interactive tool detection ─────────────────────────────────
-  // Walk all assistant messages, find the latest unanswered tool_use of
-  // a known interactive type (AskUserQuestion, ExitPlanMode).  An
-  // unanswered tool_use is one whose `id` is not present in
-  // `state.toolResults`.  Render the corresponding card; suppress the
-  // composer (the user must answer before continuing).
-  const interactivePending = findPendingInteractive(state);
+  // ─── Interactive tools ───────────────────────────────────────────
+  // AskUserQuestion / ExitPlanMode are dispatched via the
+  // `_hermes_perm_request` stream from the bridge's canUseTool —
+  // see <InteractivePermissionDispatcher /> below.  That's the SDK's
+  // contract: the host injects answers as `updatedInput` rather than
+  // writing a tool_result envelope.  No tool_use scanning needed here.
   const todos = extractTodos(
     state.messages.flatMap((m) => (m.role === "assistant" ? m.blocks : [])),
   );
@@ -251,46 +242,15 @@ export function AgentSessionView({ sessionId, workspacePathCount }: AgentSession
           {/* Plan-mode banner — visible whenever Claude reports plan mode. */}
           <PlanModeBanner permissionMode={permissionMode} />
 
-          {/* Interactive cards — ExitPlanMode / AskUserQuestion.
-              `sendAgentEnvelope` retries-after-respawn so the user's
-              reply isn't dropped when the bridge has exited between
-              turns (M10). */}
-          {interactivePending?.kind === "ExitPlanMode" && (
-            <ExitPlanModeCard
-              toolUseId={interactivePending.toolUseId}
-              input={interactivePending.input}
-              permissionMode={permissionMode}
-              onSubmit={(decision) => {
-                sendAgentEnvelope(
-                  sessionId,
-                  buildExitPlanResult(interactivePending.toolUseId, decision),
-                ).catch((err) => console.warn("[ep] send failed:", err));
-              }}
-            />
-          )}
-          {interactivePending?.kind === "AskUserQuestion" && (
-            <AskUserQuestionCard
-              toolUseId={interactivePending.toolUseId}
-              input={interactivePending.input}
-              onSubmit={(answers) => {
-                sendAgentEnvelope(
-                  sessionId,
-                  buildAskAnswerEnvelope(interactivePending.toolUseId, answers),
-                ).catch((err) => console.warn("[aq] send failed:", err));
-              }}
-              onCancel={() => {
-                sendAgentEnvelope(
-                  sessionId,
-                  buildAskAnswerEnvelope(interactivePending.toolUseId, [], { cancelled: true }),
-                ).catch((err) => console.warn("[aq] cancel send failed:", err));
-              }}
-            />
-          )}
-
-          {/* Permission request modal — driven by NDJSON envelopes from
-              the bridge's canUseTool.  The hook listens on the agent
-              event stream for `_hermes_perm_request` types. */}
-          <PermissionRequestGate sessionId={sessionId} permissionMode={permissionMode} sendAgentEnvelope={sendAgentEnvelope} />
+          {/* All interactive tooling — AskUserQuestion, ExitPlanMode,
+              and the generic permission modal — is driven by
+              `_hermes_perm_request` envelopes from the bridge's
+              canUseTool.  The dispatcher routes by toolName. */}
+          <InteractivePermissionDispatcher
+            sessionId={sessionId}
+            permissionMode={permissionMode}
+            sendAgentEnvelope={sendAgentEnvelope}
+          />
         </div>
       </div>
     </div>
@@ -298,12 +258,25 @@ export function AgentSessionView({ sessionId, workspacePathCount }: AgentSession
 }
 
 /**
- * Bridge ⇄ frontend canUseTool gate.  Listens for `_hermes_perm_request`
- * envelopes on the agent stream, renders the modal, sends the user's
- * decision back via `sendAgentEnvelope` (retry-on-not-found, M10) as a
- * `_hermes_perm_response`.
+ * Bridge ⇄ frontend canUseTool dispatcher.
+ *
+ * Listens for `_hermes_perm_request` envelopes on the agent stream and
+ * routes each by tool name:
+ *
+ *   AskUserQuestion → <AskUserQuestionCard />     allow → updatedInput
+ *                                                  with answers record;
+ *                                                  deny → user declined
+ *   ExitPlanMode    → <ExitPlanModeCard />        allow → SDK runs the
+ *                                                  tool, mode flips;
+ *                                                  deny → SDK ends turn
+ *                                                  with feedback message
+ *   else            → <PermissionRequestModal />  generic allow/deny
+ *
+ * The user's decision goes back as `_hermes_perm_response` via
+ * `sendAgentEnvelope` (retry-on-not-found, M10) so we don't drop a
+ * decision when the bridge has exited between turns.
  */
-function PermissionRequestGate({
+function InteractivePermissionDispatcher({
   sessionId,
   permissionMode,
   sendAgentEnvelope,
@@ -351,6 +324,36 @@ function PermissionRequestGate({
     setRequest(null);
   }
 
+  if (request.toolName === "AskUserQuestion") {
+    const input = request.input as unknown as AskUserQuestionInput;
+    return (
+      <AskUserQuestionCard
+        dialogId={request.id}
+        input={input}
+        onAllow={(updatedInput) => decide({ kind: "allow", updatedInput })}
+        onDeny={() => decide({ kind: "deny", message: "User cancelled the question" })}
+      />
+    );
+  }
+
+  if (request.toolName === "ExitPlanMode") {
+    const input = request.input as unknown as ExitPlanModeInput;
+    return (
+      <ExitPlanModeCard
+        dialogId={request.id}
+        input={input}
+        permissionMode={permissionMode}
+        onAllow={() => decide({ kind: "allow" })}
+        onDeny={(feedback) =>
+          decide({
+            kind: "deny",
+            message: feedback === "" ? "User rejected the plan" : feedback,
+          })
+        }
+      />
+    );
+  }
+
   return (
     <PermissionRequestModal
       request={request}
@@ -358,36 +361,6 @@ function PermissionRequestGate({
       onDecision={decide}
     />
   );
-}
-
-/** Returns the latest unanswered AskUserQuestion or ExitPlanMode tool_use,
- *  or null if none is pending.  An "unanswered" tool_use is one whose id
- *  is missing from the state's toolResults map. */
-type PendingInteractive =
-  | { kind: "AskUserQuestion"; toolUseId: string; input: AskUserQuestionInput }
-  | { kind: "ExitPlanMode"; toolUseId: string; input: ExitPlanModeInput };
-
-function findPendingInteractive(state: AgentSessionState): PendingInteractive | null {
-  for (let i = state.messages.length - 1; i >= 0; i--) {
-    const m = state.messages[i];
-    if (m.role !== "assistant") continue;
-    for (let j = m.blocks.length - 1; j >= 0; j--) {
-      const block = m.blocks[j];
-      if (block.type !== "tool_use") continue;
-      // Narrow: ContentBlock union may include UnknownBlockData where
-      // `id` is `unknown`; once we know `type === "tool_use"`, treat
-      // it as ToolUseBlockData with a string id.
-      const tu = block as { type: "tool_use"; id: string; name: string; input: Record<string, unknown> };
-      if (state.toolResults.has(tu.id)) continue;
-      if (isAskUserQuestionToolUse(tu)) {
-        return { kind: "AskUserQuestion", toolUseId: tu.id, input: tu.input as AskUserQuestionInput };
-      }
-      if (isExitPlanModeToolUse(tu)) {
-        return { kind: "ExitPlanMode", toolUseId: tu.id, input: tu.input as ExitPlanModeInput };
-      }
-    }
-  }
-  return null;
 }
 
 interface NumberedMessage {

--- a/src/agent/blocks/GenericToolBlock.tsx
+++ b/src/agent/blocks/GenericToolBlock.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import type { ContentBlock, ToolResultBlockData, ToolUseBlockData } from "../types";
 import { GLYPHS } from "./glyphs";
+import { CodeFence } from "./CodeFence";
+import { prettyJson, summarizeJsonInput } from "../../utils/jsonSummary";
 
 interface GenericToolBlockProps {
   block: ToolUseBlockData;
@@ -10,44 +12,59 @@ interface GenericToolBlockProps {
 /**
  * Fallback renderer for tools that don't fit any known family.
  *
- * **Bare-bones on purpose.** Tool name italic mono in `--ink-tertiary`. Input
- * collapsed under a `▾ input` disclosure (JSON pretty-printed). Result
- * rendered as text. No card border, no background, no embellishment. See
- * playbook §5.
+ * Surfaces a one-line micro-summary of the input (key count + size,
+ * or a hint extracted from common shapes like `command` / `file_path`
+ * / `pattern`).  Full payload is one click away inside a syntax-
+ * highlighted code fence so deeply-nested inputs no longer dump as
+ * a wall of unstyled JSON.
  *
- * Stays ugly to motivate adding a proper family-specific treatment when a
- * new tool becomes important.
+ * Result text uses the same disclosure pattern when long; short
+ * results render inline.
  */
 export function GenericToolBlock({ block, result }: GenericToolBlockProps) {
   const [open, setOpen] = useState(false);
   const status = !result ? "running" : result.is_error ? "error" : "success";
 
-  let inputJson = "";
-  try {
-    inputJson = JSON.stringify(block.input, null, 2);
-  } catch {
-    inputJson = String(block.input);
-  }
+  const summary = summarizeJsonInput(block.input);
+  const inputJson = open ? prettyJson(block.input) : "";
+
   const resultText = result ? stringifyContent(result.content) : "";
+  const resultIsLong = resultText.length > 240 || resultText.split("\n").length > 6;
 
   return (
     <div className="agent-tool-generic" data-status={status}>
       <div className="agent-tool-generic-row">
         <span className="agent-tool-generic-name">{block.name}</span>
+        <span className="agent-tool-generic-summary" title={summary.text}>
+          {summary.text}
+        </span>
         <button
           type="button"
           className="agent-tool-generic-input-toggle"
           onClick={() => setOpen((v) => !v)}
           aria-expanded={open}
+          aria-label={open ? "Hide tool input" : "Show tool input"}
         >
-          {GLYPHS.disclosure} input
+          {GLYPHS.disclosure} {open ? "hide" : "input"}
         </button>
       </div>
       {open ? (
-        <pre className="agent-tool-generic-input-pre">{inputJson}</pre>
+        <div className="agent-tool-generic-input-body">
+          <CodeFence code={inputJson} language="json" />
+        </div>
       ) : null}
-      {resultText ? (
-        <pre className="agent-tool-generic-result">{resultText}</pre>
+      {resultText && !resultIsLong ? (
+        <div className="agent-tool-generic-result">{resultText}</div>
+      ) : null}
+      {resultText && resultIsLong ? (
+        <details className="agent-tool-generic-result-details">
+          <summary className="agent-tool-generic-result-summary">
+            {GLYPHS.disclosure} result · {resultText.split("\n").length} lines
+          </summary>
+          <div className="agent-tool-generic-result-body">
+            <CodeFence code={resultText} language={detectLanguage(resultText)} />
+          </div>
+        </details>
       ) : null}
     </div>
   );
@@ -61,11 +78,15 @@ function stringifyContent(content: string | ContentBlock[]): string {
       if (b.type === "text" && typeof (b as { text?: unknown }).text === "string") {
         return (b as { text: string }).text;
       }
-      try {
-        return JSON.stringify(b, null, 2);
-      } catch {
-        return String(b);
-      }
+      return prettyJson(b);
     })
     .join("\n");
+}
+
+/** Heuristic language pick for the result body — JSON shape gets
+ *  highlight, otherwise plain. */
+function detectLanguage(s: string): string {
+  const t = s.trimStart();
+  if (t.startsWith("{") || t.startsWith("[")) return "json";
+  return "";
 }

--- a/src/agent/blocks/ToolResultBlock.tsx
+++ b/src/agent/blocks/ToolResultBlock.tsx
@@ -1,4 +1,6 @@
 import type { ContentBlock, ToolResultBlockData } from "../types";
+import { CodeFence } from "./CodeFence";
+import { prettyJson } from "../../utils/jsonSummary";
 
 interface ToolResultBlockProps {
   block: ToolResultBlockData;
@@ -14,39 +16,47 @@ interface ToolResultBlockProps {
 }
 
 /**
- * Standalone-or-inline renderer for `tool_result` blocks. See playbook §5
- * ToolResultBlock.
- *
- * Quiet inline appearance: text in `--ink-secondary`, no card. If the result
- * is an error, a `--tool-error` left bar marks it. Standalone uses a
- * hairline-bordered panel, family-neutral.
+ * Standalone-or-inline renderer for `tool_result` blocks.  Plain-text
+ * content renders inline.  Structured (non-text) content falls through
+ * a syntax-highlighted JSON code fence rather than dumping as raw
+ * `<pre>` JSON, so reconnect-time orphan results don't blow out the
+ * column width with a wall of stringified blocks.
  */
 export function ToolResultBlock({ block, compact = false }: ToolResultBlockProps) {
-  const text = stringifyContent(block.content);
+  const { plain, structured } = partitionContent(block.content);
   const cls =
     "agent-tool-result" +
     (block.is_error ? " is-error" : "") +
     (compact ? " compact" : "");
+
   return (
     <div className={cls}>
-      <pre className="agent-tool-result-body">{text}</pre>
+      {plain && <pre className="agent-tool-result-body">{plain}</pre>}
+      {structured.length > 0 && (
+        <div className="agent-tool-result-structured">
+          <CodeFence code={prettyJson(structured)} language="json" />
+        </div>
+      )}
     </div>
   );
 }
 
-function stringifyContent(content: string | ContentBlock[]): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((b) => {
-      if (b.type === "text" && typeof (b as { text?: unknown }).text === "string") {
-        return (b as { text: string }).text;
-      }
-      try {
-        return JSON.stringify(b, null, 2);
-      } catch {
-        return String(b);
-      }
-    })
-    .join("\n");
+/** Split a tool-result content array into the readable text portion
+ *  and the structured (non-text) tail.  The text portion concatenates
+ *  cleanly; the structured tail renders as JSON. */
+function partitionContent(
+  content: string | ContentBlock[],
+): { plain: string; structured: ContentBlock[] } {
+  if (typeof content === "string") return { plain: content, structured: [] };
+  if (!Array.isArray(content)) return { plain: "", structured: [] };
+  const textParts: string[] = [];
+  const structured: ContentBlock[] = [];
+  for (const b of content) {
+    if (b.type === "text" && typeof (b as { text?: unknown }).text === "string") {
+      textParts.push((b as { text: string }).text);
+    } else {
+      structured.push(b);
+    }
+  }
+  return { plain: textParts.join("\n"), structured };
 }

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -172,6 +172,21 @@ export interface UnknownAgentEvent {
   [key: string]: unknown;
 }
 
+/** Hermes-internal envelope: the bridge fires this when the live SDK
+ *  runtime values it tracks (model, permissionMode) diverge from the
+ *  last reported state — for example, after EnterPlanMode flips the
+ *  session into plan mode without a respawn.  The composer's chip
+ *  pickers and SessionContext both subscribe so the UI matches reality
+ *  without waiting for a fresh init event (the SDK only emits init at
+ *  spawn time). */
+export interface StateChangedEvent {
+  type: "_hermes_state_changed";
+  session_id?: string;
+  uuid?: string;
+  model?: string;
+  permissionMode?: string;
+}
+
 export type AgentEvent =
   | InitEvent
   | SystemEvent
@@ -180,12 +195,17 @@ export type AgentEvent =
   | ResultEvent
   | RateLimitEvent
   | ParseErrorEvent
+  | StateChangedEvent
   | UnknownAgentEvent;
 
 // === Helpers ===
 
 export function isInitEvent(e: AgentEvent): e is InitEvent {
   return e.type === "system" && (e as { subtype?: string }).subtype === "init";
+}
+
+export function isStateChangedEvent(e: AgentEvent): e is StateChangedEvent {
+  return e.type === "_hermes_state_changed";
 }
 
 export function isSystemEvent(e: AgentEvent): e is SystemEvent {

--- a/src/agent/useAgentInit.ts
+++ b/src/agent/useAgentInit.ts
@@ -20,11 +20,32 @@ import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import type { AgentEvent, InitEvent } from "./types";
-import { isInitEvent } from "./types";
+import { isInitEvent, isStateChangedEvent } from "./types";
 
-/** Pure reducer step — exported for unit testing. */
+/** Pure reducer step — exported for unit testing.
+ *
+ *  Two events feed this reducer:
+ *
+ *    1. `system/init` (fresh from the SDK on spawn / resume) — wholly
+ *       replaces the cached init.
+ *    2. `_hermes_state_changed` (bridge-internal) — patches the cached
+ *       init's `model` / `permissionMode` fields when Claude's runtime
+ *       values drift mid-session (e.g. EnterPlanMode flips the mode
+ *       without a respawn).  Ignored when no init has been seen yet —
+ *       we don't want to fabricate an init from a partial state.
+ */
 export function reduceInit(prev: InitEvent | null, event: AgentEvent): InitEvent | null {
-  return isInitEvent(event) ? event : prev;
+  if (isInitEvent(event)) return event;
+  if (isStateChangedEvent(event)) {
+    if (!prev) return prev;
+    const next = { ...prev };
+    if (typeof event.model === "string") next.model = event.model;
+    if (typeof event.permissionMode === "string") {
+      next.permissionMode = event.permissionMode;
+    }
+    return next;
+  }
+  return prev;
 }
 
 export function useAgentInit(sessionId: string | null | undefined): InitEvent | null {
@@ -38,18 +59,9 @@ export function useAgentInit(sessionId: string | null | undefined): InitEvent | 
 
     listen<AgentEvent>(`agent-event-${sessionId}`, (msg) => {
       const ev = msg.payload;
-      if (isInitEvent(ev)) {
-        // Each agent turn re-emits an init event with the current model /
-        // permission mode / slash commands — keep replacing so the composer
-        // chips track Claude's reality.
-        // Visible debug: prints model/permission as plain strings so
-        // DevTools doesn't truncate as `Object`.
-        console.log(
-          `[useAgentInit] sid=${sessionId} model=${ev.model ?? "?"}` +
-          ` perm=${(ev as { permissionMode?: string }).permissionMode ?? "?"}`,
-        );
-        setInit(ev);
-      }
+      // Funnel both event kinds through the pure reducer so the
+      // patch-on-state-changed semantics are testable.
+      setInit((prev) => reduceInit(prev, ev));
     }).then((u) => {
       if (cancelled) {
         u();

--- a/src/components/AskUserQuestionCard.tsx
+++ b/src/components/AskUserQuestionCard.tsx
@@ -5,27 +5,38 @@
  *
  * Renders Claude's structured question as a native UI: radio (single)
  * or checkbox (multi) with auto "Other" textarea for freeform answers.
- * Submit composes a `tool_result` envelope that the parent writes to
- * the bridge's stdin via `sendAgentInput`.
  *
- * Composer suppression while this card is mounted is the parent's job
- * (AgentSessionView) — this card just renders + reports.
+ * The card responds via the `canUseTool` permission channel — `onAllow`
+ * receives an `updatedInput` shaped exactly the way the SDK's
+ * AskUserQuestion tool expects (per the bundled binary's Zod schema).
+ * `onDeny` cancels the tool call and Claude reads "user declined" as
+ * the deny message.  Composer suppression while this card is mounted
+ * is the parent's job (the dispatcher) — this card just renders +
+ * reports its decision.
  */
 import "../styles/components/AskUserQuestionCard.css";
 import { useEffect, useMemo, useRef, useState } from "react";
-import type {
-  AskAnswer,
-  AskUserQuestionInput,
-  AskUserQuestionOption,
+import {
+  buildAskAnswersUpdatedInput,
+  type AskAnswer,
+  type AskUserQuestionInput,
+  type AskUserQuestionOption,
 } from "../utils/askUserQuestion";
 
 const OTHER_LABEL = "Other";
 
 interface Props {
-  toolUseId: string;
+  /** The original AskUserQuestion tool input — questions + options. */
   input: AskUserQuestionInput;
-  onSubmit: (answers: AskAnswer[]) => void;
-  onCancel: () => void;
+  /** Caller will turn this into a `_hermes_perm_response` with
+   *  decision `{ behavior: "allow", updatedInput }`.  The SDK then
+   *  formats the user-facing tool_result message itself. */
+  onAllow: (updatedInput: Record<string, unknown>) => void;
+  /** Caller will turn this into `{ behavior: "deny", message }`. */
+  onDeny: () => void;
+  /** Optional id for aria-labeling / tests; not part of the protocol
+   *  anymore.  Defaults to the perm-request id at the call site. */
+  dialogId?: string;
 }
 
 interface PerQuestionState {
@@ -33,23 +44,23 @@ interface PerQuestionState {
   otherText: string;
 }
 
-export function AskUserQuestionCard({ toolUseId, input, onSubmit, onCancel }: Props) {
+export function AskUserQuestionCard({ input, onAllow, onDeny, dialogId }: Props) {
   const questions = input.questions;
   const [state, setState] = useState<PerQuestionState[]>(() =>
     questions.map(() => ({ selected: [], otherText: "" })),
   );
-  const onCancelRef = useRef(onCancel);
-  onCancelRef.current = onCancel;
+  const onDenyRef = useRef(onDeny);
+  onDenyRef.current = onDeny;
 
-  // Degenerate input: empty questions array → nothing to ask, auto-cancel.
+  // Degenerate input: empty questions array → nothing to ask, auto-deny.
   useEffect(() => {
-    if (questions.length === 0) onCancelRef.current();
+    if (questions.length === 0) onDenyRef.current();
   }, [questions.length]);
 
   // Esc cancels.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onCancelRef.current();
+      if (e.key === "Escape") onDenyRef.current();
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -104,11 +115,17 @@ export function AskUserQuestionCard({ toolUseId, input, onSubmit, onCancel }: Pr
       }
       return ans;
     });
-    onSubmit(answers);
+    const updatedInput = buildAskAnswersUpdatedInput(input, answers);
+    onAllow(updatedInput);
   }
 
   return (
-    <div className="aq-card" data-tool-use-id={toolUseId} role="dialog" aria-label="Hermes is waiting for your answer">
+    <div
+      className="aq-card"
+      data-dialog-id={dialogId}
+      role="dialog"
+      aria-label="Hermes is waiting for your answer"
+    >
       <div className="aq-card-bar" aria-hidden="true" />
       <div className="aq-card-body">
         <div className="aq-card-header">HERMES IS WAITING FOR YOU</div>
@@ -128,7 +145,6 @@ export function AskUserQuestionCard({ toolUseId, input, onSubmit, onCancel }: Pr
                     onSelect={() => handleSelect(qi, opt.label, q.multiSelect)}
                   />
                 ))}
-                {/* Auto "Other" option */}
                 <OtherRow
                   qIndex={qi}
                   multi={q.multiSelect}
@@ -154,9 +170,10 @@ export function AskUserQuestionCard({ toolUseId, input, onSubmit, onCancel }: Pr
           <button
             type="button"
             className="aq-cancel"
-            onClick={() => onCancel()}
+            onClick={() => onDeny()}
           >
-            Esc cancel
+            <span className="aq-cancel-kbd" aria-hidden="true">Esc</span>
+            cancel
           </button>
           <button
             type="button"

--- a/src/components/ExitPlanModeCard.tsx
+++ b/src/components/ExitPlanModeCard.tsx
@@ -6,22 +6,31 @@
  * Approve / Reject only (TUI parity, no Modify per locked decision §0.4).
  * Reject opens a feedback box; user can submit empty if they just want
  * Claude to rethink without explanation.
+ *
+ * Wire: like AskUserQuestionCard, this card responds via the
+ * `canUseTool` permission channel, NOT via a `tool_result` envelope.
+ *   - Approve  →  onAllow()                 (SDK runs the tool, mode flips)
+ *   - Reject   →  onDeny(feedback || "")    (SDK ends turn with deny msg)
+ *
+ * Claude reads the deny message verbatim, so the feedback box content
+ * becomes the prompt Claude sees on its next turn.
  */
 import "../styles/components/ExitPlanModeCard.css";
 import { useState } from "react";
-import type { ExitPlanModeDecision, ExitPlanModeInput } from "../utils/exitPlanMode";
+import type { ExitPlanModeInput } from "../utils/exitPlanMode";
 import { MarkdownBody } from "../agent/blocks/MarkdownBody";
 
 interface Props {
-  toolUseId: string;
   input: ExitPlanModeInput;
   /** Active permission mode — used to render the PLAN MODE banner above
    *  the card when the session is currently in plan mode. */
   permissionMode: string;
-  onSubmit: (decision: ExitPlanModeDecision) => void;
+  onAllow: () => void;
+  onDeny: (feedback: string) => void;
+  dialogId?: string;
 }
 
-export function ExitPlanModeCard({ toolUseId, input, permissionMode, onSubmit }: Props) {
+export function ExitPlanModeCard({ input, permissionMode, onAllow, onDeny, dialogId }: Props) {
   const [rejecting, setRejecting] = useState(false);
   const [feedback, setFeedback] = useState("");
 
@@ -29,7 +38,12 @@ export function ExitPlanModeCard({ toolUseId, input, permissionMode, onSubmit }:
   const planContent = input.plan?.trim() ?? "";
 
   return (
-    <div className="ep-card" data-tool-use-id={toolUseId} role="dialog" aria-label="Plan submitted for approval">
+    <div
+      className="ep-card"
+      data-dialog-id={dialogId}
+      role="dialog"
+      aria-label="Plan submitted for approval"
+    >
       {showPlanBanner && <div className="ep-plan-banner">PLAN MODE — review and approve before claude executes</div>}
 
       <div className="ep-card-header">PLAN SUBMITTED FOR APPROVAL</div>
@@ -54,7 +68,7 @@ export function ExitPlanModeCard({ toolUseId, input, permissionMode, onSubmit }:
           <button
             type="button"
             className="ep-approve"
-            onClick={() => onSubmit({ accept: true })}
+            onClick={() => onAllow()}
           >
             ✓ approve
           </button>
@@ -85,13 +99,7 @@ export function ExitPlanModeCard({ toolUseId, input, permissionMode, onSubmit }:
             <button
               type="button"
               className="ep-approve"
-              onClick={() =>
-                onSubmit(
-                  feedback.trim() === ""
-                    ? { accept: false }
-                    : { accept: false, feedback: feedback.trim() },
-                )
-              }
+              onClick={() => onDeny(feedback.trim())}
             >
               confirm reject
             </button>

--- a/src/components/SessionComposer.tsx
+++ b/src/components/SessionComposer.tsx
@@ -231,7 +231,7 @@ export function SessionComposer() {
     } finally {
       inFlightRef.current = false;
     }
-  }, [draft, composerSessionId, pendingImages, dispatch, closeOverlay]);
+  }, [draft, composerSessionId, pendingImages, dispatch, closeOverlay, submitAgentMessage]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (slash && rankedCommands && rankedCommands.length > 0) {

--- a/src/state/SessionContext.tsx
+++ b/src/state/SessionContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useReducer, useEffect, useCallback, useMemo, useRef, useState, ReactNode } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type { AgentEvent } from "../agent/types";
-import { isInitEvent } from "../agent/types";
+import { isInitEvent, isStateChangedEvent } from "../agent/types";
 
 // Module-level guard to prevent React StrictMode from double-restoring sessions
 let workspaceRestoreStarted = false;
@@ -843,9 +843,19 @@ export function SessionProvider({ children }: { children: ReactNode }) {
    *  persisted under, so `--resume` finds the conversation. */
   const initListeners = useRef<Map<string, UnlistenFn>>(new Map());
 
-  /** Subscribe to agent-event-{sessionId} and keep `claudeUuids` synced with
-   *  Claude's reported session id.  Idempotent — calling twice for the same
-   *  session is a no-op. */
+  /** Subscribe to agent-event-{sessionId} and keep `claudeUuids` /
+   *  `claudeModels` / `claudePermissionModes` synced with whatever the
+   *  bridge reports.  Two event kinds matter:
+   *
+   *    - `system/init` — emitted on spawn/resume.  Latches the canonical
+   *      Claude-side session id so `--resume` works after exits.
+   *    - `_hermes_state_changed` — emitted by the bridge whenever the
+   *      live runtime model or permissionMode drifts (EnterPlanMode /
+   *      ExitPlanMode / `/model`).  We mirror those into the per-session
+   *      refs so the *next* respawn re-applies the new value rather than
+   *      reverting to a stale UI selection.
+   *
+   *  Idempotent — calling twice for the same session is a no-op. */
   const attachInitListener = useCallback(async (sessionId: string) => {
     if (initListeners.current.has(sessionId)) return;
     try {
@@ -855,14 +865,32 @@ export function SessionProvider({ children }: { children: ReactNode }) {
           const event = msg.payload;
           if (isInitEvent(event) && typeof event.session_id === "string") {
             const prior = claudeUuids.current.get(sessionId);
-            // Print key fields as a string so DevTools doesn't truncate
-            // them as `Object` — easier for production debugging.
             console.log(
               `[init] model=${event.model ?? "?"} session=${event.session_id}` +
               ` prior=${prior ?? "<none>"} changed=${prior !== event.session_id}` +
               ` perm=${(event as { permissionMode?: string }).permissionMode ?? "?"}`,
             );
             claudeUuids.current.set(sessionId, event.session_id);
+            // Init also reports the current model/perm — seed the refs
+            // so the picker's chip reflects spawn-time values immediately
+            // (before any state-changed event has fired).
+            if (typeof event.model === "string") {
+              claudeModels.current.set(sessionId, event.model);
+            }
+            if (typeof event.permissionMode === "string") {
+              claudePermissionModes.current.set(sessionId, event.permissionMode);
+            }
+          } else if (isStateChangedEvent(event)) {
+            console.log(
+              `[state-changed] sid=${sessionId} model=${event.model ?? "?"}` +
+              ` perm=${event.permissionMode ?? "?"}`,
+            );
+            if (typeof event.model === "string") {
+              claudeModels.current.set(sessionId, event.model);
+            }
+            if (typeof event.permissionMode === "string") {
+              claudePermissionModes.current.set(sessionId, event.permissionMode);
+            }
           }
         },
       );

--- a/src/styles/components/AskUserQuestionCard.css
+++ b/src/styles/components/AskUserQuestionCard.css
@@ -199,6 +199,28 @@
   color: var(--ink-tertiary, var(--text-3));
   cursor: pointer;
   transition: color 120ms ease;
+  /* The button text is "Esc cancel" with a literal space.  An
+   * inherited `word-spacing: 0` from a parent flexbox + zero-width
+   * fonts can collapse the space visually.  Force a real word gap. */
+  word-spacing: normal;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.aq-cancel-kbd {
+  /* The "Esc" hint as its own visually-distinct chip — guarantees
+   * it doesn't smush against the word "cancel". */
+  font-family: var(--font-display, var(--font-ui));
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-tertiary, var(--text-3));
+  border: 1px solid var(--rule, var(--border));
+  padding: 1px 5px;
+  border-radius: 2px;
+  margin-right: 6px;
+  vertical-align: 1px;
 }
 
 .aq-cancel:hover {

--- a/src/styles/components/agent/AgentSessionView.css
+++ b/src/styles/components/agent/AgentSessionView.css
@@ -38,9 +38,18 @@
  * on a piece of equipment.  Faint inner top-shadow gives it the slight
  * recess of a metal plate sunk into the surface. */
 .agent-session-header {
-  display: flex;
+  /* 3-zone grid:
+   *   [status] fixed-width LED + AGENT flag.  Never shrinks.
+   *   [title]  flexible — model / ticker / cwd-leaf.  Truncates with
+   *            ellipsis when the pane gets narrow.
+   *   [meta]   fixed-width cost + rate notice + STOP button.  Always
+   *            visible because title is the only zone that gives way.
+   * This replaces a brittle flex-wrap layout where the cost lozenge
+   * would jump to a second row and overlap STOP. */
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-areas: "status title meta";
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
   padding: 11px 20px;
   border-top: 1px solid var(--rule);
@@ -55,12 +64,58 @@
   color: var(--ink-secondary);
 }
 
-.agent-session-header-left,
-.agent-session-header-right {
+.agent-session-header-status {
+  grid-area: status;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.agent-session-header-title {
+  grid-area: title;
   display: flex;
   align-items: center;
   gap: 10px;
   min-width: 0;
+  overflow: hidden;
+  /* Items inside the title can themselves shrink (cwd path is the
+   * usual culprit); ellipsis happens at the leaf level. */
+}
+
+.agent-session-header-title > * {
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.agent-session-header-meta {
+  grid-area: meta;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  justify-content: flex-end;
+}
+
+/* Narrow panes — under ~480px the cost lozenge sheds its tokens
+ * count and shows only the dollar amount, freeing horizontal room
+ * for the title and STOP button.  STOP itself never disappears. */
+@container (max-width: 480px) {
+  .agent-session-cost-tokens,
+  .agent-session-cost-sep {
+    display: none;
+  }
+}
+
+@media (max-width: 520px) {
+  .agent-session-cost-tokens,
+  .agent-session-cost-sep {
+    display: none;
+  }
+  .agent-session-header {
+    gap: 8px;
+    padding: 11px 14px;
+  }
 }
 
 .agent-session-flag {
@@ -103,7 +158,7 @@
   background: var(--green);
   box-shadow:
     0 0 0 1px rgba(0, 0, 0, 0.5) inset,
-    0 0 6px rgba(52, 211, 153, 0.35);
+    0 0 6px color-mix(in srgb, var(--green) 35%, transparent);
 }
 
 .agent-session-status-dot[data-state="idle"] {
@@ -114,7 +169,7 @@
   background: var(--yellow);
   box-shadow:
     0 0 0 1px rgba(0, 0, 0, 0.5) inset,
-    0 0 6px rgba(234, 179, 8, 0.35);
+    0 0 6px color-mix(in srgb, var(--yellow) 35%, transparent);
 }
 
 /* "Thinking" — Claude is mid-stream writing a reply.  BRASS pulse — the
@@ -258,14 +313,14 @@
 }
 
 .agent-session-scroll::-webkit-scrollbar-thumb {
-  background: rgba(212, 168, 106, 0.22);
+  background: color-mix(in srgb, var(--brass, var(--accent-paper)) 22%, transparent);
   border-radius: 3px;
   border: 1px solid transparent;
   background-clip: padding-box;
 }
 
 .agent-session-scroll::-webkit-scrollbar-thumb:hover {
-  background: rgba(212, 168, 106, 0.5);
+  background: color-mix(in srgb, var(--brass, var(--accent-paper)) 50%, transparent);
   background-clip: padding-box;
 }
 
@@ -1080,9 +1135,12 @@
 /* ─── File family (Read / Write / Edit / NotebookEdit) ─── */
 
 .agent-tool-file {
-  border: 1px solid var(--rule-strong);
-  border-radius: var(--radius);
-  background: var(--bg-1);
+  border: var(--tool-card-border);
+  border-radius: var(--tool-card-radius);
+  background: var(--tool-card-bg);
+  box-shadow: var(--tool-card-shadow);
+  backdrop-filter: var(--tool-card-backdrop);
+  -webkit-backdrop-filter: var(--tool-card-backdrop);
   overflow: hidden;
 }
 
@@ -1542,24 +1600,60 @@
   color: var(--ink-secondary);
 }
 
-/* ─── Generic fallback (bare-bones on purpose) ─── */
+/* ─── Generic fallback ───────────────────────────────────────────
+ *
+ * Composition:
+ *   tool-name   summary-chip                              [hide/input]
+ *   ┌─ disclosed CodeFence (highlighted JSON, max-height capped) ─┐
+ *   short result text inline, OR
+ *   <details> with `result · N lines` summary that expands a fence.
+ *
+ * Designed so a deeply-nested input never renders as a wall of raw
+ * JSON.  The summary tells you what's in there at a glance; the
+ * fence is one click away. */
 
 .agent-tool-generic {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  /* Promote the generic fallback into a real tool card so all tool
+   * blocks share the same chrome under any archetype.  When the
+   * archetype is `hairline-rules` (e.g. minimal-dark theme), the
+   * card tokens collapse to transparent and the generic block stays
+   * visually quiet, just as before. */
+  padding: 8px 12px;
+  background: var(--tool-card-bg);
+  border: var(--tool-card-border);
+  border-radius: var(--tool-card-radius);
+  box-shadow: var(--tool-card-shadow);
+  backdrop-filter: var(--tool-card-backdrop);
+  -webkit-backdrop-filter: var(--tool-card-backdrop);
 }
 
 .agent-tool-generic-row {
   display: flex;
   align-items: baseline;
-  gap: 12px;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .agent-tool-generic-name {
   font: italic 11px/1 var(--font-mono);
   color: var(--ink-tertiary);
   text-transform: lowercase;
+}
+
+/* Inline one-liner — what the tool was called with, in plain words.
+ * Truncates with ellipsis on narrow rows so the disclosure button
+ * stays visible.  The full summary is in the `title` for hover. */
+.agent-tool-generic-summary {
+  font: 11px/1.4 var(--font-mono);
+  color: var(--ink-secondary);
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .agent-tool-generic-input-toggle {
@@ -1569,22 +1663,24 @@
   border: 0;
   padding: 0;
   cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .agent-tool-generic-input-toggle:hover {
   color: var(--ink-secondary);
 }
 
-.agent-tool-generic-input-pre {
-  margin: 6px 0;
-  padding: 8px;
-  background: var(--bg-1);
-  border: 1px solid var(--rule);
-  border-radius: var(--radius);
-  font: 11px/1.4 var(--font-mono);
-  color: var(--ink-secondary);
-  white-space: pre-wrap;
-  overflow-x: auto;
+/* Disclosed input body — nested CodeFence inherits all syntax-color
+ * tokens and brings its own max-height, so the input never bleeds
+ * past one screen. */
+.agent-tool-generic-input-body {
+  margin: 0;
+}
+
+.agent-tool-generic-input-body .agent-code-fence {
+  max-height: 320px;
+  overflow: auto;
 }
 
 .agent-tool-generic-result {
@@ -1595,12 +1691,57 @@
   word-break: break-word;
 }
 
+.agent-tool-generic-result-details {
+  margin: 0;
+}
+
+.agent-tool-generic-result-summary {
+  font: 11px/1 var(--font-mono);
+  color: var(--ink-tertiary);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  padding: 2px 0;
+}
+
+.agent-tool-generic-result-summary::-webkit-details-marker {
+  display: none;
+}
+
+.agent-tool-generic-result-summary:hover {
+  color: var(--ink-secondary);
+}
+
+.agent-tool-generic-result-body {
+  margin-top: 4px;
+}
+
+.agent-tool-generic-result-body .agent-code-fence {
+  max-height: 320px;
+  overflow: auto;
+}
+
+/* Fallback ToolResult structured tail — when a result block carries
+ * non-text content (rare; reconnect-time orphans), we render it as
+ * highlighted JSON instead of dumping raw <pre>. */
+.agent-tool-result-structured {
+  margin-top: 4px;
+}
+
+.agent-tool-result-structured .agent-code-fence {
+  max-height: 240px;
+  overflow: auto;
+}
+
 /* ─── Tool result (standalone + compact inline variants) ─── */
 
 .agent-tool-result {
-  border: 1px solid var(--rule);
-  border-radius: var(--radius);
-  background: var(--bg-1);
+  border: var(--tool-card-border);
+  border-radius: var(--tool-card-radius);
+  background: var(--tool-card-bg);
+  box-shadow: var(--tool-card-shadow);
+  backdrop-filter: var(--tool-card-backdrop);
+  -webkit-backdrop-filter: var(--tool-card-backdrop);
   max-height: 200px;
   overflow: auto;
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1939,3 +1939,284 @@ html[data-theme="transilvania"] {
   --scanline-opacity: 0;
   --accent-glow: 0 0 10px #bd93f922;
 }
+
+/* ════════════════════════════════════════════════════════════════════
+ * Agent Timeline · Archetype Paint
+ * ════════════════════════════════════════════════════════════════════
+ *
+ * The agent session timeline reads its visual chrome from a small
+ * vocabulary of archetype tokens (defined in tokens.css).  Each
+ * theme below overrides the defaults to express ONE of the six
+ * rendering archetypes — so the same timeline component repaints
+ * itself in every theme without any per-theme branching in the React
+ * code or the agent-side CSS.
+ *
+ * Six archetypes, one paint per theme:
+ *
+ *   glass-cards       translucent panels + backdrop-blur
+ *   paper-cards       solid card with subtle shadow (default)
+ *   hairline-rules    no enclosure — just thin separators
+ *   crt-blocks        sharp box, phosphor glow + scanlines
+ *   ribbon-rails      left-side accent rail per turn (no card)
+ *   editorial-margin  warm paper, low chrome, generous gutter
+ *
+ * Per-theme bespoke touches (paper grain, scanline overlay, animated
+ * rail pulses) live further down — see "Bespoke per-theme touches".
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* ─── Glass-cards family ─────────────────────────────────────────
+ * nightowl · frosted-light · frosted-dark · cobalt · macchiato · shibuya
+ * Translucent panels with backdrop-blur for depth — rounded, slightly
+ * shadowed, accent-tinted hairline.  Reads as macOS glass / web3 UI. */
+html[data-theme="nightowl"],
+html[data-theme="frosted-light"],
+html[data-theme="frosted-dark"],
+html[data-theme="cobalt"],
+html[data-theme="macchiato"],
+html[data-theme="shibuya"] {
+  --tool-card-bg: color-mix(in srgb, var(--bg-1) 72%, transparent);
+  --tool-card-backdrop: blur(14px) saturate(140%);
+  --tool-card-border: 1px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  --tool-card-radius: 8px;
+  --tool-card-shadow: 0 8px 24px color-mix(in srgb, #000 22%, transparent);
+  --turn-separator: 1px solid color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+/* ─── Hairline-rules family ──────────────────────────────────────
+ * minimal-dark · corporate · reactor
+ * No enclosing card.  The timeline is a stack of generously-spaced
+ * messages with thin rules between turns.  Maximum readability for
+ * GitHub-Dark / professional workflows. */
+html[data-theme="minimal-dark"],
+html[data-theme="corporate"],
+html[data-theme="reactor"] {
+  --tool-card-bg: transparent;
+  --tool-card-border: 0;
+  --tool-card-radius: 0;
+  --tool-card-shadow: none;
+  --turn-separator: 1px solid var(--rule);
+}
+
+/* ─── CRT-blocks family ──────────────────────────────────────────
+ * hacker · 80s · midnight
+ * Sharp boxes with phosphor glow.  Thicker accent-tinted border.
+ * No backdrop-blur (would soften the CRT feel).  Surface scanlines
+ * and vignette come from the per-theme bespoke touches below. */
+html[data-theme="hacker"],
+html[data-theme="80s"],
+html[data-theme="midnight"] {
+  --tool-card-bg: color-mix(in srgb, var(--bg-1) 78%, var(--bg-0) 22%);
+  --tool-card-border: 1px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  --tool-card-radius: 0;
+  --tool-card-shadow:
+    0 0 0 1px color-mix(in srgb, var(--accent) 14%, transparent),
+    0 0 14px color-mix(in srgb, var(--accent) 22%, transparent);
+  --turn-separator: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+/* ─── Ribbon-rails family ────────────────────────────────────────
+ * tron · duel · rainbow
+ * No enclosing card.  Each tool block gets a 3px accent rail on the
+ * LEFT — pulsing on tron, opposing-color on duel, gradient on
+ * rainbow.  Composed via the bespoke section below; these tokens
+ * just suppress the box. */
+html[data-theme="tron"],
+html[data-theme="duel"],
+html[data-theme="rainbow"] {
+  --tool-card-bg: transparent;
+  --tool-card-border: 0;
+  --tool-card-radius: 0;
+  --tool-card-shadow: none;
+  --turn-separator: 1px solid color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+/* ─── Editorial-margin family ────────────────────────────────────
+ * designer · sand · rose · evergreen · solarized · light
+ * Warm paper feel.  Soft drop shadow, slightly rounded, low chrome.
+ * Reads as printed page rather than terminal box.  Per-theme grain
+ * texture lives in the bespoke section. */
+html[data-theme="designer"],
+html[data-theme="sand"],
+html[data-theme="rose"],
+html[data-theme="evergreen"],
+html[data-theme="solarized"],
+html[data-theme="light"] {
+  --tool-card-bg: var(--bg-1);
+  --tool-card-border: 1px solid var(--rule);
+  --tool-card-radius: 4px;
+  --tool-card-shadow: 0 1px 2px color-mix(in srgb, #000 8%, transparent);
+  --turn-separator: 1px solid var(--rule);
+}
+
+/* The remaining themes (data, neon-sunset, polar, amber, lavender,
+ * mint, solarized-dark, transilvania) inherit the default
+ * paper-cards archetype defined in tokens.css — solid card with
+ * --rule-strong border, no shadow.  Override here only if a future
+ * tweak makes one of them stand out from the pack. */
+
+/* ════════════════════════════════════════════════════════════════════
+ * Bespoke per-theme touches
+ * ════════════════════════════════════════════════════════════════════
+ *
+ * These rules add the *personality* on top of each theme's archetype:
+ *   - CRT scanlines on `hacker` and `80s` tool cards
+ *   - DOS-style double border on `midnight`
+ *   - Subtle paper grain on `designer`
+ *   - Pulsing cyan rail on `tron`
+ *   - Animated gradient rail on `rainbow`
+ *   - Glow on accent text in glass themes
+ *
+ * Anything not listed here stays clean within its archetype paint.
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* ─── hacker — green phosphor + scanlines ────────────────────── */
+html[data-theme="hacker"] .agent-tool-file,
+html[data-theme="hacker"] .agent-tool-result,
+html[data-theme="hacker"] .agent-tool-generic {
+  background-image:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent 2px,
+      color-mix(in srgb, var(--green) 6%, transparent) 2px,
+      color-mix(in srgb, var(--green) 6%, transparent) 3px
+    );
+}
+
+html[data-theme="hacker"] .agent-tool-file-header,
+html[data-theme="hacker"] .agent-tool-generic-name {
+  text-shadow: 0 0 6px color-mix(in srgb, var(--green) 50%, transparent);
+}
+
+/* ─── 80s — heavy amber scanlines + vignette ─────────────────── */
+html[data-theme="80s"] .agent-tool-file,
+html[data-theme="80s"] .agent-tool-result,
+html[data-theme="80s"] .agent-tool-generic {
+  background-image:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent 2px,
+      color-mix(in srgb, var(--accent) 9%, transparent) 2px,
+      color-mix(in srgb, var(--accent) 9%, transparent) 3px
+    );
+}
+
+html[data-theme="80s"] .agent-session-scroll {
+  /* CRT vignette — soft inset shadow that darkens the corners. */
+  box-shadow: inset 0 0 80px color-mix(in srgb, #000 50%, transparent);
+}
+
+/* ─── midnight — DOS double border ───────────────────────────── */
+html[data-theme="midnight"] .agent-tool-file,
+html[data-theme="midnight"] .agent-tool-result,
+html[data-theme="midnight"] .agent-tool-generic {
+  /* Outer border via the archetype tokens already; the inner line
+   * comes from a 1px inset box-shadow that creates the classic
+   * DOS double-line effect. */
+  box-shadow:
+    var(--tool-card-shadow),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+/* ─── designer — paper grain texture ─────────────────────────── */
+html[data-theme="designer"] .agent-tool-file,
+html[data-theme="designer"] .agent-tool-result,
+html[data-theme="designer"] .agent-tool-generic {
+  /* Subtle SVG noise overlay — encoded inline so no extra fetch.
+   * Opacity is held low so the texture reads as paper, not static. */
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.06 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  background-blend-mode: multiply;
+}
+
+/* ─── tron — pulsing cyan rail ───────────────────────────────── */
+html[data-theme="tron"] .agent-tool-file,
+html[data-theme="tron"] .agent-tool-generic {
+  position: relative;
+  padding-left: 14px;
+}
+
+html[data-theme="tron"] .agent-tool-file::after,
+html[data-theme="tron"] .agent-tool-generic::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  animation: tron-rail-pulse 2.8s ease-in-out infinite;
+}
+
+@keyframes tron-rail-pulse {
+  0%, 100% { opacity: 0.55; box-shadow: 0 0 8px var(--accent); }
+  50%      { opacity: 1; box-shadow: 0 0 18px var(--accent); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-theme="tron"] .agent-tool-file::after,
+  html[data-theme="tron"] .agent-tool-generic::after {
+    animation: none;
+    opacity: 0.85;
+  }
+}
+
+/* ─── rainbow — animated gradient rail ───────────────────────── */
+html[data-theme="rainbow"] .agent-tool-file,
+html[data-theme="rainbow"] .agent-tool-generic {
+  position: relative;
+  padding-left: 14px;
+}
+
+html[data-theme="rainbow"] .agent-tool-file::after,
+html[data-theme="rainbow"] .agent-tool-generic::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: linear-gradient(
+    180deg,
+    var(--accent) 0%,
+    var(--violet) 33%,
+    var(--green) 66%,
+    var(--yellow) 100%
+  );
+  background-size: 100% 200%;
+  animation: rainbow-rail-shift 6s linear infinite;
+}
+
+@keyframes rainbow-rail-shift {
+  0%   { background-position: 0% 0%; }
+  100% { background-position: 0% 200%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-theme="rainbow"] .agent-tool-file::after,
+  html[data-theme="rainbow"] .agent-tool-generic::after {
+    animation: none;
+  }
+}
+
+/* ─── duel — opposing red/green rail ─────────────────────────── */
+html[data-theme="duel"] .agent-tool-file,
+html[data-theme="duel"] .agent-tool-generic {
+  position: relative;
+  padding-left: 14px;
+}
+
+html[data-theme="duel"] .agent-tool-file::after,
+html[data-theme="duel"] .agent-tool-generic::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: linear-gradient(180deg, var(--red), var(--green));
+}
+
+/* ─── glass family — accent text glow ────────────────────────── */
+html[data-theme="nightowl"] .agent-tool-file-header,
+html[data-theme="shibuya"] .agent-tool-file-header,
+html[data-theme="macchiato"] .agent-tool-file-header,
+html[data-theme="transilvania"] .agent-tool-file-header {
+  text-shadow: 0 0 10px color-mix(in srgb, var(--accent) 40%, transparent);
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2220,3 +2220,259 @@ html[data-theme="macchiato"] .agent-tool-file-header,
 html[data-theme="transilvania"] .agent-tool-file-header {
   text-shadow: 0 0 10px color-mix(in srgb, var(--accent) 40%, transparent);
 }
+
+/* ════════════════════════════════════════════════════════════════════
+ * Round 2 · Whole-timeline per-theme distinction
+ * ════════════════════════════════════════════════════════════════════
+ *
+ * Round 1 painted tool-block chrome.  Round 2 hits the surfaces you
+ * see in EVERY conversation, even text-only:
+ *
+ *   1. Brass remap     — the user-message left bar tracks each
+ *                        theme's accent (was hard-coded warm sandstone).
+ *   2. Surface texture — conversation background gets a per-family
+ *                        atmosphere (scanlines / grain / aurora).
+ *   3. Masthead strip  — top accent bar per family.
+ *   4. Separator style — turn rules vary per family.
+ *
+ * Effect: switching themes now changes how the timeline looks at a
+ * glance, not just what color it is.
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* ─── Brass remap ────────────────────────────────────────────────
+ * The user-message left bar is the most visible accent on every turn.
+ * It used to be hard-coded warm sandstone.  Now it tracks each theme's
+ * accent so the bar reads as the theme's identity.  Themes in the
+ * "warm/paper" family that BENEFIT from a warm sandstone are listed
+ * separately and keep an explicit warm value. */
+html[data-theme="hacker"],
+html[data-theme="data"],
+html[data-theme="corporate"],
+html[data-theme="80s"],
+html[data-theme="light"],
+html[data-theme="frosted-light"],
+html[data-theme="frosted-dark"],
+html[data-theme="midnight"],
+html[data-theme="solarized"],
+html[data-theme="neon-sunset"],
+html[data-theme="polar"],
+html[data-theme="reactor"],
+html[data-theme="amber"],
+html[data-theme="macchiato"],
+html[data-theme="shibuya"],
+html[data-theme="solarized-dark"],
+html[data-theme="evergreen"],
+html[data-theme="cobalt"],
+html[data-theme="minimal-dark"],
+html[data-theme="transilvania"],
+html[data-theme="nightowl"],
+html[data-theme="tron"],
+html[data-theme="duel"],
+html[data-theme="rainbow"],
+html[data-theme="lavender"],
+html[data-theme="mint"] {
+  --brass: var(--accent);
+  --brass-bright: var(--accent);
+  --brass-dim: var(--accent-dim);
+}
+
+/* designer / sand / rose deliberately KEEP the warm sandstone brass —
+ * those themes' identity is the warm accent, and remapping to the
+ * theme's accent (which IS warm) would give the same color anyway. */
+
+/* ─── Conversation surface texture ────────────────────────────────
+ * The scrolling chat surface gets a family-specific atmosphere
+ * applied via background-image overlay.  None of these darken the
+ * surface enough to hurt readability — they're meant to read as
+ * "this is hacker territory" not "this is dim". */
+
+/* CRT family — phosphor scanlines on the WHOLE conversation, not
+ * just tool cards. */
+html[data-theme="hacker"] .agent-session-scroll,
+html[data-theme="80s"] .agent-session-scroll,
+html[data-theme="midnight"] .agent-session-scroll {
+  background-image:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent 3px,
+      color-mix(in srgb, var(--accent) 4%, transparent) 3px,
+      color-mix(in srgb, var(--accent) 4%, transparent) 4px
+    );
+}
+
+/* Editorial-margin family — paper grain on the surface, not just
+ * tool cards.  Subtle SVG noise so it reads as printed paper. */
+html[data-theme="designer"] .agent-session-scroll,
+html[data-theme="sand"] .agent-session-scroll,
+html[data-theme="rose"] .agent-session-scroll,
+html[data-theme="evergreen"] .agent-session-scroll,
+html[data-theme="solarized"] .agent-session-scroll,
+html[data-theme="light"] .agent-session-scroll {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.7' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.025 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+}
+
+/* Glass-noir family — soft accent aurora at the top fading down. */
+html[data-theme="nightowl"] .agent-session-scroll,
+html[data-theme="frosted-light"] .agent-session-scroll,
+html[data-theme="frosted-dark"] .agent-session-scroll,
+html[data-theme="cobalt"] .agent-session-scroll,
+html[data-theme="macchiato"] .agent-session-scroll,
+html[data-theme="shibuya"] .agent-session-scroll,
+html[data-theme="transilvania"] .agent-session-scroll {
+  background-image:
+    radial-gradient(
+      ellipse 80% 50% at 50% 0%,
+      color-mix(in srgb, var(--accent) 6%, transparent) 0%,
+      transparent 70%
+    );
+}
+
+/* Neon-cyber family — animated diagonal rays.  Subtle and slow so
+ * they don't compete with content. */
+html[data-theme="tron"] .agent-session-scroll,
+html[data-theme="duel"] .agent-session-scroll,
+html[data-theme="rainbow"] .agent-session-scroll {
+  background-image:
+    linear-gradient(
+      135deg,
+      transparent 0%,
+      transparent 48%,
+      color-mix(in srgb, var(--accent) 5%, transparent) 50%,
+      transparent 52%,
+      transparent 100%
+    );
+  background-size: 240px 240px;
+}
+
+/* ─── Masthead per-family accent strip ────────────────────────────
+ * A 2px strip at the top of the masthead carrying the theme's
+ * personality — bright glow on CRT, gradient on glass, animated on
+ * neon, etc.  Sits above the existing border-top hairline. */
+
+/* CRT — solid accent strip with phosphor glow. */
+html[data-theme="hacker"] .agent-session-header,
+html[data-theme="80s"] .agent-session-header,
+html[data-theme="midnight"] .agent-session-header {
+  border-top: 2px solid var(--accent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.012),
+    0 1px 12px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+/* Glass — gradient strip fading from accent on the left. */
+html[data-theme="nightowl"] .agent-session-header,
+html[data-theme="frosted-dark"] .agent-session-header,
+html[data-theme="frosted-light"] .agent-session-header,
+html[data-theme="cobalt"] .agent-session-header,
+html[data-theme="macchiato"] .agent-session-header,
+html[data-theme="shibuya"] .agent-session-header {
+  border-top: 1px solid transparent;
+  background-image:
+    linear-gradient(var(--bg-paper), var(--bg-paper)),
+    linear-gradient(
+      90deg,
+      var(--accent) 0%,
+      color-mix(in srgb, var(--accent) 30%, transparent) 50%,
+      transparent 100%
+    );
+  background-origin: border-box;
+  background-clip: padding-box, border-box;
+  border-top-width: 2px;
+  border-top-style: solid;
+}
+
+/* Neon-cyber — animated horizontal sweep across the strip. */
+html[data-theme="tron"] .agent-session-header,
+html[data-theme="duel"] .agent-session-header,
+html[data-theme="rainbow"] .agent-session-header {
+  position: relative;
+  border-top: 1px solid var(--accent);
+}
+
+html[data-theme="tron"] .agent-session-header::before,
+html[data-theme="duel"] .agent-session-header::before,
+html[data-theme="rainbow"] .agent-session-header::before {
+  content: "";
+  position: absolute;
+  inset: -2px 0 auto 0;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--accent) 50%,
+    transparent
+  );
+  background-size: 30% 100%;
+  background-repeat: no-repeat;
+  animation: masthead-sweep 4s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes masthead-sweep {
+  0%   { background-position: -30% 0; }
+  100% { background-position: 130% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-theme="tron"] .agent-session-header::before,
+  html[data-theme="duel"] .agent-session-header::before,
+  html[data-theme="rainbow"] .agent-session-header::before {
+    animation: none;
+    background-position: 50% 0;
+  }
+}
+
+/* Editorial — soft warm hairline sits as-is (already the default). */
+
+/* ─── Turn separator variation ───────────────────────────────────
+ * The hairline between turns gets per-family character.  Defaults
+ * to a 1px --rule; CRT thickens with accent tint, neon gets a
+ * dotted pattern, editorial gets a slim warm line, glass gets a
+ * gradient fade. */
+
+html[data-theme="hacker"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="80s"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="midnight"] .agent-message + .agent-message[data-role="user"] {
+  border-top: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+html[data-theme="tron"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="duel"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="rainbow"] .agent-message + .agent-message[data-role="user"] {
+  border-top-style: dotted;
+  border-top-color: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+html[data-theme="designer"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="sand"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="rose"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="evergreen"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="solarized"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="light"] .agent-message + .agent-message[data-role="user"] {
+  /* Editorial — soft warm hairline at half opacity reads more like
+   * a printed page section break than a UI divider. */
+  border-top: 1px solid color-mix(in srgb, var(--ink-tertiary) 50%, transparent);
+}
+
+html[data-theme="nightowl"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="frosted-dark"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="frosted-light"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="cobalt"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="macchiato"] .agent-message + .agent-message[data-role="user"],
+html[data-theme="shibuya"] .agent-message + .agent-message[data-role="user"] {
+  /* Glass — gradient hairline that fades at the edges. */
+  border-top: 1px solid transparent;
+  background-image:
+    linear-gradient(
+      to right,
+      transparent,
+      color-mix(in srgb, var(--accent) 25%, transparent),
+      transparent
+    );
+  background-size: 100% 1px;
+  background-position: top;
+  background-repeat: no-repeat;
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -179,4 +179,42 @@
 
   /* Font features for mono — ligatures + tabular numerics */
   --font-mono-features: "calt", "liga", "ss01", "tnum";
+
+  /* ─── Archetype paint tokens ──────────────────────────────────
+   * The agent timeline reads these to render its tool cards, turn
+   * separators, and surface texture.  Each theme picks an
+   * archetype by overriding these tokens — see themes.css.
+   *
+   * Six rendering archetypes, each expressed entirely in tokens:
+   *   - paper-cards     solid card with optional shadow (default).
+   *   - glass-cards     translucent card + backdrop-blur.
+   *   - hairline-rules  no card; just thin separators.
+   *   - crt-blocks      sharp box with phosphor glow / scanlines.
+   *   - ribbon-rails    no card; left-side accent rail per turn.
+   *   - editorial-margin  paper card, generous white space, low
+   *                       chrome (warm light themes).
+   *
+   * Defaults below are paper-cards on the dark `:root` theme.  The
+   * agent CSS does NOT branch on theme — it just reads the tokens.
+   * ──────────────────────────────────────────────────────────── */
+
+  /* Tool / turn card chrome */
+  --tool-card-bg: var(--bg-1);
+  --tool-card-border: 1px solid var(--rule-strong, var(--rule));
+  --tool-card-radius: var(--radius);
+  --tool-card-shadow: none;
+  --tool-card-backdrop: none;
+  --tool-card-pad: 0; /* extra inner padding above the per-block padding */
+
+  /* Conversation surface effects (per theme) */
+  --surface-scanlines-opacity: 0;
+  --surface-grain-opacity: 0;
+  --surface-vignette: none;
+
+  /* Turn separator — the rule between turns.  Themes can replace
+   * with a thicker, bevelled, or color-shifted line. */
+  --turn-separator: 1px solid var(--rule);
+
+  /* Composer / footer chrome (used by the result footer + exit notice) */
+  --result-footer-border: 1px dashed var(--rule);
 }

--- a/src/utils/askUserQuestion.ts
+++ b/src/utils/askUserQuestion.ts
@@ -42,34 +42,54 @@ export function isAskUserQuestionToolUse(
   return !!block && block.type === "tool_use" && block.name === "AskUserQuestion";
 }
 
-/** Compose the `tool_result` envelope Claude expects in response.
- *  `answers` carries the user's selections; `cancelled: true` signals
- *  the user dismissed the prompt with Esc. */
-export function buildAskAnswerEnvelope(
-  toolUseId: string,
+/** Project the user's answers into the SDK-shaped `updatedInput` record
+ *  the AskUserQuestion tool expects to receive via `canUseTool`.
+ *
+ *  Confirmed against the bundled Claude Code binary
+ *  (`@anthropic-ai/claude-agent-sdk-darwin-arm64/claude` strings):
+ *
+ *    answers     :  Record<questionText, answerString>
+ *                   - single-select  → the chosen option label
+ *                   - multi-select   → comma-joined option labels
+ *                   - "Other"        → the freeform notes text
+ *    annotations :  Record<questionText, { notes?: string }>
+ *                   - present when the user supplied freeform notes
+ *                     (e.g. typed text in the auto "Other" textarea)
+ *
+ *  The SDK then formats its own `tool_result` block via
+ *  `mapToolResultToToolResultBlockParam`; we never write a `tool_result`
+ *  envelope ourselves for AskUserQuestion.  Doing so was the cause of
+ *  the silent "submit does nothing" bug — the SDK was waiting on
+ *  canUseTool's promise, not on a user message. */
+export function buildAskAnswersUpdatedInput(
+  input: AskUserQuestionInput,
   answers: AskAnswer[],
-  opts: { cancelled?: boolean } = {},
-): {
-  type: "user";
-  message: {
-    role: "user";
-    content: Array<{ type: "tool_result"; tool_use_id: string; content: string }>;
+): Record<string, unknown> {
+  const answersByQuestion: Record<string, string> = {};
+  const annotations: Record<string, { notes?: string }> = {};
+
+  for (const ans of answers) {
+    const isOther = ans.selected.length === 1 && ans.selected[0] === "Other";
+    if (isOther) {
+      // "Other" is the auto-injected freeform option — the user's
+      // actual answer lives in `notes`.  Surface it as the answer
+      // string so Claude sees the typed text, not the literal word
+      // "Other".
+      answersByQuestion[ans.question] = ans.notes?.trim() || "Other";
+    } else {
+      answersByQuestion[ans.question] = ans.selected.join(", ");
+    }
+    if (ans.notes && ans.notes.trim() !== "" && !isOther) {
+      annotations[ans.question] = { notes: ans.notes.trim() };
+    }
+  }
+
+  const updated: Record<string, unknown> = {
+    ...input,
+    answers: answersByQuestion,
   };
-} {
-  const payload = opts.cancelled
-    ? { cancelled: true, answers }
-    : { answers };
-  return {
-    type: "user",
-    message: {
-      role: "user",
-      content: [
-        {
-          type: "tool_result",
-          tool_use_id: toolUseId,
-          content: JSON.stringify(payload),
-        },
-      ],
-    },
-  };
+  if (Object.keys(annotations).length > 0) {
+    updated.annotations = annotations;
+  }
+  return updated;
 }

--- a/src/utils/exitPlanMode.ts
+++ b/src/utils/exitPlanMode.ts
@@ -4,7 +4,12 @@
  * ExitPlanMode is the SDK tool Claude calls at the end of plan-mode
  * deliberation.  Its `input.plan` is a markdown summary of what Claude
  * will do if the user approves.  We render it as a card with Approve /
- * Reject buttons and write the user's decision back as a `tool_result`.
+ * Reject buttons; the response goes back through `canUseTool` as
+ * `{behavior: "allow"}` (Claude proceeds and the SDK flips out of plan
+ * mode) or `{behavior: "deny", message: <feedback>}` (Claude reads the
+ * feedback as a deny message and revises).
+ *
+ * No envelope builder lives here — the perm response is the protocol.
  */
 
 import type { ToolUseBlockData } from "../agent/types";
@@ -13,41 +18,8 @@ export interface ExitPlanModeInput {
   plan: string;
 }
 
-export interface ExitPlanModeDecision {
-  accept: boolean;
-  feedback?: string;
-}
-
 export function isExitPlanModeToolUse(
   block: { type?: string; name?: string } | null | undefined,
 ): block is ToolUseBlockData & { name: "ExitPlanMode"; input: ExitPlanModeInput } {
   return !!block && block.type === "tool_use" && block.name === "ExitPlanMode";
-}
-
-export function buildExitPlanResult(
-  toolUseId: string,
-  decision: ExitPlanModeDecision,
-): {
-  type: "user";
-  message: {
-    role: "user";
-    content: Array<{ type: "tool_result"; tool_use_id: string; content: string }>;
-  };
-} {
-  const payload: ExitPlanModeDecision = decision.feedback
-    ? decision
-    : { accept: decision.accept };
-  return {
-    type: "user",
-    message: {
-      role: "user",
-      content: [
-        {
-          type: "tool_result",
-          tool_use_id: toolUseId,
-          content: JSON.stringify(payload),
-        },
-      ],
-    },
-  };
 }

--- a/src/utils/jsonSummary.ts
+++ b/src/utils/jsonSummary.ts
@@ -1,0 +1,152 @@
+/**
+ * Micro-summary helpers for tool input / unknown content payloads.
+ *
+ * The agent timeline used to dump pretty-printed JSON inside an
+ * unbounded `<pre>` whenever a tool's input didn't match a known
+ * family (GenericToolBlock) or when a tool_result contained nested
+ * non-text blocks (ToolResultBlock fallback).  On a long config or
+ * deeply-nested structure that produced a wall of unstyled JSON,
+ * blowing out the column width.
+ *
+ * The replacement is a one-line summary that hints at the shape +
+ * size, plus a `<details>` disclosure that reveals the full payload
+ * inside a syntax-highlighted, scrollable, max-height-capped code
+ * block.  The summary lives next to the tool name; the disclosure is
+ * one click away.
+ *
+ * The summary intentionally avoids JSON-stringify on big inputs — it
+ * only inspects keys / lengths so the cost is O(n) shallow.
+ */
+
+const COMMAND_HINT_KEYS = ["command", "cmd", "shell"] as const;
+const PATH_HINT_KEYS = ["file_path", "path", "filePath", "file"] as const;
+const PATTERN_HINT_KEYS = ["pattern", "query", "search"] as const;
+const URL_HINT_KEYS = ["url", "endpoint"] as const;
+
+export interface JsonSummary {
+  /** Human-readable one-liner suitable for inline display. */
+  text: string;
+  /** Approximate serialized size in bytes (UTF-8). */
+  bytes: number;
+}
+
+export function summarizeJsonInput(input: unknown): JsonSummary {
+  // Primitives — render the value itself, modestly truncated.
+  if (input === null || input === undefined) {
+    return { text: "(empty)", bytes: 0 };
+  }
+  if (typeof input === "string") {
+    return {
+      text: input.length === 0 ? "(empty string)" : `"${truncate(input, 64)}"`,
+      bytes: byteLength(input),
+    };
+  }
+  if (typeof input === "number" || typeof input === "boolean") {
+    const s = String(input);
+    return { text: s, bytes: s.length };
+  }
+
+  if (Array.isArray(input)) {
+    if (input.length === 0) return { text: "[ ] (empty array)", bytes: 2 };
+    const bytes = byteLengthOfJsonStringify(input);
+    return {
+      text: `[${input.length} ${input.length === 1 ? "item" : "items"}] · ${formatBytes(bytes)}`,
+      bytes,
+    };
+  }
+
+  if (typeof input === "object") {
+    const obj = input as Record<string, unknown>;
+    const keys = Object.keys(obj);
+    if (keys.length === 0) return { text: "{ } (empty object)", bytes: 2 };
+    const bytes = byteLengthOfJsonStringify(obj);
+
+    // Common shapes: surface the most informative key inline.
+    const cmdKey = COMMAND_HINT_KEYS.find((k) => typeof obj[k] === "string");
+    if (cmdKey) {
+      return {
+        text: `${cmdKey}: ${truncate(String(obj[cmdKey]), 60)}`,
+        bytes,
+      };
+    }
+    const pathKey = PATH_HINT_KEYS.find((k) => typeof obj[k] === "string");
+    if (pathKey) {
+      return {
+        text: `${truncate(String(obj[pathKey]), 64)}`,
+        bytes,
+      };
+    }
+    const patKey = PATTERN_HINT_KEYS.find((k) => typeof obj[k] === "string");
+    if (patKey) {
+      return {
+        text: `${patKey}: ${truncate(String(obj[patKey]), 60)}`,
+        bytes,
+      };
+    }
+    const urlKey = URL_HINT_KEYS.find((k) => typeof obj[k] === "string");
+    if (urlKey) {
+      return {
+        text: `${truncate(String(obj[urlKey]), 64)}`,
+        bytes,
+      };
+    }
+
+    // Generic fallback — key count + size.
+    return {
+      text: `${keys.length} ${keys.length === 1 ? "key" : "keys"} · ${formatBytes(bytes)}`,
+      bytes,
+    };
+  }
+
+  // Catch-all (functions, symbols, BigInt — vanishingly rare on
+  // tool inputs, but we mustn't throw).
+  const s = String(input);
+  return { text: s, bytes: s.length };
+}
+
+/** Pretty-printed JSON for the disclosure body.  Falls back gracefully
+ *  on circular references (which don't normally occur in tool input
+ *  but are not impossible — e.g. observation artifacts of a buggy SDK
+ *  shim). */
+export function prettyJson(input: unknown): string {
+  try {
+    return JSON.stringify(input, null, 2);
+  } catch {
+    return String(input);
+  }
+}
+
+// ─── Internal helpers ───────────────────────────────────────────────
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + "…";
+}
+
+function byteLength(s: string): number {
+  // Approximate — Unicode-safe count via TextEncoder is exact, but
+  // we're only sizing for human-readable hints, so length is fine
+  // for ASCII-heavy code.  Use TextEncoder when available for
+  // accuracy with multibyte content.
+  if (typeof TextEncoder !== "undefined") {
+    return new TextEncoder().encode(s).length;
+  }
+  return s.length;
+}
+
+function byteLengthOfJsonStringify(v: unknown): number {
+  try {
+    return byteLength(JSON.stringify(v));
+  } catch {
+    return 0;
+  }
+}
+
+export function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const kb = n / 1024;
+  if (kb < 100) return `${kb.toFixed(1)} KB`;
+  if (kb < 1024) return `${Math.round(kb)} KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)} MB`;
+}

--- a/src/utils/permissionRequest.ts
+++ b/src/utils/permissionRequest.ts
@@ -29,7 +29,7 @@ export interface PermResponse {
 
 export type PermissionDecision =
   | { kind: "allow"; updatedInput?: Record<string, unknown>; persist?: string }
-  | { kind: "deny" };
+  | { kind: "deny"; message?: string };
 
 export function isPermRequest(v: unknown): v is PermRequest {
   if (!v || typeof v !== "object") return false;
@@ -56,7 +56,12 @@ export function buildPermResponse(id: string, decision: PermissionDecision): Per
   return {
     type: "_hermes_perm_response",
     id,
-    decision: { behavior: "deny", message: "user declined" },
+    decision: {
+      behavior: "deny",
+      message: decision.message && decision.message.trim() !== ""
+        ? decision.message
+        : "user declined",
+    },
   };
 }
 

--- a/src/utils/sendAgentEnvelope.ts
+++ b/src/utils/sendAgentEnvelope.ts
@@ -34,9 +34,7 @@ export async function sendAgentEnvelopeWithRevive(
     return;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    if (!/not found/i.test(message)) {
-      throw err;
-    }
+    if (!/not found/i.test(message)) throw err;
     const ok = await deps.respawn(sessionId);
     if (!ok) {
       throw new Error("Could not revive Claude subprocess to deliver tool response");


### PR DESCRIPTION
## Summary

Two stacked fixes to the agent session experience.

### 1. Interactive tools — Send button silently dropped in plan mode (`ae49d49`)

Plan-mode rejections, AskUserQuestion answers, and ExitPlanMode approvals were silently dropped: the host wrote `tool_result` envelopes, but the SDK gates these tools through `canUseTool` and waits for `updatedInput` instead.  Worse, when the host approved without editing input, the bridge omitted `updatedInput` entirely and the SDK threw `ZodError(expected record, received undefined)`.

- `AskUserQuestion` and `ExitPlanMode` now flow through `canUseTool` again — `allowedTools` no longer auto-allows them.
- `InteractivePermissionDispatcher` routes perm-requests by tool name to the right card.  Cards answer through the existing `_hermes_perm_request` / `_hermes_perm_response` round-trip.  Approve → `{behavior: "allow", updatedInput}`; reject → `{behavior: "deny", message: <feedback>}` so plan-rejection feedback reaches Claude verbatim.
- `buildAskAnswersUpdatedInput` produces the SDK-canonical answers record (single = label, multi = comma-joined, "Other" surfaces typed notes).  Schema confirmed against the bundled Claude Code binary.
- Bridge's allow-decision normalization extracted to `canUseToolHelpers.mjs` and unit-tested for the ZodError regression.

**Picker drift (Plan / Default chip out of sync when Claude itself flips mode):**

- Bridge emits `_hermes_state_changed` envelopes when its tracked `model` / `permissionMode` drift mid-session (EnterPlanMode tool, `/model`, etc).
- `useAgentInit.reduceInit` patches the cached init from those events; `SessionContext` mirrors the new values into the per-session refs so the next respawn doesn't revert.

**Cosmetic:** "Esccancel" smushed text fixed by splitting Esc into its own kbd chip.

### 2. Session timeline redesign — archetype paint per theme (`9bdd200`)

The session window read like an ugly terminal: tool blocks dumped raw pretty-printed JSON in unbounded `<pre>` elements, the masthead's flex-wrap collapsed cost lozenge into the STOP button on narrow panes, and three semantic colors were hand-coded as RGB so every theme inherited the same generic glow.

Reshaped in four passes:

- **Worst-offender ugly-fixes.** Three hand-coded `rgba()` colors migrated to `color-mix(in srgb, var(--…))` so each theme paints its own LED.  GenericToolBlock now surfaces a one-line input summary inline (`"command: git status"`, `"/etc/hosts"`, `"3 keys · 0.4 KB"`) and hides the full payload behind a disclosure that mounts a syntax-highlighted CodeFence on demand, max-height capped at 320px.  Same for ToolResultBlock's structured-content fallback.  Long results (>240 chars or >6 lines) get a `<details>` with a "result · N lines" summary so a Bash dump never blows out the column.  Masthead replaced with a 3-zone CSS grid (status / title / meta).  STOP and cost live in the meta zone so the title is the only cell that ever shrinks.
- **Archetype paint system.** Six rendering archetypes expressed entirely in CSS tokens: `paper-cards` (default), `glass-cards`, `hairline-rules`, `crt-blocks`, `ribbon-rails`, `editorial-margin`.  All tool-block surfaces read these tokens uniformly — no theme branching in the agent CSS.  Each of the 30 themes maps to one archetype via per-theme overrides.
- **Bespoke per-theme touches.** `hacker` / `80s` tool cards get repeating scanline overlays.  `midnight` gets a DOS-style double-line border.  `designer` gets an inline SVG noise paper grain.  `tron` gets a 3px cyan rail with a 2.8s pulse.  `rainbow` gets an animated 6s gradient rail.  `duel` gets an opposing red→green gradient rail.  Glass-family themes get a 10px text-shadow on tool headers.  All keyframes have `prefers-reduced-motion` guards.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test -- --run` — 3017 passing, 152 files (+45 new tests across json-summary, generic-tool-block, theme-archetype-tokens, ask-user-question contract, exit-plan-mode contract, bridge can-use-tool regression, use-agent-init state-changed reducer)
- [x] `cargo test --lib` — 205 passing
- [x] `cargo clippy --lib -- -D warnings` — clean
- [x] In-app smoke: AskUserQuestion answers reach Claude with correct `Record<question, answer>` shape (verified via live-app round-trip with 4 multi-choice questions including "Other" + freeform notes).  ExitPlanMode approve flow exits plan mode gracefully.  `[state-changed]` event fires on session init — picker chips reflect Claude's reported runtime.
- [ ] Visually verify each archetype family in dev mode (glass / paper / hairline / crt / ribbon / editorial) — recommend `hacker` (CRT scanlines), `nightowl` (glass blur), `designer` (paper grain), `tron` (pulse rail), `rainbow` (gradient rail), `minimal-dark` (hairlines).
- [ ] Visually verify masthead alignment at narrow widths (<520px) — STOP and title should never overlap.

## Notes

- This PR ships on top of the merged v1.0.0 work (commit `fa14386`) and the prior clippy fix (`02bd571`).
- All console `[send-debug]` logs added during diagnosis have been stripped — only the existing `[init]` and the new `[state-changed]` info traces remain (matching the existing log style).