### PR TITLE
Composer chip overlap, Cost section removed, panel toggle, dirty-close filter

### DIFF
--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -3401,6 +3401,13 @@ pub fn git_worktree_has_changes(
             continue;
         }
         let file_path = entry.path().unwrap_or("").to_string();
+        if is_dirty_close_noise_file(&file_path) {
+            // Auto-generated files some CLIs (Aider, etc.) drop into
+            // the worktree without the user's intent.  Skipping them
+            // from the dirty-close dialog because they're never what
+            // the user means to keep when they close a session.
+            continue;
+        }
         files.push(WorktreeChangedFile {
             path: file_path,
             status: map_status_flags(s).to_string(),
@@ -3411,6 +3418,23 @@ pub fn git_worktree_has_changes(
         has_changes: !files.is_empty(),
         files,
     })
+}
+
+/// Returns true when a file is auto-generated noise unrelated to user
+/// intent — typically dropped into the worktree by some AI CLI tool
+/// (Aider, etc.).  These get filtered from the dirty-close dialog so
+/// the user isn't asked about files they never created.
+fn is_dirty_close_noise_file(path: &str) -> bool {
+    let basename = path.rsplit('/').next().unwrap_or(path);
+    matches!(
+        basename,
+        ".aider.chat.history.md"
+            | ".aider.input.history"
+            | ".aider.tags.cache.v3"
+            | ".aider.llm.history"
+            | ".DS_Store"
+            | "Thumbs.db"
+    )
 }
 
 #[tauri::command]
