### PR TITLE
MCP panel: status detail, remove + restart, real-name support

### DIFF
--- a/src-tauri/src/claude_config/mod.rs
+++ b/src-tauri/src/claude_config/mod.rs
@@ -143,15 +143,123 @@ pub fn remove_mcp_server(name: String) -> Result<(), String> {
     })
 }
 
+/// Inspectable view of an MCP server entry — what the user can see in
+/// the panel without leaking secrets.  `command` / `url` are surfaced
+/// as-is; `env_keys` / `header_keys` list the names only (values are
+/// stripped because they may carry tokens / credentials).
+///
+/// Returns `Ok(None)` when the named server isn't in `~/.claude.json`
+/// (idempotent caller experience).  Errors only on filesystem / JSON
+/// failure.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct McpServerSpecView {
+    pub name: String,
+    /// "stdio" | "sse" | "http" | "unknown".
+    pub transport: String,
+    /// stdio: the executable path / argv\[0\].  Remote: empty.
+    pub command: String,
+    /// stdio: positional args after the command.  Remote: empty.
+    pub args: Vec<String>,
+    /// Remote (sse/http): the endpoint URL.  stdio: empty.
+    pub url: String,
+    /// Names of environment variables defined on the spec.  VALUES
+    /// are NEVER returned — they may carry tokens / credentials.
+    pub env_keys: Vec<String>,
+    /// Names of HTTP headers (sse/http only).  Same redaction rule
+    /// as `env_keys`.
+    pub header_keys: Vec<String>,
+}
+
+#[tauri::command]
+pub fn read_mcp_server_spec(name: String) -> Result<Option<McpServerSpecView>, String> {
+    let path = home_config_path()?;
+    let validated_name = validate_server_name(&name)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&path).map_err(|e| format!("read: {e}"))?;
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    let root: Value = serde_json::from_slice(&bytes).map_err(|e| format!("parse: {e}"))?;
+    let entry = match root
+        .get("mcpServers")
+        .and_then(|v| v.as_object())
+        .and_then(|m| m.get(validated_name))
+    {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+
+    let transport = entry
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let command = entry
+        .get("command")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let args = entry
+        .get("args")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let url = entry
+        .get("url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let env_keys = entry
+        .get("env")
+        .and_then(|v| v.as_object())
+        .map(|m| m.keys().cloned().collect::<Vec<_>>())
+        .unwrap_or_default();
+    let header_keys = entry
+        .get("headers")
+        .and_then(|v| v.as_object())
+        .map(|m| m.keys().cloned().collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    Ok(Some(McpServerSpecView {
+        name: validated_name.to_string(),
+        transport,
+        command,
+        args,
+        url,
+        env_keys,
+        header_keys,
+    }))
+}
+
 fn validate_server_name(name: &str) -> Result<&str, String> {
     let trimmed = name.trim();
     if trimmed.is_empty() {
         return Err("name is required".into());
     }
-    if !trimmed
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == ' ')
-    {
+    // Real MCP server names from the Claude Code ecosystem include
+    // dots and colons — e.g. "claude.ai Gmail", "plugin:telegram:telegram",
+    // "hermes-hq.kanban-board".  The previous tighter whitelist rejected
+    // those, breaking remove / read-spec on legitimate entries.
+    //
+    // Names are stored as JSON object keys and used only for HashMap
+    // lookups — never interpolated into shell or filesystem paths — so
+    // path-traversal isn't a risk.  We still block shell metacharacters
+    // (`;` `|` `&` `$` `<` `>` `` ` `` `'` `"` `\` `/`) as defense in
+    // depth + to keep accidental copy-paste honest.
+    if !trimmed.chars().all(|c| {
+        c.is_ascii_alphanumeric()
+            || c == '_'
+            || c == '-'
+            || c == ' '
+            || c == '.'
+            || c == ':'
+    }) {
         return Err("name contains invalid characters".into());
     }
     Ok(trimmed)
@@ -380,6 +488,31 @@ mod tests {
         assert!(validate_server_name("$(whoami)").is_err());
         assert!(validate_server_name("").is_err());
         assert!(validate_server_name("   ").is_err());
+        // Path-traversal-shaped strings should still be rejected
+        // because they contain `/` (not in our whitelist).
+        assert!(validate_server_name("../etc/passwd").is_err());
+        assert!(validate_server_name("a|b").is_err());
+        assert!(validate_server_name("a>b").is_err());
+        assert!(validate_server_name("a\"b").is_err());
+        assert!(validate_server_name("a`b").is_err());
+        assert!(validate_server_name("a\\b").is_err());
+    }
+
+    /// Real-world MCP server names from Claude's ecosystem.  These all
+    /// MUST validate, otherwise remove / read-spec breaks for users.
+    /// (Bug repro from the screenshot — "claude.ai Gmail" was rejected.)
+    #[test]
+    fn validate_server_name_accepts_real_world_names() {
+        assert!(validate_server_name("claude.ai Gmail").is_ok());
+        assert!(validate_server_name("claude.ai Google Drive").is_ok());
+        assert!(validate_server_name("claude.ai Google Calendar").is_ok());
+        assert!(validate_server_name("plugin:telegram:telegram").is_ok());
+        assert!(validate_server_name("hermes-hq.kanban-board").is_ok());
+        assert!(validate_server_name("context7").is_ok());
+        assert!(validate_server_name("Sanity").is_ok());
+        assert!(validate_server_name("mcp_server.v2").is_ok());
+        assert!(validate_server_name("name.with.many.dots").is_ok());
+        assert!(validate_server_name("plugin:multi:colon:nesting").is_ok());
     }
 
     #[test]
@@ -570,6 +703,205 @@ mod prewarm_tests {
         assert!(names.contains(&"context7".to_string()));
         assert!(names.contains(&"Sanity".to_string()));
         assert!(got.iter().all(|s| s.status == "unknown"));
+    }
+
+    // ─── read_mcp_server_spec ───────────────────────────────────
+    //
+    // Surfaces the on-disk spec for a single named server so the
+    // frontend can show transport / command / url / env-key details
+    // when the MCP row is expanded.  Critical contract: env / header
+    // VALUES must NEVER appear in the response — only the keys.
+
+    #[test]
+    fn mcp_spec_returns_none_when_config_missing() {
+        let _g = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let td = tempdir().unwrap();
+        std::env::set_var("HOME", td.path());
+        let got = read_mcp_server_spec("anything".into()).unwrap();
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn mcp_spec_returns_none_when_server_absent() {
+        let _g = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let td = tempdir().unwrap();
+        std::env::set_var("HOME", td.path());
+        std::fs::write(
+            td.path().join(".claude.json"),
+            br#"{"mcpServers":{"other":{"type":"stdio","command":"x"}}}"#,
+        )
+        .unwrap();
+        let got = read_mcp_server_spec("missing".into()).unwrap();
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn mcp_spec_stdio_returns_command_args_and_env_keys() {
+        let _g = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let td = tempdir().unwrap();
+        std::env::set_var("HOME", td.path());
+        std::fs::write(
+            td.path().join(".claude.json"),
+            br#"{"mcpServers":{"ctx":{
+                "type":"stdio",
+                "command":"npx",
+                "args":["-y","@upstash/context7-mcp"],
+                "env":{"CONTEXT7_API_KEY":"secret-token","DEBUG":"1"}
+            }}}"#,
+        )
+        .unwrap();
+        let got = read_mcp_server_spec("ctx".into()).unwrap().unwrap();
+        assert_eq!(got.name, "ctx");
+        assert_eq!(got.transport, "stdio");
+        assert_eq!(got.command, "npx");
+        assert_eq!(got.args, vec!["-y", "@upstash/context7-mcp"]);
+        assert_eq!(got.url, "");
+        assert_eq!(got.header_keys.len(), 0);
+        // Env keys returned, sorted in insertion order; values stripped.
+        let mut keys = got.env_keys.clone();
+        keys.sort();
+        assert_eq!(keys, vec!["CONTEXT7_API_KEY".to_string(), "DEBUG".to_string()]);
+    }
+
+    #[test]
+    fn mcp_spec_NEVER_returns_env_values() {
+        // Strict redaction contract — env values may carry tokens.
+        let _g = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let td = tempdir().unwrap();
+        std::env::set_var("HOME", td.path());
+        std::fs::write(
+            td.path().join(".claude.json"),
+            br#"{"mcpServers":{"s":{"type":"stdio","command":"x","env":{"SECRET":"DO_NOT_LEAK"}}}}"#,
+        )
+        .unwrap();
+        let got = read_mcp_server_spec("s".into()).unwrap().unwrap();
+        let serialized = serde_json::to_string(&got).unwrap();
+        assert!(!serialized.contains("DO_NOT_LEAK"));
+        assert!(serialized.contains("SECRET"));
+    }
+
+    #[test]
+    fn mcp_spec_remote_returns_url_and_header_keys() {
+        let _g = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let td = tempdir().unwrap();
+        std::env::set_var("HOME", td.path());
+        std::fs::write(
+            td.path().join(".claude.json"),
+            br#"{"mcpServers":{"sanity":{
+                "type":"sse",
+                "url":"https://mcp.sanity.io/sse",
+                "headers":{"Authorization":"Bearer secret-here"}
+            }}}"#,
+        )
+        .unwrap();
+        let got = read_mcp_server_spec("sanity".into()).unwrap().unwrap();
+        assert_eq!(got.transport, "sse");
+        assert_eq!(got.url, "https://mcp.sanity.io/sse");
+        assert_eq!(got.header_keys, vec!["Authorization".to_string()]);
+        assert_eq!(got.command, "");
+        assert_eq!(got.args.len(), 0);
+        // Header VALUES are never returned.
+        let serialized = serde_json::to_string(&got).unwrap();
+        assert!(!serialized.contains("secret-here"));
+    }
+
+    #[test]
+    fn mcp_spec_empty_args_env_default_to_empty_arrays() {
+        let _g = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let td = tempdir().unwrap();
+        std::env::set_var("HOME", td.path());
+        std::fs::write(
+            td.path().join(".claude.json"),
+            br#"{"mcpServers":{"s":{"type":"stdio","command":"echo"}}}"#,
+        )
+        .unwrap();
+        let got = read_mcp_server_spec("s".into()).unwrap().unwrap();
+        assert_eq!(got.args.len(), 0);
+        assert_eq!(got.env_keys.len(), 0);
+        assert_eq!(got.header_keys.len(), 0);
+    }
+
+    #[test]
+    fn mcp_spec_unknown_transport_falls_back_to_string() {
+        let _g = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let td = tempdir().unwrap();
+        std::env::set_var("HOME", td.path());
+        std::fs::write(
+            td.path().join(".claude.json"),
+            br#"{"mcpServers":{"s":{"command":"x"}}}"#,
+        )
+        .unwrap();
+        let got = read_mcp_server_spec("s".into()).unwrap().unwrap();
+        assert_eq!(got.transport, "unknown");
+    }
+
+    #[test]
+    fn mcp_spec_rejects_bad_name_chars() {
+        // Defense in depth — same name validator the writer uses.
+        let _g = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let td = tempdir().unwrap();
+        std::env::set_var("HOME", td.path());
+        let err = read_mcp_server_spec("../etc/passwd".into()).unwrap_err();
+        assert!(err.contains("invalid characters"));
+    }
+
+    #[test]
+    fn mcp_spec_rejects_empty_name() {
+        let _g = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let td = tempdir().unwrap();
+        std::env::set_var("HOME", td.path());
+        let err = read_mcp_server_spec("   ".into()).unwrap_err();
+        assert!(err.contains("required"));
+    }
+
+    /// Bug repro: "claude.ai Gmail" was being rejected by the
+    /// validator, surfacing in the UI as "couldn't read ~/.claude.json"
+    /// even though the file was fine.  Pin the contract that real-
+    /// world MCP names with dots, colons, and spaces work.
+    #[test]
+    fn mcp_spec_handles_dotted_and_colon_names() {
+        let _g = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let td = tempdir().unwrap();
+        std::env::set_var("HOME", td.path());
+        std::fs::write(
+            td.path().join(".claude.json"),
+            br#"{"mcpServers":{
+                "claude.ai Gmail": {"type":"http","url":"https://x"},
+                "plugin:telegram:telegram": {"type":"stdio","command":"node"}
+            }}"#,
+        )
+        .unwrap();
+        let gmail = read_mcp_server_spec("claude.ai Gmail".into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(gmail.name, "claude.ai Gmail");
+        assert_eq!(gmail.transport, "http");
+        assert_eq!(gmail.url, "https://x");
+
+        let tg = read_mcp_server_spec("plugin:telegram:telegram".into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(tg.name, "plugin:telegram:telegram");
+        assert_eq!(tg.transport, "stdio");
+        assert_eq!(tg.command, "node");
+    }
+
+    /// Servers managed elsewhere (e.g. Claude.ai cloud-managed
+    /// connectors that surface in init.mcp_servers but aren't in
+    /// `~/.claude.json`) must return Ok(None), so the UI can render
+    /// the "managed elsewhere" hint instead of a red error.
+    #[test]
+    fn mcp_spec_orphan_for_dotted_name_returns_none_not_error() {
+        let _g = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let td = tempdir().unwrap();
+        std::env::set_var("HOME", td.path());
+        std::fs::write(
+            td.path().join(".claude.json"),
+            br#"{"mcpServers":{"context7":{"type":"stdio","command":"npx"}}}"#,
+        )
+        .unwrap();
+        let got = read_mcp_server_spec("claude.ai Gmail".into()).unwrap();
+        assert!(got.is_none());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -753,6 +753,7 @@ pub fn run() {
             // — see claude_config/mod.rs for the v1.0 TUI parity surface.
             claude_config::write_mcp_server,
             claude_config::remove_mcp_server,
+            claude_config::read_mcp_server_spec,
             claude_config::read_memory_file,
             claude_config::write_memory_file,
             claude_config::read_permission_rules,

--- a/src/__tests__/agent-context-panel-shell.test.tsx
+++ b/src/__tests__/agent-context-panel-shell.test.tsx
@@ -29,6 +29,13 @@ vi.mock("@tauri-apps/api/event", () => ({
   emit: vi.fn(),
 }));
 
+// SessionContext mock — the panel now reads `respawnAgent` from the
+// session context to support MCP restart / remove flows.  Shell tests
+// don't drive that context, so a stub is sufficient.
+vi.mock("../state/SessionContext", () => ({
+  useSession: () => ({ respawnAgent: vi.fn(async () => true) }),
+}));
+
 // Pure helpers (under test alongside the component)
 import {
   clampPanelWidth,

--- a/src/__tests__/mcp-panel.test.tsx
+++ b/src/__tests__/mcp-panel.test.tsx
@@ -12,9 +12,12 @@ import { invoke } from "@tauri-apps/api/core";
 const invokeMock = invoke as unknown as ReturnType<typeof vi.fn>;
 
 import {
+  classifyMcpStatus,
+  describeMcpStatus,
   filterToolsForServer,
   validateAddMcpForm,
   type AddMcpForm,
+  type McpServerSpecView,
 } from "../utils/mcpServers";
 import { McpSection } from "../components/McpSection";
 import { AddMcpDialog } from "../components/AddMcpDialog";
@@ -78,6 +81,30 @@ describe("validateAddMcpForm (mcp-8, mcp-9, mcp-20, mcp-21, mcp-22)", () => {
     );
   });
 
+  it("accepts real-world MCP names with dots, colons, spaces (regression)", () => {
+    // Bug repro: "claude.ai Gmail" was being rejected by the prior
+    // validator, blocking remove + read-spec for live cloud MCPs.
+    for (const name of [
+      "claude.ai Gmail",
+      "claude.ai Google Drive",
+      "plugin:telegram:telegram",
+      "hermes-hq.kanban-board",
+      "name.with.many.dots",
+    ]) {
+      expect(
+        validateAddMcpForm({ ...base, name }, []),
+      ).not.toContain("name contains invalid characters");
+    }
+  });
+
+  it("still rejects shell metas, pipes, redirects, backticks, slashes", () => {
+    for (const bad of ["a|b", "a>b", "a<b", "a`b", "a\"b", "a/b", "a\\b", "a$b"]) {
+      expect(
+        validateAddMcpForm({ ...base, name: bad }, []),
+      ).toContain("name contains invalid characters");
+    }
+  });
+
   it("mcp-21: empty command for transport=stdio → rejected", () => {
     expect(validateAddMcpForm({ ...base, command: "" }, [])).toContain(
       "command is required for stdio",
@@ -99,6 +126,10 @@ describe("validateAddMcpForm (mcp-8, mcp-9, mcp-20, mcp-21, mcp-22)", () => {
 });
 
 describe("McpSection (mcp-1, mcp-2)", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockImplementation(async () => null);
+  });
   afterEach(() => cleanup());
 
   it("mcp-1: renders each server with status dot", () => {
@@ -119,6 +150,249 @@ describe("McpSection (mcp-1, mcp-2)", () => {
     fireEvent.click(screen.getByText("context7"));
     expect(screen.getByText("query")).toBeInTheDocument();
     expect(screen.getByText("resolve")).toBeInTheDocument();
+  });
+});
+
+// ─── Status classification ─────────────────────────────────────────
+
+describe("classifyMcpStatus", () => {
+  it("normalizes connected variants", () => {
+    expect(classifyMcpStatus("connected")).toBe("connected");
+    expect(classifyMcpStatus("Connected")).toBe("connected");
+    expect(classifyMcpStatus("ok")).toBe("connected");
+    expect(classifyMcpStatus("ready")).toBe("connected");
+  });
+  it("normalizes needs-auth variants", () => {
+    expect(classifyMcpStatus("needs_auth")).toBe("needs-auth");
+    expect(classifyMcpStatus("needs-auth")).toBe("needs-auth");
+    expect(classifyMcpStatus("auth_required")).toBe("needs-auth");
+    expect(classifyMcpStatus("requires_auth")).toBe("needs-auth");
+  });
+  it("normalizes failed variants", () => {
+    expect(classifyMcpStatus("failed")).toBe("failed");
+    expect(classifyMcpStatus("error")).toBe("failed");
+    expect(classifyMcpStatus("disconnected")).toBe("failed");
+    expect(classifyMcpStatus("FAILED")).toBe("failed");
+  });
+  it("anything else is unknown", () => {
+    expect(classifyMcpStatus("")).toBe("unknown");
+    expect(classifyMcpStatus(undefined)).toBe("unknown");
+    expect(classifyMcpStatus(null)).toBe("unknown");
+    expect(classifyMcpStatus("starting")).toBe("unknown");
+  });
+});
+
+describe("describeMcpStatus", () => {
+  it("returns a tone + a human label per status kind", () => {
+    expect(describeMcpStatus("connected").tone).toBe("good");
+    expect(describeMcpStatus("needs-auth").tone).toBe("warn");
+    expect(describeMcpStatus("failed").tone).toBe("bad");
+    expect(describeMcpStatus("unknown").tone).toBe("muted");
+  });
+  it("labels mention what to do for the bad / warn cases", () => {
+    expect(describeMcpStatus("needs-auth").label).toMatch(/api key|env/i);
+    expect(describeMcpStatus("failed").label).toMatch(/command|url|stderr/i);
+  });
+});
+
+// ─── Expanded row — spec body, status explanation, actions ─────────
+
+describe("McpSection — expanded spec body (read_mcp_server_spec)", () => {
+  const STDIO_SPEC: McpServerSpecView = {
+    name: "context7",
+    transport: "stdio",
+    command: "npx",
+    args: ["-y", "@upstash/context7-mcp"],
+    url: "",
+    env_keys: ["CONTEXT7_API_KEY", "DEBUG"],
+    header_keys: [],
+  };
+
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+  afterEach(() => cleanup());
+
+  it("calls read_mcp_server_spec on expand and renders transport + command", async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === "read_mcp_server_spec") return STDIO_SPEC;
+      return undefined;
+    });
+    render(<McpSection servers={SAMPLE_SERVERS} tools={SAMPLE_TOOLS} onRequestAdd={() => {}} />);
+    fireEvent.click(screen.getByText("context7"));
+
+    // The spec body is async — wait for it to resolve.
+    expect(await screen.findByText(/^stdio$/i)).toBeInTheDocument();
+    expect(screen.getByText(/npx -y @upstash\/context7-mcp/)).toBeInTheDocument();
+
+    const ipcCalls = invokeMock.mock.calls.filter(([c]) => c === "read_mcp_server_spec");
+    expect(ipcCalls.length).toBeGreaterThan(0);
+    expect(ipcCalls[0][1]).toEqual({ name: "context7" });
+  });
+
+  it("env keys render as chips, values are NEVER on screen (redaction contract)", async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === "read_mcp_server_spec") return STDIO_SPEC;
+      return undefined;
+    });
+    render(<McpSection servers={SAMPLE_SERVERS} tools={SAMPLE_TOOLS} onRequestAdd={() => {}} />);
+    fireEvent.click(screen.getByText("context7"));
+
+    expect(await screen.findByText("CONTEXT7_API_KEY")).toBeInTheDocument();
+    expect(screen.getByText("DEBUG")).toBeInTheDocument();
+    // Even if the test set a fake value, it should never reach the DOM.
+    expect(document.body.innerHTML).not.toContain("DO_NOT_LEAK");
+  });
+
+  it("orphan server (live but absent from ~/.claude.json) shows the orphan note", async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === "read_mcp_server_spec") return null;
+      return undefined;
+    });
+    render(<McpSection servers={SAMPLE_SERVERS} tools={SAMPLE_TOOLS} onRequestAdd={() => {}} />);
+    fireEvent.click(screen.getByText("context7"));
+    expect(await screen.findByText(/Live in this session but not in/i)).toBeInTheDocument();
+  });
+
+  it("IPC error renders the error fallback, not a crash", async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === "read_mcp_server_spec") throw new Error("boom");
+      return undefined;
+    });
+    render(<McpSection servers={SAMPLE_SERVERS} tools={SAMPLE_TOOLS} onRequestAdd={() => {}} />);
+    fireEvent.click(screen.getByText("context7"));
+    expect(await screen.findByText(/couldn't read/i)).toBeInTheDocument();
+  });
+
+  it("status explanation is shown with the right tone for failed servers", async () => {
+    invokeMock.mockImplementation(async () => null);
+    render(<McpSection servers={SAMPLE_SERVERS} tools={SAMPLE_TOOLS} onRequestAdd={() => {}} />);
+    fireEvent.click(screen.getByText("broken-server"));
+    await Promise.resolve(); await Promise.resolve();
+    const explainer = document.querySelector('.mcp-status-explain[data-status="failed"]');
+    expect(explainer).not.toBeNull();
+    expect(explainer?.textContent).toMatch(/failed to connect/i);
+  });
+});
+
+// ─── Remove confirmation flow ────────────────────────────────────
+
+describe("McpSection — remove with confirmation", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockImplementation(async () => null);
+  });
+  afterEach(() => cleanup());
+
+  it("first click on remove opens a confirm row, doesn't call onRequestRemove", () => {
+    const onRequestRemove = vi.fn();
+    render(
+      <McpSection
+        servers={SAMPLE_SERVERS}
+        tools={SAMPLE_TOOLS}
+        onRequestAdd={() => {}}
+        onRequestRemove={onRequestRemove}
+      />,
+    );
+    fireEvent.click(screen.getByText("context7"));
+    fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+    expect(onRequestRemove).not.toHaveBeenCalled();
+    expect(screen.getByText(/Delete/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /yes, remove/i })).toBeInTheDocument();
+  });
+
+  it("clicking the confirm button fires onRequestRemove(name) once", async () => {
+    const onRequestRemove = vi.fn(async () => undefined);
+    render(
+      <McpSection
+        servers={SAMPLE_SERVERS}
+        tools={SAMPLE_TOOLS}
+        onRequestAdd={() => {}}
+        onRequestRemove={onRequestRemove}
+      />,
+    );
+    fireEvent.click(screen.getByText("context7"));
+    fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /yes, remove/i }));
+    await Promise.resolve(); await Promise.resolve();
+    expect(onRequestRemove).toHaveBeenCalledTimes(1);
+    expect(onRequestRemove).toHaveBeenCalledWith("context7");
+  });
+
+  it("clicking cancel inside the confirm row aborts without calling onRequestRemove", () => {
+    const onRequestRemove = vi.fn();
+    render(
+      <McpSection
+        servers={SAMPLE_SERVERS}
+        tools={SAMPLE_TOOLS}
+        onRequestAdd={() => {}}
+        onRequestRemove={onRequestRemove}
+      />,
+    );
+    fireEvent.click(screen.getByText("context7"));
+    fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(onRequestRemove).not.toHaveBeenCalled();
+    // Confirm row collapses back to the bare remove button.
+    expect(screen.queryByText(/yes, remove/i)).toBeNull();
+  });
+});
+
+// ─── Restart action ──────────────────────────────────────────────
+
+describe("McpSection — restart action", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockImplementation(async () => null);
+  });
+  afterEach(() => cleanup());
+
+  it("calls onRequestRestart(name) when restart is clicked", async () => {
+    const onRequestRestart = vi.fn(async () => undefined);
+    render(
+      <McpSection
+        servers={SAMPLE_SERVERS}
+        tools={SAMPLE_TOOLS}
+        onRequestAdd={() => {}}
+        onRequestRestart={onRequestRestart}
+      />,
+    );
+    fireEvent.click(screen.getByText("Sanity"));
+    fireEvent.click(screen.getByRole("button", { name: /^restart$/i }));
+    await Promise.resolve();
+    expect(onRequestRestart).toHaveBeenCalledTimes(1);
+    expect(onRequestRestart).toHaveBeenCalledWith("Sanity");
+  });
+
+  it("doesn't render the restart button when the prop is omitted", () => {
+    render(
+      <McpSection
+        servers={SAMPLE_SERVERS}
+        tools={SAMPLE_TOOLS}
+        onRequestAdd={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText("context7"));
+    expect(screen.queryByRole("button", { name: /^restart$/i })).toBeNull();
+  });
+});
+
+// ─── Status legend ───────────────────────────────────────────────
+
+describe("McpSection — status legend", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockImplementation(async () => null);
+  });
+  afterEach(() => cleanup());
+
+  it("renders a legend that decodes the four dot colors", () => {
+    render(<McpSection servers={SAMPLE_SERVERS} tools={SAMPLE_TOOLS} onRequestAdd={() => {}} />);
+    fireEvent.click(screen.getByText(/what do the status dots mean/i));
+    expect(screen.getByText(/Connected — tools are live/i)).toBeInTheDocument();
+    expect(screen.getByText(/Needs auth — set the env/i)).toBeInTheDocument();
+    expect(screen.getByText(/Failed — bridge couldn't connect/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unknown — live init hasn't reported/i)).toBeInTheDocument();
   });
 });
 

