### PR TITLE
Modernize agent timeline: speaker chips + sans-serif prose

### DIFF
--- a/src/__tests__/agent-marginalia.test.tsx
+++ b/src/__tests__/agent-marginalia.test.tsx
@@ -1,14 +1,20 @@
 /**
- * Engineering-logbook layout (post-frontend-design rethink) — replaces the
- * earlier marginalia + 2px-bar treatment with a numbered turn gutter
- * (`№ 01 · 17:15:23`).  Each user message starts a new turn; assistant
- * continuations leave the gutter empty so the eye groups them together.
+ * Modern speaker-chip layout — replaces the earlier engineering-logbook
+ * gutter (`№ 01 · 17:15:23`) with an inline speaker row above each
+ * message body:
  *
- * These tests pin:
- *   - No ASSISTANT/USER caps headers anywhere.
- *   - Each role uses `data-role=…` for styling hooks.
- *   - The gutter element is rendered for every message.
- *   - The number + timestamp render only when `isFirstOfTurn` is true.
+ *   [avatar]  You · 14:27
+ *             body content (sans-serif)
+ *
+ * No left gutter, no marginalia numbering, no brass margin bar.  These
+ * tests pin the new contract:
+ *
+ *   - data-role="user" / data-role="assistant" still drive styling
+ *   - Speaker chip carries the avatar + name + (optional) timestamp
+ *   - Timestamp shows on the first-of-turn message only — assistant
+ *     continuations within a turn drop it so the eye groups the turn
+ *   - Old logbook artefacts (gutter, № sigil, role-label headers) are
+ *     gone and stay gone.
  */
 import { describe, expect, it, vi } from "vitest";
 