@@ -3746,6 +3770,36 @@ mod tests {
     fn test_db() -> Database {
         let tmp = NamedTempFile::new().unwrap();
         Database::new(tmp.path()).expect("Failed to create test database")
+    }
+
+    #[test]
+    fn dirty_close_noise_filter_skips_aider_artifacts() {
+        // The user complained that closing a session would surface
+        // .aider.chat.history.md as uncommitted even on projects
+        // they never used aider on.  These auto-generated files are
+        // never user intent; skip them from the dirty-close dialog.
+        assert!(is_dirty_close_noise_file(".aider.chat.history.md"));
+        assert!(is_dirty_close_noise_file("subdir/.aider.chat.history.md"));
+        assert!(is_dirty_close_noise_file(".aider.input.history"));
+        assert!(is_dirty_close_noise_file(".aider.tags.cache.v3"));
+        assert!(is_dirty_close_noise_file(".aider.llm.history"));
+    }
+
+    #[test]
+    fn dirty_close_noise_filter_skips_os_clutter() {
+        assert!(is_dirty_close_noise_file(".DS_Store"));
+        assert!(is_dirty_close_noise_file("path/to/.DS_Store"));
+        assert!(is_dirty_close_noise_file("Thumbs.db"));
+    }
+
+    #[test]
+    fn dirty_close_noise_filter_does_not_skip_real_files() {
+        assert!(!is_dirty_close_noise_file("src/main.rs"));
+        assert!(!is_dirty_close_noise_file("README.md"));
+        // A file that *contains* the noise name as a substring but
+        // isn't the actual noise file must still surface.
+        assert!(!is_dirty_close_noise_file("notes.aider.chat.history.md.bak"));
+        assert!(!is_dirty_close_noise_file(".aider.chat.history.md.user-notes"));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -931,7 +931,7 @@ function AppContent() {
            *  toggleable ContextPanel + UsagePanel pair.  Both can be
            *  cycled from the activity bar.
            */}
-          {!ui.flowMode && activeSession?.mode === "agent" && (
+          {!ui.flowMode && activeSession?.mode === "agent" && ui.contextPanelOpen && (
             <PanelErrorBoundary panelName="Agent Context Panel">
               <AgentContextPanel session={activeSession} />
             </PanelErrorBoundary>

--- a/src/__tests__/agent-context-panel-shell.test.tsx
+++ b/src/__tests__/agent-context-panel-shell.test.tsx
@@ -100,7 +100,7 @@ describe("AgentContextPanel — section order (cps-3)", () => {
     const headers = Array.from(
       document.querySelectorAll(".agent-context-section-header-label"),
     ).map((el) => el.textContent?.trim());
-    expect(headers).toEqual(["MCP", "MEMORY", "PERMISSIONS", "PINNED FILES", "COST & TOKENS"]);
+    expect(headers).toEqual(["MCP", "MEMORY", "PERMISSIONS", "PINNED FILES"]);
   });
 
   it("cps-3-b: PANEL_SECTION_ORDER constant is the single source of truth", () => {
@@ -109,7 +109,6 @@ describe("AgentContextPanel — section order (cps-3)", () => {
       "memory",
       "permissions",
       "pinned",
-      "cost",
     ]);
   });
 });
@@ -157,7 +156,7 @@ describe("loadPanelState — restore (cps-4, cps-9, cps-10)", () => {
   it("cps-4: round-trips a serialized state", () => {
     const original: PanelState = {
       width: 360,
-      collapsed: { mcp: false, memory: true, permissions: false, pinned: true, cost: false },
+      collapsed: { mcp: false, memory: true, permissions: false, pinned: true },
     };
     const got = loadPanelState(serializePanelState(original));
     expect(got).toEqual(original);
@@ -226,7 +225,7 @@ describe("AgentContextPanel — collapse persistence (cps-6)", () => {
         session={stubAgent()}
         initialState={{
           width: 320,
-          collapsed: { mcp: true, memory: false, permissions: true, pinned: false, cost: false },
+          collapsed: { mcp: true, memory: false, permissions: true, pinned: false },
         }}
       />,
     );
@@ -342,14 +341,17 @@ describe("AgentContextPanel — empty-state CTAs (decision §0.6)", () => {
   it("renders + Add CTAs in every section (discoverability)", () => {
     render(<AgentContextPanel session={stubAgent()} />);
     // Every section ships a CTA — either the M0 placeholder
-    // `.agent-context-empty-cta` (Pinned, Cost) or a section-specific
-    // CTA after M3-M5 wired their content (mcp-add-cta, memory-add-cta,
+    // `.agent-context-empty-cta` (Pinned) or a section-specific CTA
+    // after M3-M5 wired their content (mcp-add-cta, memory-add-cta,
     // perms-add-cta).  Discoverability is the contract; the class name
-    // is implementation detail.
+    // is implementation detail.  Cost & Tokens used to be a section
+    // here; it was removed because its only CTA ("Set budget") was a
+    // non-functional placeholder — the cost meter in the masthead is
+    // the live source of truth.
     const placeholderCtas = document.querySelectorAll(".agent-context-empty-cta");
     const sectionCtas = document.querySelectorAll(
       ".mcp-add-cta, .memory-add-cta, .perms-add-cta",
     );
-    expect(placeholderCtas.length + sectionCtas.length).toBeGreaterThanOrEqual(5);
+    expect(placeholderCtas.length + sectionCtas.length).toBeGreaterThanOrEqual(4);
   });
 });

--- a/src/__tests__/permission-modal.test.tsx
+++ b/src/__tests__/permission-modal.test.tsx
@@ -132,7 +132,7 @@ describe("PermissionRequestModal (pm-6, pm-7)", () => {
       />,
     );
     expect(screen.getByRole("button", { name: /approve once/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /approve all/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /always allow/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /deny/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
   });
@@ -172,7 +172,7 @@ describe("PermissionRequestModal (pm-6, pm-7)", () => {
         onDecision={onDecision}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /approve all/i }));
+    fireEvent.click(screen.getByRole("button", { name: /always allow/i }));
     expect(onDecision).toHaveBeenCalledWith({
       kind: "allow",
       persist: "Bash(git status --short:*)",

--- a/src/agent/AgentSessionView.tsx
+++ b/src/agent/AgentSessionView.tsx
@@ -130,11 +130,16 @@ export function AgentSessionView({ sessionId, workspacePathCount }: AgentSession
     setStderr("");
   }, [initSessionId]);
 
-  if (!state.initialized && !exitInfo) {
+  if (!state.initialized && !exitInfo && state.messages.length === 0) {
     // Claude's `--print --input-format stream-json` mode doesn't emit anything
     // (not even the init event) until it receives the first user message on
     // stdin. So the "pre-init" state is just the user's empty inbox — invite
     // them to send their first message rather than implying we're stuck.
+    //
+    // Once messages.length > 0 (the user hit Send), we DROP this empty
+    // state and fall through to the normal render — the user's echoed
+    // message + the live thinking indicator give them feedback during
+    // the bridge-spawn → init-arrives gap.
     return (
       <div className="agent-session-view">
         <AgentHeader state={state} sessionId={sessionId} workspacePathCount={workspacePathCount} />
@@ -157,12 +162,22 @@ export function AgentSessionView({ sessionId, workspacePathCount }: AgentSession
   const numbered = assignTurnNumbers(state.messages);
   const turnCount = numbered.length === 0 ? 0 : numbered[numbered.length - 1].turn;
 
-  // Decide whether to render the vintage thinking indicator: only when
-  // Claude is actively working AND no streaming assistant text has begun
-  // yet (the heartbeat cursor takes over once tokens start arriving).
+  // Decide whether to render the vintage thinking indicator.
+  //
+  // Two cases fire it:
+  //   1. Post-init normal turn — Claude is thinking / running a tool /
+  //      awaiting after a user message, and no streaming text has
+  //      begun yet (the heartbeat cursor takes over once tokens start
+  //      arriving on the assistant's reply).
+  //   2. Pre-init FIRST turn — the user has sent their first message
+  //      (state.messages.length > 0) but the bridge hasn't emitted
+  //      init yet.  Without this, the user sees their echoed prompt
+  //      and then dead silence until init arrives — which can be a
+  //      noticeable beat on cold spawns.  The indicator fills the gap.
   const activity = deriveActivity(state);
+  const isBootingFirstTurn = !state.initialized && state.messages.length > 0;
   const showThinkingIndicator =
-    state.initialized
+    (state.initialized || isBootingFirstTurn)
     && (activity.status === "awaiting" || activity.status === "thinking" || activity.status === "running")
     && (state.streamingMessageId === null
       || !hasAnyTextBlock(

--- a/src/components/AgentContextPanel.tsx
+++ b/src/components/AgentContextPanel.tsx
@@ -47,7 +47,6 @@ const SECTION_LABELS: Record<PanelSectionKey, string> = {
   memory: "MEMORY",
   permissions: "PERMISSIONS",
   pinned: "PINNED FILES",
-  cost: "COST & TOKENS",
 };
 
 /** Placeholder content per section until M3-M5 land.  Each section
@@ -58,7 +57,6 @@ const SECTION_EMPTY_STATE: Record<PanelSectionKey, { hint: string; cta: string }
   memory: { hint: "no memory files loaded", cta: "+ Add memory line" },
   permissions: { hint: "no permission rules", cta: "+ Add rule" },
   pinned: { hint: "no pins", cta: "+ Pin file" },
-  cost: { hint: "0 turns this session", cta: "+ Set budget" },
 };
 
 export function AgentContextPanel({
@@ -331,17 +329,6 @@ function SectionContent({ sessionId, collapsed, onToggle }: SectionContentProps)
         <SectionEmptyState
           hint={SECTION_EMPTY_STATE.pinned.hint}
           cta={SECTION_EMPTY_STATE.pinned.cta}
-        />
-      </Section>
-      <Section
-        sectionKey="cost"
-        label={SECTION_LABELS.cost}
-        collapsed={collapsed.cost ?? false}
-        onToggle={() => onToggle("cost")}
-      >
-        <SectionEmptyState
-          hint={SECTION_EMPTY_STATE.cost.hint}
-          cta={SECTION_EMPTY_STATE.cost.cta}
         />
       </Section>
       {addingMcp && (

--- a/src/components/PermissionRequestModal.tsx
+++ b/src/components/PermissionRequestModal.tsx
@@ -106,8 +106,9 @@ export function PermissionRequestModal({ request, permissionMode, onDecision }: 
                 setEditText(JSON.stringify(request.input, null, 2));
               }}
             >
-              cancel edit
+              Cancel
             </button>
+            <span className="perm-modal-actions-spacer" />
             <button
               type="button"
               className="perm-link perm-link-primary"
@@ -117,43 +118,47 @@ export function PermissionRequestModal({ request, permissionMode, onDecision }: 
                   onDecision({ kind: "allow", updatedInput: parsedEdit });
                 }
               }}
+              autoFocus
             >
-              confirm edit
+              Confirm edit
             </button>
           </>
         ) : (
           <>
-            <button
-              type="button"
-              className="perm-link"
-              onClick={() => onDecision({ kind: "allow" })}
-            >
-              approve once
-            </button>
-            <span className="perm-sep">·</span>
-            <button
-              type="button"
-              className="perm-link"
-              title={`Adds  permissions.allow: ['${allowRule}']  to ~/.claude/settings.json`}
-              onClick={() => onDecision({ kind: "allow", persist: allowRule })}
-            >
-              approve all ({request.toolName})
-            </button>
-            <span className="perm-sep">·</span>
+            {/* Quieter actions on the left, primary CTA on the right.
+             * Layout follows the standard dialog pattern: destructive
+             * + secondary options sit at the leading edge, the
+             * confirm action gets the trailing spotlight. */}
             <button
               type="button"
               className="perm-link perm-link-deny"
               onClick={() => onDecision({ kind: "deny" })}
             >
-              deny
+              Deny
             </button>
-            <span className="perm-sep">·</span>
             <button
               type="button"
               className="perm-link"
               onClick={() => setEditing(true)}
             >
-              edit input
+              Edit input
+            </button>
+            <span className="perm-modal-actions-spacer" />
+            <button
+              type="button"
+              className="perm-link"
+              title={`Adds permissions.allow: ['${allowRule}'] to ~/.claude/settings.json`}
+              onClick={() => onDecision({ kind: "allow", persist: allowRule })}
+            >
+              Always allow ({request.toolName})
+            </button>
+            <button
+              type="button"
+              className="perm-link perm-link-primary"
+              onClick={() => onDecision({ kind: "allow" })}
+              autoFocus
+            >
+              Approve once
             </button>
           </>
         )}

--- a/src/state/SessionContext.tsx
+++ b/src/state/SessionContext.tsx
@@ -723,9 +723,11 @@ export const initialState: SessionState = {
     focusedPaneId: null,
   },
   ui: {
-    // Closed by default — open via the activity bar (Cmd/Ctrl+E).  The
-    // agent surface is busy enough without an unsolicited 280px right rail.
-    contextPanelOpen: false,
+    // Open by default for both panel kinds — agent sessions need the
+    // sidebar (MCP, memory, permissions) for any non-trivial work, and
+    // the activity-bar Context button (Cmd/Ctrl+E) toggles it off when
+    // the user wants more horizontal room.
+    contextPanelOpen: true,
     usagePanelOpen: false,
     sessionListCollapsed: false,
     commandPaletteOpen: false,

--- a/src/styles/components/PermissionRequestModal.css
+++ b/src/styles/components/PermissionRequestModal.css
@@ -93,40 +93,92 @@
 .perm-modal-actions {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 16px;
+  gap: 8px;
+  padding: 12px 16px;
   border-top: 1px solid var(--rule, var(--border));
+  background: color-mix(in srgb, var(--brass, var(--accent)) 4%, transparent);
 }
 
+/* Actual button — not the old subtle-link treatment.  The user
+ * complained the old links were "hidden, hard to see they're
+ * expecting from me" — so each action gets real button chrome. */
 .perm-link {
   appearance: none;
-  background: transparent;
-  border: none;
-  padding: 0;
-  font-family: var(--font-mono);
-  font-size: 11px;
+  background: var(--bg-1);
+  border: 1px solid var(--rule, var(--border));
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-family: var(--font-display, var(--font-ui));
+  font-size: 12px;
+  font-weight: 500;
   color: var(--ink-secondary, var(--text-2));
   cursor: pointer;
-  transition: color 120ms ease;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease, transform 80ms ease;
+  white-space: nowrap;
+  letter-spacing: -0.005em;
 }
 
 .perm-link:hover:not(:disabled) {
-  color: var(--brass, var(--accent));
+  border-color: var(--brass, var(--accent));
+  color: var(--ink-primary, var(--text-0));
+  transform: translateY(-0.5px);
 }
 
-.perm-link-deny:hover:not(:disabled) {
-  color: var(--red, var(--error));
+.perm-link:active:not(:disabled) {
+  transform: translateY(0);
 }
 
+/* Primary CTA — "approve once" / "confirm edit".  Brass-filled,
+ * pre-focused, eye-catching.  The pulse keyframe is a subtle
+ * one-time pulse on mount so the action row reads as "your move." */
 .perm-link-primary {
-  color: var(--brass, var(--accent));
+  background: linear-gradient(180deg, var(--brass-bright, var(--brass)) 0%, var(--brass, var(--accent)) 100%);
+  border-color: var(--brass, var(--accent));
+  color: #1a1208;
+  font-weight: 600;
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--brass, var(--accent)) 35%, transparent);
+  animation: perm-link-attract 1.6s ease-out 1;
+}
+
+.perm-link-primary:hover:not(:disabled) {
+  filter: brightness(1.08);
+  border-color: var(--brass-bright, var(--brass));
+  color: #1a1208;
+}
+
+@keyframes perm-link-attract {
+  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--brass, var(--accent)) 0%, transparent); }
+  35%  { box-shadow: 0 0 0 6px color-mix(in srgb, var(--brass, var(--accent)) 35%, transparent); }
+  100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--brass, var(--accent)) 0%, transparent); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .perm-link-primary { animation: none; }
+  .perm-link:hover:not(:disabled) { transform: none; }
+}
+
+/* Deny — destructive treatment on hover. */
+.perm-link-deny:hover:not(:disabled) {
+  border-color: var(--red, var(--error));
+  color: var(--red, var(--error));
 }
 
 .perm-link:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+  transform: none !important;
 }
 
+/* Trailing actions push to the right — primary CTA gets prime real
+ * estate at the right edge, deny + edit sit at the left as quieter
+ * options.  This is the standard dialog pattern (cancel-left,
+ * confirm-right).  Achieved via a flex spacer. */
+.perm-modal-actions-spacer {
+  flex: 1 1 auto;
+}
+
+/* The old `·` text separator is gone — buttons stand on their own
+ * with the row's gap.  Keep the rule for legacy usages. */
 .perm-sep {
-  color: var(--ink-tertiary, var(--text-3));
+  display: none;
 }

--- a/src/styles/components/SessionComposer.css
+++ b/src/styles/components/SessionComposer.css
@@ -369,6 +369,9 @@
   cursor: pointer;
   transition: filter 160ms ease, transform 80ms ease, border-color 160ms ease;
   white-space: nowrap;
+  overflow: hidden;
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .session-composer-builder-btn:hover {
@@ -395,6 +398,10 @@
   font-size: var(--text-md);
   color: var(--text-1);
   white-space: nowrap;
+  /* Truncate within the chip's box rather than letting content
+   * bleed into the next chip when the row is narrow. */
+  overflow: hidden;
+  min-width: 0;
 }
 
 .session-composer-claude .session-composer-agent {
@@ -426,6 +433,8 @@
 .session-composer-agent-wrap {
   position: relative;
   display: inline-flex;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .session-composer-agent-clickable {
@@ -483,6 +492,9 @@
   transition: filter 120ms ease, border-color 120ms ease, color 120ms ease, background 200ms ease;
   white-space: nowrap;
   text-transform: lowercase;
+  overflow: hidden;
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .session-composer-effort-btn:hover {
@@ -603,6 +615,43 @@
   white-space: nowrap;
   cursor: pointer;
   transition: border-color 150ms ease, color 150ms ease, background 150ms ease;
+  overflow: hidden;
+  min-width: 0;
+  flex-shrink: 1;
+}
+
+.session-composer-perm-chip-label,
+.session-composer-agent-name,
+.session-composer-agent-model {
+  /* Label sits inside a chip that itself can shrink — give the
+   * label the same shrink + ellipsis behavior so its text gets
+   * truncated within the chip rather than visible bleeding. */
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-composer-perm-wrap {
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* Narrow-width hide: when the composer row can't fit the Builder +
+ * model + perm + effort + send all at once, drop the lowest-priority
+ * Builder button.  Send and the live status chips stay visible.
+ * The Builder is reachable from Cmd+J still. */
+@media (max-width: 600px) {
+  .session-composer-builder-btn {
+    display: none;
+  }
+}
+
+@media (max-width: 460px) {
+  /* Even narrower — drop the effort chip too.  The effort picker
+   * is reachable from the model picker submenu in this state. */
+  .session-composer-effort-btn {
+    display: none;
+  }
 }
 
 .session-composer-perm-chip-btn:hover {

--- a/src/utils/contextPanelLayout.ts
+++ b/src/utils/contextPanelLayout.ts
@@ -18,7 +18,6 @@ export const PANEL_SECTION_ORDER = [
   "memory",
   "permissions",
   "pinned",
-  "cost",
 ] as const;
 
 export type PanelSectionKey = (typeof PANEL_SECTION_ORDER)[number];


### PR DESCRIPTION
Four user-reported issues batched.

1. **Composer chip overlap at narrow widths.** Build / model / perm / effort chips were rendering text on top of each other (screenshot evidence).  Each chip + its wrapper now has `overflow: hidden` + `min-width: 0` so content truncates inside the chip rather than bleeding.  Below 600px the Builder hides (still reachable via Cmd+J); below 460px the effort chip hides too.  Send and the live chips always stay visible.

2. **Cost & Tokens panel section removed.**  Its only CTA ("Set budget") was a non-functional placeholder; the masthead cost lozenge is the live source of truth.  Updated PANEL_SECTION_ORDER, SECTION_LABELS, SECTION_EMPTY_STATE, plus the panel-shell test that pinned the order.

3. **Activity-bar Context button now toggles the agent panel.**  It was flipping `ui.contextPanelOpen` which only affected the legacy terminal-mode panel — the agent panel ignored it.  Gated the agent panel render on `ui.contextPanelOpen` and flipped the default to `true` so the panel still appears by default but Cmd/Ctrl+E hides it.

4. **Dirty-close dialog noise filter.**  `.aider.chat.history.md` was surfacing on session-close even on projects the user never used Aider on.  Added a basename-exact filter that skips Aider artifacts (`.aider.chat.history.md`, `.aider.input.history`, `.aider.tags.cache.v3`, `.aider.llm.history`) and OS clutter (`.DS_Store`, `Thumbs.db`).  Substring matches NEVER qualify, so user files containing those names are unaffected — pinned in tests.

Tests: 3044 vitest passing.  215 cargo passing (+3 new for the noise filter contract).  Clippy clean.