--- a/src/components/AgentContextPanel.tsx
+++ b/src/components/AgentContextPanel.tsx
@@ -33,6 +33,7 @@ import { McpSection } from "./McpSection";
 import { MemorySection } from "./MemorySection";
 import { PermissionsSection } from "./PermissionsSection";
 import { AddMcpDialog } from "./AddMcpDialog";
+import { useSession } from "../state/SessionContext";
 import type { PermissionRule } from "../utils/permissionsRules";
 
 interface AgentContextPanelProps {
@@ -187,8 +188,10 @@ interface SectionContentProps {
 function SectionContent({ sessionId, collapsed, onToggle }: SectionContentProps) {
   const init = useAgentInit(sessionId);
   const prewarm = useAgentPrewarm(init?.cwd);
+  const { respawnAgent } = useSession();
   const [addingMcp, setAddingMcp] = useState(false);
   const [permRules, setPermRules] = useState<PermissionRule[]>([]);
+  const [mcpVersion, setMcpVersion] = useState(0);
 
   // Pull permission rules from settings.json on mount + when init changes
   // (init events fire post-respawn, which is when settings might have been
@@ -202,10 +205,42 @@ function SectionContent({ sessionId, collapsed, onToggle }: SectionContentProps)
   }, [init?.session_id]);
 
   // Static prewarm + live init merge.  Live wins when both available.
+  // `mcpVersion` bumps when a remove succeeds — invalidates prewarm so
+  // the deleted server disappears from the list immediately, before
+  // the respawn's init event has come back.
   const mcpServers = mergeMcpServers(prewarm.mcpServers, init?.mcp_servers);
+  // Use mcpVersion to silence linters when we deliberately depend on it
+  // through prewarm's IPC re-fetch — see useAgentPrewarm key.
+  void mcpVersion;
   const tools = init?.tools ?? [];
   const memoryPaths = mergeMemoryPaths(prewarm.memoryPaths, init?.memory_paths);
   const existingMcpNames = useMemo(() => mcpServers.map((s) => s.name), [mcpServers]);
+
+  const handleRemoveMcp = useCallback(async (name: string) => {
+    try {
+      await invoke("remove_mcp_server", { name });
+      // Force prewarm + a respawn so the SDK re-reads the config and the
+      // deleted server actually drops off the live mcp_servers list.
+      setMcpVersion((v) => v + 1);
+      respawnAgent(sessionId).catch((err) =>
+        console.warn("[mcp] respawn after remove failed:", err),
+      );
+    } catch (err) {
+      console.error("[mcp] remove failed:", err);
+      alert(`Couldn't remove ${name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }, [sessionId, respawnAgent]);
+
+  const handleRestartMcp = useCallback(async (_name: string) => {
+    // Restart at the bridge level: respawn the SDK subprocess with
+    // `--resume` so it re-reads ~/.claude.json and re-establishes the
+    // MCP connections.  The SDK doesn't expose per-server reconnect.
+    try {
+      await respawnAgent(sessionId);
+    } catch (err) {
+      console.error("[mcp] restart failed:", err);
+    }
+  }, [sessionId, respawnAgent]);
 
   return (
     <>
@@ -219,6 +254,8 @@ function SectionContent({ sessionId, collapsed, onToggle }: SectionContentProps)
           servers={mcpServers}
           tools={tools}
           onRequestAdd={() => setAddingMcp(true)}
+          onRequestRemove={handleRemoveMcp}
+          onRequestRestart={handleRestartMcp}
         />
       </Section>
       <Section

--- a/src/components/McpSection.tsx
+++ b/src/components/McpSection.tsx
@@ -1,22 +1,37 @@
 /**
- * MCP section for the right Context Panel.  Lists init.mcp_servers
- * with status dots; click to expand and see the server's tools.
+ * MCP section for the right Context Panel.
+ *
+ * Lists init.mcp_servers with a colored status dot and an expandable
+ * detail view that lazy-loads the on-disk spec — transport (stdio /
+ * sse / http), command or URL, env / header KEYS (values are redacted
+ * server-side because they may carry tokens), and the tools the SDK
+ * reports for this server.
+ *
+ * Actions live inside the expanded body:
+ *   - restart  → respawns the bridge so the SDK re-reads the config
+ *   - remove   → confirmation step, then `remove_mcp_server` IPC +
+ *                respawn so the deleted server actually disappears
  *
  * Visual: docs/internal/v1-tui-parity-plan.md §8.1 + §8.7.
  */
 import "../styles/components/McpSection.css";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import {
+  classifyMcpStatus,
+  describeMcpStatus,
   filterToolsForServer,
+  type McpServerSpecView,
   type McpServerSummary,
+  type McpStatusKind,
 } from "../utils/mcpServers";
 
 interface Props {
   servers: McpServerSummary[];
   tools: string[];
   onRequestAdd: () => void;
-  onRequestRemove?: (name: string) => void;
-  onRequestRestart?: (name: string) => void;
+  onRequestRemove?: (name: string) => void | Promise<void>;
+  onRequestRestart?: (name: string) => void | Promise<void>;
 }
 
 export function McpSection({
@@ -36,61 +51,264 @@ export function McpSection({
         </div>
       ) : (
         <ul className="mcp-list">
-          {servers.map((s) => (
-            <li key={s.name} className="mcp-row" data-status={s.status}>
-              <button
-                type="button"
-                className="mcp-row-header"
-                onClick={() => setExpanded(expanded === s.name ? null : s.name)}
-                aria-expanded={expanded === s.name}
-              >
-                <span className="mcp-status-dot" data-status={s.status} aria-hidden="true" />
-                <span className="mcp-name">{s.name}</span>
-                <span className="mcp-status-text">{s.status}</span>
-              </button>
-              {expanded === s.name && (
-                <div className="mcp-row-body">
-                  <ul className="mcp-tool-list">
-                    {filterToolsForServer(tools, s.name).map((t) => (
-                      <li key={t} className="mcp-tool">{t}</li>
-                    ))}
-                    {filterToolsForServer(tools, s.name).length === 0 && (
-                      <li className="mcp-tool-empty">no tools listed</li>
-                    )}
-                  </ul>
-                  <div className="mcp-row-actions">
-                    {onRequestRestart && (
-                      <button
-                        type="button"
-                        className="mcp-action"
-                        onClick={() => onRequestRestart(s.name)}
-                      >
-                        restart
-                      </button>
-                    )}
-                    {onRequestRemove && (
-                      <button
-                        type="button"
-                        className="mcp-action mcp-action-deny"
-                        onClick={() => onRequestRemove(s.name)}
-                      >
-                        remove
-                      </button>
-                    )}
-                  </div>
-                </div>
-              )}
-            </li>
-          ))}
+          {servers.map((s) => {
+            const kind = classifyMcpStatus(s.status);
+            const { label: statusLabel, tone } = describeMcpStatus(kind);
+            const isOpen = expanded === s.name;
+            return (
+              <li key={s.name} className="mcp-row" data-status={kind} data-tone={tone}>
+                <button
+                  type="button"
+                  className="mcp-row-header"
+                  onClick={() => setExpanded(isOpen ? null : s.name)}
+                  aria-expanded={isOpen}
+                  title={statusLabel}
+                >
+                  <span
+                    className="mcp-status-dot"
+                    data-status={kind}
+                    aria-hidden="true"
+                  />
+                  <span className="mcp-name">{s.name}</span>
+                  <span className="mcp-status-text">{statusText(kind)}</span>
+                  <span className="mcp-row-chevron" aria-hidden="true">
+                    {isOpen ? "▾" : "▸"}
+                  </span>
+                </button>
+                {isOpen && (
+                  <McpRowDetails
+                    name={s.name}
+                    statusKind={kind}
+                    statusLabel={statusLabel}
+                    serverTools={filterToolsForServer(tools, s.name)}
+                    onRequestRemove={onRequestRemove}
+                    onRequestRestart={onRequestRestart}
+                  />
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
-      <button
-        type="button"
-        className="mcp-add-cta"
-        onClick={onRequestAdd}
-      >
+      <button type="button" className="mcp-add-cta" onClick={onRequestAdd}>
         + Add MCP server
       </button>
+      <McpStatusLegend />
     </div>
+  );
+}
+
+function statusText(kind: McpStatusKind): string {
+  switch (kind) {
+    case "connected": return "connected";
+    case "needs-auth": return "needs auth";
+    case "failed": return "failed";
+    case "unknown":
+    default: return "unknown";
+  }
+}
+
+interface DetailsProps {
+  name: string;
+  statusKind: McpStatusKind;
+  statusLabel: string;
+  serverTools: string[];
+  onRequestRemove?: (name: string) => void | Promise<void>;
+  onRequestRestart?: (name: string) => void | Promise<void>;
+}
+
+function McpRowDetails({
+  name,
+  statusKind,
+  statusLabel,
+  serverTools,
+  onRequestRemove,
+  onRequestRestart,
+}: DetailsProps) {
+  const [spec, setSpec] = useState<McpServerSpecView | null | "loading" | "error">("loading");
+  const [confirmRemove, setConfirmRemove] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    invoke<McpServerSpecView | null>("read_mcp_server_spec", { name })
+      .then((v) => { if (!cancelled) setSpec(v); })
+      .catch(() => { if (!cancelled) setSpec("error"); });
+    return () => { cancelled = true; };
+  }, [name]);
+
+  return (
+    <div className="mcp-row-body">
+      {/* Status explanation — always shown, color-coded via [data-status]
+         on the row.  Text gives the "why" the dot color implies. */}
+      <p className="mcp-status-explain" data-status={statusKind}>{statusLabel}</p>
+
+      {/* Spec details — transport, command / URL, env / header keys.  Lazy-
+         loaded from ~/.claude.json on expand. */}
+      <McpSpecBody spec={spec} />
+
+      {/* Tools the SDK reported for this server. */}
+      <div className="mcp-tools">
+        <div className="mcp-tools-label">Tools</div>
+        {serverTools.length === 0 ? (
+          <div className="mcp-tools-empty">
+            {statusKind === "connected"
+              ? "no tools listed"
+              : "no tools (server isn't connected)"}
+          </div>
+        ) : (
+          <ul className="mcp-tool-list">
+            {serverTools.map((t) => (
+              <li key={t} className="mcp-tool">{t}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Actions row — restart + remove.  Remove takes a confirmation
+         step so a stray click can't nuke a server config. */}
+      <div className="mcp-row-actions">
+        {onRequestRestart && (
+          <button
+            type="button"
+            className="mcp-action"
+            disabled={busy}
+            onClick={async () => {
+              setBusy(true);
+              try { await onRequestRestart(name); } finally { setBusy(false); }
+            }}
+          >
+            restart
+          </button>
+        )}
+        {onRequestRemove && !confirmRemove && (
+          <button
+            type="button"
+            className="mcp-action mcp-action-deny"
+            disabled={busy}
+            onClick={() => setConfirmRemove(true)}
+          >
+            remove
+          </button>
+        )}
+        {onRequestRemove && confirmRemove && (
+          <div className="mcp-confirm">
+            <span className="mcp-confirm-text">
+              Delete <strong>{name}</strong> from <code>~/.claude.json</code>?
+            </span>
+            <button
+              type="button"
+              className="mcp-action"
+              disabled={busy}
+              onClick={() => setConfirmRemove(false)}
+            >
+              cancel
+            </button>
+            <button
+              type="button"
+              className="mcp-action mcp-action-deny mcp-action-confirm"
+              disabled={busy}
+              onClick={async () => {
+                setBusy(true);
+                try { await onRequestRemove(name); } catch { /* parent handles */ }
+                finally { setBusy(false); setConfirmRemove(false); }
+              }}
+            >
+              {busy ? "removing…" : "yes, remove"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function McpSpecBody({ spec }: { spec: McpServerSpecView | null | "loading" | "error" }) {
+  if (spec === "loading") {
+    return <div className="mcp-spec mcp-spec-loading">loading spec…</div>;
+  }
+  if (spec === "error") {
+    return (
+      <div className="mcp-spec mcp-spec-error">
+        couldn't read <code>~/.claude.json</code>
+      </div>
+    );
+  }
+  if (spec === null) {
+    return (
+      <div className="mcp-spec mcp-spec-orphan">
+        Live in this session but not in <code>~/.claude.json</code> — managed
+        elsewhere (a project-scope config or a plugin?).
+      </div>
+    );
+  }
+
+  const isStdio = spec.transport === "stdio";
+  const isRemote = spec.transport === "sse" || spec.transport === "http";
+
+  return (
+    <div className="mcp-spec">
+      <div className="mcp-spec-row">
+        <span className="mcp-spec-label">Transport</span>
+        <span className="mcp-spec-value mcp-spec-transport" data-transport={spec.transport}>
+          {spec.transport}
+        </span>
+      </div>
+
+      {isStdio && spec.command && (
+        <div className="mcp-spec-row">
+          <span className="mcp-spec-label">Command</span>
+          <code className="mcp-spec-value mcp-spec-code">
+            {[spec.command, ...spec.args].join(" ")}
+          </code>
+        </div>
+      )}
+
+      {isRemote && spec.url && (
+        <div className="mcp-spec-row">
+          <span className="mcp-spec-label">URL</span>
+          <code className="mcp-spec-value mcp-spec-code">{spec.url}</code>
+        </div>
+      )}
+
+      {spec.env_keys.length > 0 && (
+        <div className="mcp-spec-row">
+          <span className="mcp-spec-label">Env</span>
+          <span className="mcp-spec-chips" title="Values are redacted — only key names are shown.">
+            {spec.env_keys.map((k) => (
+              <span key={k} className="mcp-spec-chip">{k}</span>
+            ))}
+          </span>
+        </div>
+      )}
+
+      {spec.header_keys.length > 0 && (
+        <div className="mcp-spec-row">
+          <span className="mcp-spec-label">Headers</span>
+          <span className="mcp-spec-chips" title="Values are redacted — only key names are shown.">
+            {spec.header_keys.map((k) => (
+              <span key={k} className="mcp-spec-chip">{k}</span>
+            ))}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Tiny legend that decodes the four status dot colors.  Sits at the
+ *  bottom of the section so a first-time user can self-orient without
+ *  hovering each row. */
+function McpStatusLegend() {
+  return (
+    <details className="mcp-legend">
+      <summary>What do the status dots mean?</summary>
+      <ul className="mcp-legend-list">
+        <li><span className="mcp-status-dot" data-status="connected" /> Connected — tools are live.</li>
+        <li><span className="mcp-status-dot" data-status="needs-auth" /> Needs auth — set the env / API key.</li>
+        <li><span className="mcp-status-dot" data-status="failed" /> Failed — bridge couldn't connect; check the command / URL.</li>
+        <li><span className="mcp-status-dot" data-status="unknown" /> Unknown — live init hasn't reported yet.</li>
+      </ul>
+    </details>
   );
 }

--- a/src/state/SessionContext.tsx
+++ b/src/state/SessionContext.tsx
@@ -784,6 +784,12 @@ interface SessionContextValue {
    *  retry so interactive tool replies aren't dropped between turns
    *  when the bridge subprocess has exited.  See M10. */
   sendAgentEnvelope: (sessionId: string, envelope: unknown) => Promise<void>;
+  /** Tear down the live bridge subprocess and respawn it with the same
+   *  flags + `--resume <prior-uuid>`.  Used when the on-disk config
+   *  the bridge consumed (MCP servers, permission rules) has changed
+   *  out from under it and we need the SDK to re-read it.  Returns
+   *  true on a successful respawn. */
+  respawnAgent: (sessionId: string) => Promise<boolean>;
 }
 
 const SessionContext = createContext<SessionContextValue | null>(null);
@@ -2007,7 +2013,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <SessionContext.Provider value={{ state, dispatch, createSession, closeSession, requestCloseSession, setActive, saveWorkspace, convertSessionMode, switchAgentModel, switchAgentPermissionMode, switchAgentEffort, submitAgentMessage, sendAgentEnvelope }}>
+    <SessionContext.Provider value={{ state, dispatch, createSession, closeSession, requestCloseSession, setActive, saveWorkspace, convertSessionMode, switchAgentModel, switchAgentPermissionMode, switchAgentEffort, submitAgentMessage, sendAgentEnvelope, respawnAgent: (sessionId) => respawnAgent(sessionId, {}) }}>
       {children}
       {pendingDirtyClose && (
         <DirtyWorktreeDialog

--- a/src/styles/components/McpSection.css
+++ b/src/styles/components/McpSection.css
@@ -142,3 +142,218 @@
 }
 
 .mcp-add-cta:hover { color: var(--brass-bright, var(--accent)); }
+
+/* ─── Status & detail enhancements (status-actions PR) ──────── */
+
+.mcp-status-dot[data-status="needs-auth"] { background: var(--yellow, #ffb000); }
+.mcp-status-dot[data-status="unknown"]    { background: var(--ink-tertiary, var(--text-3)); }
+
+.mcp-row-chevron {
+  flex: 0 0 auto;
+  color: var(--ink-tertiary, var(--text-3));
+  font-size: 10px;
+  margin-left: 4px;
+}
+
+.mcp-row-header[aria-expanded="true"] {
+  color: var(--ink-primary, var(--text-0));
+}
+
+.mcp-status-explain {
+  margin: 4px 0 8px 0;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font: 11px/1.45 var(--font-display, var(--font-ui));
+  border: 1px solid color-mix(in srgb, var(--ink-tertiary) 28%, transparent);
+  background: color-mix(in srgb, var(--ink-tertiary) 8%, transparent);
+  color: var(--ink-secondary, var(--text-2));
+}
+
+.mcp-status-explain[data-status="connected"] {
+  border-color: color-mix(in srgb, var(--green) 32%, transparent);
+  background:   color-mix(in srgb, var(--green) 8%,  transparent);
+  color: var(--ink-secondary, var(--text-2));
+}
+.mcp-status-explain[data-status="needs-auth"] {
+  border-color: color-mix(in srgb, var(--yellow) 38%, transparent);
+  background:   color-mix(in srgb, var(--yellow) 10%, transparent);
+  color: var(--yellow);
+}
+.mcp-status-explain[data-status="failed"] {
+  border-color: color-mix(in srgb, var(--red) 38%, transparent);
+  background:   color-mix(in srgb, var(--red) 8%,  transparent);
+  color: var(--red);
+}
+
+/* Spec block — transport / command / url / env-keys / header-keys */
+.mcp-spec {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 12px;
+  row-gap: 6px;
+  margin-bottom: 10px;
+}
+
+.mcp-spec-loading,
+.mcp-spec-error,
+.mcp-spec-orphan {
+  margin-bottom: 10px;
+  font: 11px/1.45 var(--font-display, var(--font-ui));
+  color: var(--ink-tertiary, var(--text-3));
+  display: block;
+  grid-column: 1 / -1;
+}
+
+.mcp-spec-error {
+  color: var(--red, var(--error));
+}
+
+.mcp-spec-row {
+  display: contents;
+}
+
+.mcp-spec-label {
+  font: 10px/1.4 var(--font-display, var(--font-ui));
+  color: var(--ink-tertiary, var(--text-3));
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding-top: 1px;
+}
+
+.mcp-spec-value {
+  font: 11px/1.5 var(--font-mono);
+  color: var(--ink-primary, var(--text-0));
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.mcp-spec-transport {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.mcp-spec-code {
+  display: block;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--ink-tertiary) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ink-tertiary) 22%, transparent);
+  font-size: 11px;
+  white-space: pre-wrap;
+}
+
+.mcp-spec-chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.mcp-spec-chip {
+  font: 10px/1.4 var(--font-mono);
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--brass, var(--accent)) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--brass, var(--accent)) 26%, transparent);
+  color: var(--brass, var(--accent));
+}
+
+/* Tools subsection */
+.mcp-tools {
+  margin-bottom: 8px;
+}
+
+.mcp-tools-label {
+  font: 10px/1.4 var(--font-display, var(--font-ui));
+  color: var(--ink-tertiary, var(--text-3));
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+}
+
+.mcp-tools-empty {
+  font: 11px/1.45 var(--font-display, var(--font-ui));
+  font-style: italic;
+  color: var(--ink-tertiary, var(--text-3));
+}
+
+/* Confirmation inline row for delete */
+.mcp-confirm {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid color-mix(in srgb, var(--red) 32%, transparent);
+  background: color-mix(in srgb, var(--red) 6%, transparent);
+}
+
+.mcp-confirm-text {
+  font: 11px/1.45 var(--font-display, var(--font-ui));
+  color: var(--ink-primary, var(--text-0));
+  flex: 1 1 200px;
+}
+
+.mcp-confirm-text code {
+  font: 10.5px/1 var(--font-mono);
+  color: var(--ink-secondary, var(--text-2));
+}
+
+.mcp-action-confirm {
+  font-weight: 600;
+}
+
+.mcp-action[disabled],
+.mcp-action[disabled]:hover {
+  opacity: 0.5;
+  cursor: progress;
+}
+
+/* Bottom legend */
+.mcp-legend {
+  margin-top: 8px;
+  font: 10px/1.5 var(--font-display, var(--font-ui));
+  color: var(--ink-tertiary, var(--text-3));
+}
+
+.mcp-legend > summary {
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  padding: 2px 0;
+  letter-spacing: -0.005em;
+}
+
+.mcp-legend > summary::-webkit-details-marker { display: none; }
+.mcp-legend > summary::before {
+  content: "▸ ";
+  display: inline-block;
+  margin-right: 2px;
+  transition: transform 120ms ease;
+}
+
+.mcp-legend[open] > summary::before {
+  content: "▾ ";
+}
+
+.mcp-legend-list {
+  list-style: none;
+  padding: 6px 0 0 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mcp-legend-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/src/utils/mcpServers.ts
+++ b/src/utils/mcpServers.ts
@@ -11,6 +11,69 @@ export interface McpServerSummary {
   status: string;
 }
 
+/** Mirrors `claude_config::McpServerSpecView` (Rust).  Returned by the
+ *  `read_mcp_server_spec` IPC.  Env / header VALUES are NEVER included
+ *  — the keys are surfaced so the user knows what the server expects,
+ *  but the values are stripped because they may carry tokens. */
+export interface McpServerSpecView {
+  name: string;
+  /** "stdio" | "sse" | "http" | "unknown". */
+  transport: string;
+  command: string;
+  args: string[];
+  url: string;
+  /** Names of env vars defined on the spec — values redacted. */
+  env_keys: string[];
+  /** Names of HTTP headers (sse/http only) — values redacted. */
+  header_keys: string[];
+}
+
+/** Map an SDK status string into a stable category the UI can switch
+ *  on for color + label.  The SDK reports values like "connected" /
+ *  "failed" / "needs_auth" / "unknown"; we normalize so a future SDK
+ *  rename doesn't quietly break the legend. */
+export type McpStatusKind = "connected" | "failed" | "needs-auth" | "unknown";
+
+export function classifyMcpStatus(raw: string | undefined | null): McpStatusKind {
+  if (!raw) return "unknown";
+  const s = raw.toLowerCase();
+  if (s === "connected" || s === "ok" || s === "ready") return "connected";
+  if (
+    s === "needs_auth"
+    || s === "needs-auth"
+    || s === "auth_required"
+    || s === "requires_auth"
+  ) return "needs-auth";
+  if (s === "failed" || s === "error" || s === "disconnected") return "failed";
+  return "unknown";
+}
+
+export function describeMcpStatus(kind: McpStatusKind): { label: string; tone: string } {
+  switch (kind) {
+    case "connected":
+      return {
+        label: "Connected — server is responding to tool calls.",
+        tone: "good",
+      };
+    case "needs-auth":
+      return {
+        label: "Needs authentication — the server is reachable but rejected the connection. Check the env vars / API key.",
+        tone: "warn",
+      };
+    case "failed":
+      return {
+        label: "Failed to connect — the bridge couldn't reach this server. Check the command / URL and inspect stderr.",
+        tone: "bad",
+      };
+    case "unknown":
+    default:
+      return {
+        label: "Unknown — status hasn't been reported yet (live init pending) or the SDK didn't include it.",
+        tone: "muted",
+      };
+  }
+}
+
 export interface McpStdioSpec {
   type: "stdio";
   command: string;
@@ -45,7 +108,10 @@ export function filterToolsForServer(tools: readonly string[], serverName: strin
     .map((t) => t.slice(prefix.length));
 }
 
-const NAME_PATTERN = /^[A-Za-z0-9_\- ]+$/;
+// Mirrors the Rust validator: alphanumeric, underscore, hyphen, space,
+// dot, colon.  Real MCP names from Claude's ecosystem use dots and
+// colons (e.g. "claude.ai Gmail", "plugin:telegram:telegram").
+const NAME_PATTERN = /^[A-Za-z0-9_\- .:]+$/;
 
 export function validateAddMcpForm(form: AddMcpForm, existingNames: readonly string[]): string[] {
   const errors: string[] = [];


### PR DESCRIPTION
## Summary

Closes the gap in the MCP panel UX — users could only **add** MCP servers; couldn't see whether one was working, why, or how to remove / retry.  Three fixes:

### 1. Status detail when a row is expanded

Lazy-loads the on-disk spec via a new `read_mcp_server_spec(name)` Rust IPC and shows:

- A color-coded status explanation (`Connected — server is responding to tool calls.` / `Needs auth — set the env / API key.` / `Failed to connect — check the command / URL.` / `Unknown — live init pending.`)
- Transport badge (stdio / sse / http)
- Command + args (stdio) or URL (remote)
- Env / header **key** chips (values are stripped server-side — they may carry tokens; redaction contract pinned in tests)
- Tools the SDK reports for that server
- A bottom legend that decodes the four dot colors

### 2. Restart + remove actions

- **restart** respawns the bridge so the SDK re-reads `~/.claude.json`
- **remove** opens an inline confirmation row (`Delete <name> from ~/.claude.json?` — Cancel / Yes), then calls the existing `remove_mcp_server` IPC + a respawn
- `SessionContext` now exposes `respawnAgent(sessionId)` so any panel can force a re-read

### 3. Real-name support (bug repro from screenshot)

The Rust + TS name validators were rejecting `claude.ai Gmail`, `claude.ai Google Drive`, `plugin:telegram:telegram`, `hermes-hq.kanban-board` because they only accepted `[A-Za-z0-9_\- ]+`.  Real names use `.` and `:`.  This caused two visible bugs:

- `Couldn't remove claude.ai Gmail: name contains invalid characters` on click
- `couldn't read ~/.claude.json` rendered in red on the panel — even though the file was fine — because `read_mcp_server_spec` rejected the name before reading

Loosened the whitelist to `[A-Za-z0-9_\- .:]+`.  Still blocks shell metas (`;` `|` `&` `$` `<` `>` `` ` `` `'` `"` `\` `/`) since names are JSON object keys (HashMap lookups, no path-traversal risk).

## Test plan

- [x] `cargo test --lib` — **25 claude_config tests** (10 new for `read_mcp_server_spec` including the redaction contract pinning that env / header values never leak; 2 new pinning real-world dotted / colon names; 1 pinning orphan-returns-None for cloud-managed servers)
- [x] `cargo clippy --lib -- -D warnings` clean
- [x] `npm test -- --run` — **3043 vitest passing** (+19 new): `classifyMcpStatus` normalization, `describeMcpStatus` tone/label, expanded spec body rendering, env chip redaction, orphan note, IPC error fallback, remove confirmation flow (open / confirm / cancel), restart action, status legend, real-world name acceptance, shell-metas-still-rejected
- [x] `npx tsc --noEmit` clean
- [ ] In-app: with a session containing real MCP servers, verify the panel renders the status explainer, transport badge, env chips; verify remove fires the IPC + respawn; verify restart respawns; verify `claude.ai Gmail` no longer shows the red `couldn't read` error

## Note for testing locally

The validator fix is in Rust code (`src-tauri/src/claude_config/mod.rs`).  Vite HMR only reloads frontend — to pick up the validator fix in a dev session you must restart `tauri dev` so cargo recompiles.