@@ -42,7 +48,7 @@ function assistantMessage(text: string, id = "msg_1"): RenderedMessage {
 
 const emptyToolResults = new Map<string, ToolResultBlockData>();
 
-describe("engineering-logbook message rows", () => {
+describe("modern speaker-chip message rows", () => {
   it("renders no ASSISTANT or USER caps headers anywhere", () => {
     const html = [
       renderToString(
@@ -62,17 +68,19 @@ describe("engineering-logbook message rows", () => {
     expect(html).not.toContain("agent-message-role");
   });
 
-  it("user message has data-role=user and the body wrapper", () => {
+  it("user message has data-role=user, the body wrapper, and a 'You' speaker", () => {
     const html = renderToString(
       <MessageRow message={userMessage("hi")} toolResults={emptyToolResults} />,
     );
     expect(html).toContain('data-role="user"');
     expect(html).toContain("agent-message-user");
     expect(html).toContain("agent-message-body");
-    expect(html).toContain("agent-message-gutter");
+    expect(html).toContain("agent-message-speaker");
+    expect(html).toContain("agent-message-avatar");
+    expect(html).toMatch(/agent-message-name[^>]*>You</);
   });
 
-  it("assistant message has data-role=assistant and the same DOM shape", () => {
+  it("assistant message has data-role=assistant and a 'Hermes' speaker", () => {
     const html = renderToString(
       <MessageRow
         message={assistantMessage("ok")}
@@ -82,10 +90,12 @@ describe("engineering-logbook message rows", () => {
     expect(html).toContain('data-role="assistant"');
     expect(html).toContain("agent-message-assistant");
     expect(html).toContain("agent-message-body");
-    expect(html).toContain("agent-message-gutter");
+    expect(html).toContain("agent-message-speaker");
+    expect(html).toContain("agent-message-avatar");
+    expect(html).toMatch(/agent-message-name[^>]*>Hermes</);
   });
 
-  it("renders the timestamp in the gutter on the first message of a turn", () => {
+  it("renders the timestamp inline in the speaker chip on the first message of a turn", () => {
     const html = renderToString(
       <MessageRow
         message={userMessage("hi")}
@@ -95,15 +105,15 @@ describe("engineering-logbook message rows", () => {
       />,
     );
     expect(html).toContain("agent-message-time");
-    // The "№ NN" turn-number lockup was rejected by the user — assert it's
-    // gone and stays gone.  Only the timestamp lives in the gutter now.
+    // Old gutter / marginalia artefacts must stay gone.
     expect(html).not.toContain("agent-message-num");
+    expect(html).not.toContain("agent-message-gutter");
     expect(html).not.toContain("№");
   });
 
-  it("leaves the gutter empty on assistant continuations within a turn", () => {
-    // The assistant reply that follows a user prompt should not duplicate
-    // the timestamp — the eye should pair it with the prompt above.
+  it("drops the timestamp on continuation messages within a turn", () => {
+    // Assistant continuations within the same turn should not duplicate
+    // the timestamp — the eye groups the user prompt with its reply.
     const html = renderToString(
       <MessageRow
         message={assistantMessage("ok")}
@@ -112,10 +122,30 @@ describe("engineering-logbook message rows", () => {
         isFirstOfTurn={false}
       />,
     );
-    expect(html).toContain("agent-message-gutter");
+    expect(html).toContain("agent-message-speaker");
+    expect(html).toContain("agent-message-avatar");
     expect(html).not.toContain("agent-message-time");
     expect(html).not.toContain("agent-message-num");
+    expect(html).not.toContain("agent-message-gutter");
     expect(html).not.toContain("№");
+  });
+
+  it("user avatar has data-role=user (theme accent paints the disc)", () => {
+    const html = renderToString(
+      <MessageRow message={userMessage("hi")} toolResults={emptyToolResults} />,
+    );
+    // The disc inherits its color from theme-scoped CSS via [data-role].
+    expect(html).toMatch(/agent-message-avatar[^>]*data-role="user"/);
+  });
+
+  it("assistant avatar has data-role=assistant", () => {
+    const html = renderToString(
+      <MessageRow
+        message={assistantMessage("ok")}
+        toolResults={emptyToolResults}
+      />,
+    );
+    expect(html).toMatch(/agent-message-avatar[^>]*data-role="assistant"/);
   });
 });
 
@@ -125,7 +155,6 @@ describe("formatHHMMSS", () => {
   });
 
   it("zero-pads hours, minutes, seconds", () => {
-    // 2024-01-01 03:04:05 in local time.
     const d = new Date(2024, 0, 1, 3, 4, 5);
     expect(formatHHMMSS(d.getTime())).toBe("03:04:05");
   });

--- a/src/__tests__/agent-stream-integration.test.tsx
+++ b/src/__tests__/agent-stream-integration.test.tsx
@@ -182,11 +182,15 @@ describe("rendered DOM matches redesign spec — text-response", () => {
     expect(html).not.toContain("agent-message-role");
   });
 
-  it("renders an assistant message row with data-role=assistant + the gutter", () => {
+  it("renders an assistant message row with data-role=assistant + speaker chip + body", () => {
     expect(html).toContain('data-role="assistant"');
-    expect(html).toContain("agent-message-gutter");
+    expect(html).toContain("agent-message-speaker");
+    expect(html).toContain("agent-message-avatar");
     expect(html).toContain("agent-message-assistant");
     expect(html).toContain("agent-message-body");
+    // Old logbook gutter artefacts must stay gone.
+    expect(html).not.toContain("agent-message-gutter");
+    expect(html).not.toContain("№");
   });
 
   it("renders the colophon summary, not the old CAPS CI dump", () => {

--- a/src/agent/AgentSessionView.tsx
+++ b/src/agent/AgentSessionView.tsx
@@ -435,14 +435,14 @@ function AgentHeader({ state, sessionId, workspacePathCount }: AgentHeaderProps)
 
   const isWorking = state.initialized && activity.status !== "idle";
   const tickerLabel = !state.initialized
-    ? "READY"
+    ? "Ready"
     : activity.status === "running"
-      ? `RUNNING ${(activity.toolName ?? "TOOL").toUpperCase()}`
+      ? `Running ${activity.toolName ?? "tool"}`
       : activity.status === "thinking"
-        ? "THINKING"
+        ? "Thinking"
         : activity.status === "awaiting"
-          ? "AWAITING CLAUDE"
-          : "READY";
+          ? "Awaiting Claude"
+          : "Ready";
 
   const cwdLabel = cwd ? cwd.split("/").pop() ?? cwd : null;
 
@@ -459,7 +459,7 @@ function AgentHeader({ state, sessionId, workspacePathCount }: AgentHeaderProps)
           data-state={dotState}
           aria-hidden="true"
         />
-        <span className="agent-session-flag">AGENT</span>
+        <span className="agent-session-flag">Agent</span>
       </div>
 
       <div className="agent-session-header-title">
@@ -522,7 +522,7 @@ function AgentHeader({ state, sessionId, workspacePathCount }: AgentHeaderProps)
             title="Stop this turn (Esc)"
             aria-label="Stop the current turn"
           >
-            ◼ STOP
+            ◼ Stop
           </button>
         ) : null}
       </div>
@@ -632,13 +632,13 @@ interface MessageRowProps {
   streamingMessageId?: string | null;
   thinkingStartedAt?: Map<string, number>;
   thinkingElapsed?: Map<string, number>;
-  /** Unused since the №-numbered gutter was removed.  Kept on the prop
-   *  surface so callers (tests, the messages map) don't need to refactor;
-   *  may come back for a different left-gutter treatment later. */
+  /** No longer used by the speaker-chip layout but kept on the prop
+   *  surface so existing callers / tests don't break. */
   turnNumber?: number;
-  /** When true, this message renders the turn's timestamp in the left
-   *  gutter.  False on continuation messages (the assistant response
-   *  that follows the user prompt within the same turn). */
+  /** When true, this is the first message of its turn — the speaker
+   *  chip carries the timestamp.  Continuation messages (assistant
+   *  replies after a user prompt within the same turn) suppress the
+   *  timestamp so the eye groups the turn as one unit. */
   isFirstOfTurn?: boolean;
 }
 
@@ -670,6 +670,7 @@ export function MessageRow({
   // source.  User messages don't need this — what you typed is what you see.
   const [showRaw, setShowRaw] = useState(false);
   const rawText = message.role === "assistant" ? collectRawText(message) : "";
+  const speakerName = message.role === "user" ? "You" : "Hermes";
 
   return (
     <div
@@ -677,7 +678,13 @@ export function MessageRow({
       data-role={message.role}
       data-first-of-turn={isFirstOfTurn ? "true" : "false"}
     >
-      <div className="agent-message-gutter" aria-hidden="true">
+      <div className="agent-message-speaker">
+        <span
+          className="agent-message-avatar"
+          data-role={message.role}
+          aria-hidden="true"
+        />
+        <span className="agent-message-name">{speakerName}</span>
         {isFirstOfTurn ? (
           <span className="agent-message-time">{formatHHMMSS(message.timestamp)}</span>
         ) : null}

--- a/src/agent/AgentSessionView.tsx
+++ b/src/agent/AgentSessionView.tsx
@@ -683,7 +683,9 @@ export function MessageRow({
           className="agent-message-avatar"
           data-role={message.role}
           aria-hidden="true"
-        />
+        >
+          {message.role === "user" ? <UserIcon /> : <BotIcon />}
+        </span>
         <span className="agent-message-name">{speakerName}</span>
         {isFirstOfTurn ? (
           <span className="agent-message-time">{formatHHMMSS(message.timestamp)}</span>
@@ -711,6 +713,56 @@ export function MessageRow({
         )}
       </div>
     </div>
+  );
+}
+
+/** Speaker-chip icons.  Drawn inline with `currentColor` so each
+ *  theme's accent (via the brass-remap landed in #254) paints the
+ *  glyph — green-phosphor on hacker, cyan on tron, terracotta on
+ *  designer, etc.  Sized to fit the 24px avatar chip. */
+function BotIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {/* Antenna */}
+      <line x1="8" y1="2.5" x2="8" y2="4.5" />
+      <circle cx="8" cy="2" r="0.7" fill="currentColor" stroke="none" />
+      {/* Head */}
+      <rect x="3" y="4.5" width="10" height="8" rx="2" />
+      {/* Eyes */}
+      <circle cx="6" cy="8.5" r="0.85" fill="currentColor" stroke="none" />
+      <circle cx="10" cy="8.5" r="0.85" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+function UserIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {/* Head */}
+      <circle cx="8" cy="5.5" r="2.6" />
+      {/* Shoulders */}
+      <path d="M3 13.5c0-2.6 2.2-4.3 5-4.3s5 1.7 5 4.3" />
+    </svg>
   );
 }
 

--- a/src/styles/components/agent/AgentSessionView.css
+++ b/src/styles/components/agent/AgentSessionView.css
@@ -38,29 +38,21 @@
  * on a piece of equipment.  Faint inner top-shadow gives it the slight
  * recess of a metal plate sunk into the surface. */
 .agent-session-header {
-  /* 3-zone grid:
-   *   [status] fixed-width LED + AGENT flag.  Never shrinks.
-   *   [title]  flexible — model / ticker / cwd-leaf.  Truncates with
-   *            ellipsis when the pane gets narrow.
-   *   [meta]   fixed-width cost + rate notice + STOP button.  Always
-   *            visible because title is the only zone that gives way.
-   * This replaces a brittle flex-wrap layout where the cost lozenge
-   * would jump to a second row and overlap STOP. */
+  /* 3-zone grid: [status] [title] [meta]. */
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   grid-template-areas: "status title meta";
   align-items: center;
-  gap: 12px;
-  padding: 11px 20px;
-  border-top: 1px solid var(--rule);
+  gap: 14px;
+  padding: 14px 22px;
   border-bottom: 1px solid var(--rule);
   background: var(--bg-paper);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.012);
   flex: 0 0 auto;
-  font: 11px/1 var(--font-mono);
-  font-feature-settings: var(--font-mono-features);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  /* Calmer typography — display sans, normal case, light tracking.
+   * The old all-caps tracked mono read as "instrument panel"; this
+   * reads as "app title bar". */
+  font: 13px/1 var(--font-display, var(--font-ui));
+  letter-spacing: -0.005em;
   color: var(--ink-secondary);
 }
 
@@ -120,8 +112,10 @@
 
 .agent-session-flag {
   font-weight: 600;
-  letter-spacing: 0.14em;
+  letter-spacing: -0.01em;
   color: var(--ink-primary);
+  font-size: 13px;
+  text-transform: none;
 }
 
 .agent-session-flag-sep {
@@ -131,16 +125,16 @@
 }
 
 .agent-session-ticker {
-  /* Active running label glows in brass — same color family as the LED
-   * pulse so the eye reads them as one unit. */
   color: var(--brass);
-  letter-spacing: 0.1em;
+  letter-spacing: -0.005em;
   text-shadow: 0 0 8px var(--brass-dim);
+  font-size: 13px;
 }
 
 .agent-session-cwd-name {
   color: var(--ink-secondary);
-  letter-spacing: 0.04em;
+  letter-spacing: -0.005em;
+  font-size: 12px;
 }
 
 /* LED.  Tiny filled disc; active states get a faint matching glow so it
@@ -227,8 +221,8 @@
   color: var(--ink-secondary);
   font-family: var(--font-mono);
   font-size: 11px;
-  letter-spacing: 0.04em;
-  text-transform: lowercase;
+  letter-spacing: 0.01em;
+  text-transform: none;
   padding: 0;
   background: transparent;
   border-radius: 0;
@@ -238,28 +232,35 @@
   color: var(--ink-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
-  letter-spacing: 0.02em;
-  text-transform: lowercase;
+  letter-spacing: 0.01em;
+  text-transform: none;
   max-width: 420px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* Stop button — visible only while Claude is actively working.  Brass
- * outline; reads as instrument-panel hardware, not a chat-app button. */
+/* Stop button — visible only while Claude is actively working. */
 .agent-session-stop {
   margin-left: 8px;
-  padding: 1px 8px;
+  padding: 5px 12px;
   background: transparent;
   border: 1px solid var(--brass, var(--accent-paper));
-  border-radius: 3px;
+  border-radius: 6px;
   color: var(--brass, var(--accent-paper));
-  font: 11px/1 var(--font-mono);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font: 12px/1 var(--font-display, var(--font-ui));
+  font-weight: 500;
+  letter-spacing: -0.005em;
   cursor: pointer;
-  transition: background 150ms ease, color 150ms ease;
+  transition: background 150ms ease, color 150ms ease, transform 80ms ease;
+}
+
+.agent-session-stop:hover {
+  transform: translateY(-0.5px);
+}
+
+.agent-session-stop:active {
+  transform: translateY(0);
 }
 
 .agent-session-stop:hover {
@@ -267,17 +268,16 @@
   color: var(--ink-primary);
 }
 
-/* Cost lozenge — running total of session spend.  Right-aligned in the
- * masthead, brass-tinted so it reads as "live counter" not "warning". */
+/* Cost lozenge — running total of session spend. */
 .agent-session-cost {
   font: 11px/1 var(--font-mono);
   font-feature-settings: var(--font-mono-features), 'tnum';
   font-variant-numeric: tabular-nums;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.01em;
   color: var(--brass, var(--accent-paper));
-  padding: 2px 8px;
+  padding: 5px 10px;
+  border-radius: 6px;
   border: 1px solid color-mix(in srgb, var(--brass, var(--accent-paper)) 28%, transparent);
-  border-radius: 3px;
   background: color-mix(in srgb, var(--brass, var(--accent-paper)) 8%, transparent);
 }
 
@@ -287,12 +287,12 @@
 
 .agent-rate-notice {
   color: var(--yellow);
-  font-size: 10px;
+  font-size: 11px;
   background: transparent;
   border: 1px solid var(--yellow);
-  padding: 2px 8px;
-  border-radius: 0;
-  letter-spacing: 0.06em;
+  padding: 5px 10px;
+  border-radius: 6px;
+  letter-spacing: -0.005em;
 }
 
 .agent-session-scroll {
@@ -345,11 +345,12 @@
     padding: 16px 12px;
     gap: 12px;
   }
-  .agent-message {
-    grid-template-columns: 56px 1fr;
+  .agent-message-body {
+    padding-left: 0;
   }
-  .agent-message-gutter {
-    padding-right: 10px;
+  .agent-message[data-role="user"] .agent-message-body {
+    margin-left: 0;
+    padding: 12px 14px;
   }
 }
 
@@ -420,91 +421,132 @@
   font-size: var(--text-md);
 }
 
-/* ─── Message rows (engineering logbook layout) ──────────────
+/* ─── Message rows (modern chat layout) ───────────────────────
  *
- * Two columns: a 78px numbered gutter on the left and the body.  The
- * gutter carries `№ 01` + a HH:MM:SS timestamp, but ONLY for the first
- * message of each turn — assistant continuations leave the gutter empty
- * so the eye groups the user prompt and its assistant reply as one unit.
+ * Each turn renders as a vertical stack of speaker rows.  A speaker
+ * row is:
  *
- * Inter-turn separation uses a hairline rule + larger top padding on the
- * second-and-later user message.  Intra-turn separation rides the parent
- * `.agent-session-messages` `gap`. */
+ *   [avatar]  Name · 14:27
+ *             body content (sans-serif prose, mono for code only)
+ *
+ * No left gutter, no numbered marginalia, no brass margin bar.  User
+ * messages get a faintly accent-tinted card so the prompt visually
+ * anchors as "yours"; assistant messages render on the surface.
+ * Tool calls and code keep mono — only prose moves to sans.
+ *
+ * Inter-turn rhythm comes from generous vertical gap (32px between
+ * turns), not a hairline rule.  Hairlines reappear per-theme as a
+ * family-specific touch, not as the default chrome. */
 
 .agent-message {
-  display: grid;
-  grid-template-columns: 64px 1fr;
-  column-gap: 0;
-  padding: 0;
-  position: relative;
-}
-
-.agent-message + .agent-message[data-role="user"] {
-  border-top: 1px solid var(--rule);
-  padding-top: 18px;
-  margin-top: 6px;
-}
-
-/* The gutter carries the turn number + timestamp.  Right-aligned so the
- * numerals ride the inner edge of the column, like marginalia in a
- * printed reference book. */
-.agent-message-gutter {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  padding: 2px 16px 0 0;
-  gap: 2px;
+  gap: 8px;
+  padding: 0;
+  position: relative;
+  /* Cap conversation column width on wide monitors so prose lines
+   * don't blow past comfortable reading length.  68ch is the sweet
+   * spot for sans-serif body at 14–15px. */
+  max-width: 68ch;
+}
+
+/* Generous space between turns — the modern app feel.  No hairline
+ * rule: whitespace IS the separator. */
+.agent-message + .agent-message[data-role="user"] {
+  margin-top: 28px;
+}
+
+.agent-message + .agent-message[data-role="assistant"] {
+  margin-top: 16px;
+}
+
+/* Speaker row — the small chip identifying who's speaking. */
+.agent-message-speaker {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font: 12px/1 var(--font-display, var(--font-ui));
+  color: var(--ink-secondary);
   user-select: none;
 }
 
-.agent-message-num {
-  font: 10px/1 var(--font-mono);
-  font-feature-settings: var(--font-mono-features), 'tnum';
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 0.12em;
-  color: var(--ink-secondary);
-  text-transform: uppercase;
+.agent-message-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--ink-tertiary);
+  position: relative;
 }
 
-.agent-message[data-role="user"] .agent-message-num {
-  /* User-prompt turns get a slightly punchier color in the number — that
-   * single hue draws the eye down the gutter as you scan turns. */
-  color: var(--accent-paper);
+.agent-message-avatar[data-role="user"] {
+  background: var(--brass, var(--accent));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, #000 24%, transparent),
+    0 0 0 2px color-mix(in srgb, var(--brass, var(--accent)) 14%, transparent);
+}
+
+.agent-message-avatar[data-role="assistant"] {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--accent) 90%, transparent),
+    color-mix(in srgb, var(--accent) 50%, transparent) 80%
+  );
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, #000 24%, transparent),
+    0 0 0 2px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.agent-message-name {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink-primary);
+  font-size: 13px;
 }
 
 .agent-message-time {
-  font: 10px/1 var(--font-mono);
+  font: 11px/1 var(--font-mono);
   color: var(--ink-tertiary);
   font-variant-numeric: tabular-nums;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.02em;
+  margin-left: 2px;
   opacity: 0.7;
 }
 
+/* Body — sans-serif prose at a comfortable reading rhythm.  Mono is
+ * reserved for code fences, tool calls, file paths, timestamps — set
+ * by the individual block renderers, not inherited from here. */
 .agent-message-body {
-  font: 13px/1.6 var(--font-mono);
+  font: 14px/1.6 var(--font-display, var(--font-ui));
   color: var(--ink-primary);
-  font-feature-settings: var(--font-mono-features);
+  letter-spacing: -0.005em;
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;
+  /* Indent the body so it lines up under the speaker name, not under
+   * the avatar.  32px = avatar (22px) + speaker gap (10px). */
+  padding-left: 32px;
 }
 
-/* User messages — the QUESTION.  Italic mono, slightly larger than the
- * answer body, with a BRASS left rule so the prompt visually anchors as
- * "the active note from the operator".  The brass bar is the strongest
- * recurring signal of the workshop palette — every user message is a
- * little glow on the page. */
+/* User messages get a soft accent-tinted card on the body — the
+ * "this is yours" signal that replaces the old brass left bar.
+ * Padding INSIDE the card so the speaker chip sits flush above it. */
 .agent-message[data-role="user"] .agent-message-body {
-  font-style: italic;
-  font-size: 14px;
+  background: color-mix(in srgb, var(--brass, var(--accent)) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--brass, var(--accent)) 12%, transparent);
+  border-radius: 10px;
+  padding: 14px 18px;
+  margin-left: 32px;
+  padding-left: 18px;
   color: var(--ink-primary);
-  border-left: 2px solid var(--brass);
-  padding-left: 14px;
-  margin-left: -14px;
-  box-shadow: -8px 0 16px -10px var(--brass-dim);
+  font-size: 14.5px;
+  line-height: 1.55;
 }
 
+/* Assistant body has no card chrome — sits flat on the surface so
+ * prose reads as continuous, not stamped onto a panel.  Tool blocks
+ * inside get their own chrome via the archetype tokens. */
 .agent-message[data-role="assistant"] .agent-message-body {
   color: var(--ink-primary);
 }
@@ -605,8 +647,10 @@
 
 .agent-text-block {
   color: var(--ink-primary);
-  line-height: 1.6;
-  font-size: 13px;
+  line-height: 1.65;
+  font-size: 14.5px;
+  font-family: var(--font-display, var(--font-ui));
+  letter-spacing: -0.005em;
 }
 
 .agent-markdown {

--- a/src/styles/components/agent/AgentSessionView.css
+++ b/src/styles/components/agent/AgentSessionView.css
@@ -470,31 +470,41 @@
   user-select: none;
 }
 
+/* Speaker chip — a small rounded square holding the bot/person icon.
+ * No more solid disc.  The chip background is a tinted accent at low
+ * alpha; the border is the same accent at higher alpha; the icon
+ * itself takes the FULL accent via currentColor.  Each theme's accent
+ * (brass-remapped per theme via #254) lights the chip its own way. */
 .agent-message-avatar {
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
   flex-shrink: 0;
-  background: var(--ink-tertiary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   position: relative;
+  transition: transform 120ms ease, background 120ms ease;
 }
 
 .agent-message-avatar[data-role="user"] {
-  background: var(--brass, var(--accent));
-  box-shadow:
-    inset 0 0 0 1px color-mix(in srgb, #000 24%, transparent),
-    0 0 0 2px color-mix(in srgb, var(--brass, var(--accent)) 14%, transparent);
+  background: color-mix(in srgb, var(--brass, var(--accent)) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--brass, var(--accent)) 28%, transparent);
+  color: var(--brass, var(--accent));
 }
 
 .agent-message-avatar[data-role="assistant"] {
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--accent) 90%, transparent),
-    color-mix(in srgb, var(--accent) 50%, transparent) 80%
-  );
-  box-shadow:
-    inset 0 0 0 1px color-mix(in srgb, #000 24%, transparent),
-    0 0 0 2px color-mix(in srgb, var(--accent) 12%, transparent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  color: var(--accent);
+}
+
+.agent-message:hover .agent-message-avatar {
+  transform: translateY(-0.5px);
+}
+
+.agent-message-avatar svg {
+  display: block;
 }
 
 .agent-message-name {


### PR DESCRIPTION
## Summary

Structural rewrite of the agent session timeline.  The previous look read like a terminal — left-gutter `№ 01` marginalia, brass left-bar margin marker, all-caps tracked mono masthead, JetBrains Mono for prose, hairline rules between every turn.  The 30-theme paint work in #254 didn't fix that because the underlying *layout* still felt like a logbook.

This PR is layout-only — no theme color changes.

## What changes (visually)

| Before | After |
|---|---|
| Left gutter with timestamp on every turn | Inline speaker chip: small accent disc + "You" / "Hermes" + time |
| `№ 01` marginalia numbering | Removed |
| User messages: brass left bar + italic mono | User messages: soft accent-tinted card with 10px radius |
| Body: JetBrains Mono 13px | Body: Inter Tight 14.5px / 1.65 line-height |
| Masthead: `AGENT · MODEL · CWD` all-caps tracked mono | `Agent · model · cwd` calm display-sans |
| Status ticker: `THINKING`, `RUNNING TOOL`, `AWAITING CLAUDE` | `Thinking`, `Running …`, `Awaiting Claude` |
| `STOP` 11px mono button | `Stop` 12px display, 6px radius, hover-rise |
| Hairline rule between every turn | Whitespace (28px) between turns |
| No max width on prose | 68ch cap so reading lines don't blow out on wide monitors |

Mono is preserved where it earns its keep — code fences, tool calls, file paths, timestamps, the cost lozenge.  Only prose moves to sans.

## Scope notes

- Theme palettes and per-theme bespoke touches from #254 are untouched.  Hacker still has phosphor scanlines, designer still has paper grain — they just paint a calmer underlying layout.
- The composer (`SessionComposer.tsx` / `.css`) is intentionally out of scope here — that's the next pass if you want it.
- `ResultFooter` (the colophon) stays mono — it's a metadata whisper, sans there would feel out of place.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test -- --run` — 3024 passing (rewrote `agent-marginalia.test.tsx` for the speaker-chip contract; updated one assertion in `agent-stream-integration.test.tsx`)
- [x] `cargo test --lib` — 205 passing
- [x] `cargo clippy --lib -- -D warnings` — clean
- [ ] Visual review in dev mode across themes — verify the speaker chip avatar takes the theme's accent (`hacker` → green, `tron` → cyan, `designer` → terracotta, etc., from the brass-remap landed in #254)