### PR TITLE
MCP add: union prewarm into live so new entries appear instantly

### DIFF
--- a/src/__tests__/prewarm-merge.test.ts
+++ b/src/__tests__/prewarm-merge.test.ts
@@ -29,12 +29,37 @@ describe("mergeMcpServers (pw-7, pw-9)", () => {
     ]);
   });
 
-  it("static-only entries removed when init arrives (init is authoritative)", () => {
+  it("static-only entries are appended when init lacks them (--resume keeps stale list)", () => {
+    // Claude's `--resume <uuid>` restores the session's prior MCP
+    // list from its transcript.  When the user adds a server to
+    // `~/.claude.json` mid-session, the new entry exists in static
+    // (read from disk) but NOT in init (still showing the old list).
+    // We surface both so the new entry doesn't vanish from the panel
+    // until a fresh-spawn session.
     const got = mergeMcpServers(
-      [{ name: "old-server", status: "unknown" }],
-      [{ name: "new-server", status: "connected" }],
+      [{ name: "newly-added", status: "unknown" }],
+      [{ name: "from-resume", status: "connected" }],
     );
-    expect(got).toEqual([{ name: "new-server", status: "connected" }]);
+    expect(got).toEqual([
+      { name: "from-resume", status: "connected" },
+      { name: "newly-added", status: "unknown" },
+    ]);
+  });
+
+  it("does NOT duplicate entries that exist in both static and live", () => {
+    const got = mergeMcpServers(
+      [
+        { name: "context7", status: "unknown" },
+        { name: "newly-added", status: "unknown" },
+      ],
+      [{ name: "context7", status: "connected" }],
+    );
+    // context7 appears once with the live status; newly-added is
+    // appended from static.
+    expect(got).toEqual([
+      { name: "context7", status: "connected" },
+      { name: "newly-added", status: "unknown" },
+    ]);
   });
 });
 

--- a/src/components/AgentContextPanel.tsx
+++ b/src/components/AgentContextPanel.tsx
@@ -345,7 +345,18 @@ function SectionContent({ sessionId, collapsed, onToggle }: SectionContentProps)
         />
       </Section>
       {addingMcp && (
-        <AddMcpDialog existingNames={existingMcpNames} onClose={() => setAddingMcp(false)} />
+        <AddMcpDialog
+          existingNames={existingMcpNames}
+          onClose={() => {
+            setAddingMcp(false);
+            // After the dialog writes a new entry to ~/.claude.json,
+            // re-read prewarm so the new server appears in the panel
+            // immediately — `mergeMcpServers` unions prewarm into live
+            // so the new name surfaces even though init's mcp_servers
+            // (under --resume) doesn't include it yet.
+            prewarm.refresh();
+          }}
+        />
       )}
     </>
   );

--- a/src/utils/prewarm.ts
+++ b/src/utils/prewarm.ts
@@ -27,10 +27,22 @@ export function mergeMcpServers(
   staticServers: readonly PrewarmMcpServer[],
   liveServers: readonly PrewarmMcpServer[] | undefined,
 ): PrewarmMcpServer[] {
-  // Live wins when it's a real array.  When live arrives, it's the
-  // canonical list — static entries that aren't in live are stale.
-  if (Array.isArray(liveServers)) return [...liveServers];
-  return asArray(staticServers);
+  // Until live arrives, the static list is all we have.
+  if (!Array.isArray(liveServers)) return asArray(staticServers);
+
+  // Otherwise UNION: live entries win on shape (status from the SDK),
+  // and any static-only entries are appended.  Static-only happens
+  // when the user has just added a server to `~/.claude.json` but
+  // the bridge is still running on an older `--resume` that restored
+  // its prior MCP list — the new entry is on disk but not in init
+  // yet.  Without this union, freshly-added servers wouldn't appear
+  // in the panel until a brand-new session spawn.
+  const out = [...liveServers];
+  const seen = new Set(out.map((s) => s.name));
+  for (const s of asArray<PrewarmMcpServer>(staticServers)) {
+    if (!seen.has(s.name)) out.push(s);
+  }
+  return out;
 }
 
 export function mergeSlashCommands(


### PR DESCRIPTION
Same `--resume` quirk that hid removes also hides ADDITIONS.  When the user adds a server to `~/.claude.json` and the bridge respawns under `--resume <uuid>`, init reports the resumed session's prior MCP list — without the new entry.  `mergeMcpServers` was discarding the static (file-derived) list whenever init existed, so the new entry was invisible.

Switched the merge from "live-replaces-static" to a UNION: live wins on shape (status from SDK), static-only names are appended.  New entries surface immediately via static; duplicates dedupe correctly.

Also wires `prewarm.refresh()` into AddMcpDialog onClose, mirroring the remove path from #259.

3044 vitest passing.