### PR TITLE
Slash dropdown: classify CLI vs in-app + embedded terminal

### DIFF
--- a/src-tauri/src/claude_config/mod.rs
+++ b/src-tauri/src/claude_config/mod.rs
@@ -253,12 +253,7 @@ fn validate_server_name(name: &str) -> Result<&str, String> {
     // (`;` `|` `&` `$` `<` `>` `` ` `` `'` `"` `\` `/`) as defense in
     // depth + to keep accidental copy-paste honest.
     if !trimmed.chars().all(|c| {
-        c.is_ascii_alphanumeric()
-            || c == '_'
-            || c == '-'
-            || c == ' '
-            || c == '.'
-            || c == ':'
+        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == ' ' || c == '.' || c == ':'
     }) {
         return Err("name contains invalid characters".into());
     }
@@ -760,7 +755,10 @@ mod prewarm_tests {
         // Env keys returned, sorted in insertion order; values stripped.
         let mut keys = got.env_keys.clone();
         keys.sort();
-        assert_eq!(keys, vec!["CONTEXT7_API_KEY".to_string(), "DEBUG".to_string()]);
+        assert_eq!(
+            keys,
+            vec!["CONTEXT7_API_KEY".to_string(), "DEBUG".to_string()]
+        );
     }
 
     #[test]

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -3798,8 +3798,12 @@ mod tests {
         assert!(!is_dirty_close_noise_file("README.md"));
         // A file that *contains* the noise name as a substring but
         // isn't the actual noise file must still surface.
-        assert!(!is_dirty_close_noise_file("notes.aider.chat.history.md.bak"));
-        assert!(!is_dirty_close_noise_file(".aider.chat.history.md.user-notes"));
+        assert!(!is_dirty_close_noise_file(
+            "notes.aider.chat.history.md.bak"
+        ));
+        assert!(!is_dirty_close_noise_file(
+            ".aider.chat.history.md.user-notes"
+        ));
     }
 
     #[test]

--- a/src-tauri/src/inline_pty/mod.rs
+++ b/src-tauri/src/inline_pty/mod.rs
@@ -206,10 +206,7 @@ pub fn resize_inline_pty(
 }
 
 #[tauri::command]
-pub fn kill_inline_pty(
-    state: State<'_, InlinePtyManager>,
-    pty_id: String,
-) -> Result<(), String> {
+pub fn kill_inline_pty(state: State<'_, InlinePtyManager>, pty_id: String) -> Result<(), String> {
     let mut map = state.inner.lock().unwrap_or_else(|e| e.into_inner());
     if let Some(mut entry) = map.remove(&pty_id) {
         let _ = entry.killer.kill();

--- a/src-tauri/src/inline_pty/mod.rs
+++ b/src-tauri/src/inline_pty/mod.rs
@@ -1,0 +1,218 @@
+//! Lightweight one-shot PTY for embedded slash-command terminals.
+//!
+//! Hermes' main `PtyManager` is heavyweight: it persists sessions to
+//! the database, tracks worktrees, runs agent-detection nudges, and
+//! is keyed off Hermes session ids.  None of that fits when the user
+//! picks `/mcp` from the slash dropdown and just wants to run
+//! `claude /mcp` interactively in a 280-px-tall xterm above the
+//! composer.
+//!
+//! This module exposes a focused IPC surface for that use case:
+//!
+//!   spawn_inline_pty(command, args, cwd, rows, cols) -> pty_id
+//!   write_inline_pty(pty_id, data)
+//!   resize_inline_pty(pty_id, rows, cols)
+//!   kill_inline_pty(pty_id)
+//!
+//! Each spawn registers a fresh PTY with a unique id.  A background
+//! reader thread streams output to the frontend as Tauri events:
+//!
+//!   `inline-pty-output-{pty_id}` — UTF-8 chunks of stdout/stderr
+//!   `inline-pty-exit-{pty_id}`   — fired once when the child exits,
+//!                                  with the exit code (or null on
+//!                                  signal).
+
+use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, PtySize};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+use tauri::{AppHandle, Emitter, State};
+use uuid::Uuid;
+
+#[derive(Serialize, Clone)]
+pub struct InlinePtyExitPayload {
+    pub code: Option<i32>,
+}
+
+struct InlinePty {
+    /// Process kill handle — drop on close to terminate the child.
+    killer: Box<dyn ChildKiller + Send>,
+    /// Writes to the PTY master (stdin to the child).
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    /// Master PTY — kept alive so resize works.  Wrapped in Arc<Mutex>
+    /// so the resize command can borrow it without locking out the
+    /// writer.
+    master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
+}
+
+#[derive(Default)]
+pub struct InlinePtyManager {
+    inner: Mutex<HashMap<String, InlinePty>>,
+}
+
+impl InlinePtyManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[tauri::command]
+pub fn spawn_inline_pty(
+    app: AppHandle,
+    state: State<'_, InlinePtyManager>,
+    command: String,
+    args: Vec<String>,
+    cwd: Option<String>,
+    rows: Option<u16>,
+    cols: Option<u16>,
+) -> Result<String, String> {
+    if command.trim().is_empty() {
+        return Err("command is required".to_string());
+    }
+    let rows = rows.unwrap_or(24);
+    let cols = cols.unwrap_or(80);
+
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| format!("openpty: {e}"))?;
+
+    let mut cmd = CommandBuilder::new(&command);
+    for a in &args {
+        cmd.arg(a);
+    }
+    if let Some(d) = cwd.as_deref().filter(|s| !s.is_empty()) {
+        cmd.cwd(d);
+    }
+    // Forward TERM so xterm.js sees a recognizable terminal type.
+    cmd.env("TERM", "xterm-256color");
+    // Hint to interactive CLIs that this IS a TTY.
+    cmd.env("COLORTERM", "truecolor");
+
+    let mut child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|e| format!("spawn: {e}"))?;
+    drop(pair.slave);
+
+    let writer = pair
+        .master
+        .take_writer()
+        .map_err(|e| format!("take_writer: {e}"))?;
+    let reader = pair
+        .master
+        .try_clone_reader()
+        .map_err(|e| format!("clone_reader: {e}"))?;
+    let killer = child.clone_killer();
+
+    let pty_id = format!("ipty-{}", Uuid::new_v4());
+
+    // Reader thread — emits output chunks until the master EOFs
+    // (which happens when the child closes).
+    {
+        let app = app.clone();
+        let pty_id = pty_id.clone();
+        std::thread::spawn(move || {
+            let mut reader = reader;
+            let mut buf = [0u8; 4096];
+            loop {
+                match std::io::Read::read(&mut reader, &mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let chunk = String::from_utf8_lossy(&buf[..n]).into_owned();
+                        let event = format!("inline-pty-output-{pty_id}");
+                        let _ = app.emit(&event, chunk);
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+    }
+
+    // Wait thread — emits an exit event once the child terminates.
+    {
+        let app = app.clone();
+        let pty_id = pty_id.clone();
+        std::thread::spawn(move || {
+            let exit_code = match child.wait() {
+                Ok(status) => {
+                    if status.success() {
+                        Some(0)
+                    } else {
+                        // portable_pty's ExitStatus exposes exit_code()
+                        Some(status.exit_code() as i32)
+                    }
+                }
+                Err(_) => None,
+            };
+            let event = format!("inline-pty-exit-{pty_id}");
+            let _ = app.emit(&event, InlinePtyExitPayload { code: exit_code });
+        });
+    }
+
+    let mut map = state.inner.lock().unwrap_or_else(|e| e.into_inner());
+    map.insert(
+        pty_id.clone(),
+        InlinePty {
+            killer,
+            writer: Arc::new(Mutex::new(writer)),
+            master: Arc::new(Mutex::new(pair.master)),
+        },
+    );
+
+    Ok(pty_id)
+}
+
+#[tauri::command]
+pub fn write_inline_pty(
+    state: State<'_, InlinePtyManager>,
+    pty_id: String,
+    data: String,
+) -> Result<(), String> {
+    let map = state.inner.lock().unwrap_or_else(|e| e.into_inner());
+    let entry = map.get(&pty_id).ok_or("inline pty not found")?;
+    let mut w = entry.writer.lock().unwrap_or_else(|e| e.into_inner());
+    w.write_all(data.as_bytes())
+        .map_err(|e| format!("write: {e}"))?;
+    w.flush().map_err(|e| format!("flush: {e}"))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn resize_inline_pty(
+    state: State<'_, InlinePtyManager>,
+    pty_id: String,
+    rows: u16,
+    cols: u16,
+) -> Result<(), String> {
+    let map = state.inner.lock().unwrap_or_else(|e| e.into_inner());
+    let entry = map.get(&pty_id).ok_or("inline pty not found")?;
+    let master = entry.master.lock().unwrap_or_else(|e| e.into_inner());
+    master
+        .resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| format!("resize: {e}"))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn kill_inline_pty(
+    state: State<'_, InlinePtyManager>,
+    pty_id: String,
+) -> Result<(), String> {
+    let mut map = state.inner.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(mut entry) = map.remove(&pty_id) {
+        let _ = entry.killer.kill();
+    }
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,11 +3,11 @@ mod claude_config;
 mod clipboard;
 mod db;
 mod git;
+mod inline_pty;
 mod menu;
 mod platform;
 mod plugins;
 mod process;
-mod inline_pty;
 mod project;
 /// Exposed for benchmarks — not part of the public API.
 #[doc(hidden)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod menu;
 mod platform;
 mod plugins;
 mod process;
+mod inline_pty;
 mod project;
 /// Exposed for benchmarks — not part of the public API.
 #[doc(hidden)]
@@ -526,6 +527,7 @@ pub fn run() {
             app.manage(state);
             app.manage(Mutex::new(transcript::TranscriptWatcherState::default()));
             app.manage(agent::AgentState::default());
+            app.manage(inline_pty::InlinePtyManager::new());
 
             // Save workspace when the main window is about to close
             let save_handle = app.handle().clone();
@@ -763,6 +765,12 @@ pub fn run() {
             claude_config::read_static_mcp_servers,
             claude_config::read_static_slash_commands,
             claude_config::read_static_memory_paths,
+            // Inline PTY for embedded slash-command terminals
+            // (see src/inline_pty/mod.rs).
+            inline_pty::spawn_inline_pty,
+            inline_pty::write_inline_pty,
+            inline_pty::resize_inline_pty,
+            inline_pty::kill_inline_pty,
         ])
         .build(tauri::generate_context!())
         .expect("error while building HERMES-IDE")

--- a/src/__tests__/slash-command-kind.test.ts
+++ b/src/__tests__/slash-command-kind.test.ts
@@ -1,38 +1,48 @@
 /**
  * `classifySlashCommand` — pins which CLI commands need an embedded
- * PTY vs which run as a normal stream-json prompt.  This is the
- * routing decision the composer makes when the user accepts a
- * slash-command popover entry.
+ * PTY vs which run as a normal stream-json prompt.
+ *
+ * Priority (in order):
+ *   1. `<plugin>:<skill>` namespace → always native.
+ *   2. Description with terminal hint ("opens terminal", etc) → cli.
+ *   3. Description present + no CLI hint → native (trust the SDK).
+ *   4. No description + name in KNOWN_CLI_COMMANDS → cli.
+ *   5. Otherwise → native.
+ *
+ * The priority matters: an SDK-reported skill that happens to share
+ * a name with a CLI built-in (e.g. `/init` is both a CLI command and
+ * a Conductor skill) MUST classify as native when the SDK provides a
+ * description — we trust the SDK's word.
  */
 import { describe, it, expect } from "vitest";
-import { classifySlashCommand, stripSlash } from "../utils/slashCommandKind";
+import {
+  classifySlashCommand,
+  missingCliBuiltins,
+  stripSlash,
+} from "../utils/slashCommandKind";
 
-describe("classifySlashCommand — known CLI built-ins", () => {
-  it("/mcp, /agents, /help, /cost, /init etc. are CLI-only", () => {
+describe("classifySlashCommand — known CLI built-ins (no description)", () => {
+  it("interactive-only verbs without an SDK description fall through to cli", () => {
     for (const cmd of [
       "/mcp",
+      "/mcp-status",
       "/agents",
       "/help",
       "/cost",
-      "/init",
       "/login",
       "/logout",
       "/permissions",
-      "/output-style",
       "/clear",
       "/compact",
       "/config",
       "/doctor",
       "/memory",
       "/model",
-      "/pr-comments",
+      "/recap",
       "/release-notes",
-      "/review",
-      "/settings",
       "/status",
       "/terminal-setup",
       "/vim",
-      "/mcp-status",
     ]) {
       expect(classifySlashCommand({ command: cmd })).toBe("cli");
     }
@@ -45,29 +55,29 @@ describe("classifySlashCommand — known CLI built-ins", () => {
   });
 });
 
-describe("classifySlashCommand — namespaced (skill / plugin)", () => {
-  it("/<plugin>:<skill> is always native — runs through stream-json", () => {
-    expect(classifySlashCommand({ command: "/frontend-design:frontend-design" })).toBe("native");
-    expect(classifySlashCommand({ command: "/telegram:configure" })).toBe("native");
-    expect(classifySlashCommand({ command: "/hermes-test:ping" })).toBe("native");
+describe("classifySlashCommand — description trumps the KNOWN list", () => {
+  it("a same-named SDK skill (with description, no CLI hint) → native", () => {
+    // `/init` is BOTH a CLI built-in and an SDK-reported skill in
+    // Conductor's catalog.  When the SDK reports it (i.e. provides
+    // a description), we treat it as the skill — running it through
+    // stream-json — not the interactive terminal.  This protects
+    // user intent: they picked the skill from the popover.
+    expect(
+      classifySlashCommand({
+        command: "/init",
+        description: "Initialize a new CLAUDE.md file with codebase docs",
+      }),
+    ).toBe("native");
+
+    expect(
+      classifySlashCommand({
+        command: "/recap",
+        description: "Summarize the conversation in five bullets",
+      }),
+    ).toBe("native");
   });
 
-  it("plugin-namespaced names that look like CLI commands are STILL native", () => {
-    // /someplugin:mcp is a skill that happens to be named `mcp` —
-    // not the actual built-in.  Must NOT be misclassified.
-    expect(classifySlashCommand({ command: "/myplugin:mcp" })).toBe("native");
-    expect(classifySlashCommand({ command: "/myplugin:help" })).toBe("native");
-  });
-});
-
-describe("classifySlashCommand — user / project commands", () => {
-  it("custom commands from .claude/commands/*.md default to native", () => {
-    expect(classifySlashCommand({ command: "/recap" })).toBe("native");
-    expect(classifySlashCommand({ command: "/ship" })).toBe("native");
-    expect(classifySlashCommand({ command: "/hermes-ping" })).toBe("native");
-  });
-
-  it("custom command whose description hints at terminal → cli", () => {
+  it("description with CLI hint still wins → cli", () => {
     expect(
       classifySlashCommand({
         command: "/my-tui",
@@ -83,13 +93,90 @@ describe("classifySlashCommand — user / project commands", () => {
     ).toBe("cli");
   });
 
-  it("description mentioning the word 'terminal' in passing does NOT flip classification", () => {
+  it("description mentioning the word 'terminal' in passing does NOT flip", () => {
     expect(
       classifySlashCommand({
         command: "/explain-terminal",
         description: "Explain what a terminal command does without running it",
       }),
     ).toBe("native");
+  });
+});
+
+describe("classifySlashCommand — namespaced (skill / plugin)", () => {
+  it("/<plugin>:<skill> is always native", () => {
+    expect(classifySlashCommand({ command: "/frontend-design:frontend-design" })).toBe("native");
+    expect(classifySlashCommand({ command: "/telegram:configure" })).toBe("native");
+    expect(classifySlashCommand({ command: "/hermes-test:ping" })).toBe("native");
+  });
+
+  it("plugin-namespaced names that look like CLI commands are STILL native", () => {
+    expect(classifySlashCommand({ command: "/myplugin:mcp" })).toBe("native");
+    expect(classifySlashCommand({ command: "/myplugin:help" })).toBe("native");
+  });
+});
+
+describe("classifySlashCommand — user / custom commands", () => {
+  it("custom commands NOT on the curated list default to native", () => {
+    expect(classifySlashCommand({ command: "/ship" })).toBe("native");
+    expect(classifySlashCommand({ command: "/hermes-ping" })).toBe("native");
+    expect(classifySlashCommand({ command: "/team-standup" })).toBe("native");
+  });
+});
+
+describe("missingCliBuiltins — curated-mirror merge", () => {
+  it("returns the well-known Claude Code CLI built-ins when none are in the existing list", () => {
+    const got = missingCliBuiltins([]);
+    const names = got.map((b) => b.command);
+    // Spot-check several names across the catalog.
+    expect(names).toContain("/mcp");
+    expect(names).toContain("/mcp-status");
+    expect(names).toContain("/agents");
+    expect(names).toContain("/help");
+    expect(names).toContain("/cost");
+    expect(names).toContain("/login");
+    expect(names).toContain("/logout");
+    expect(names).toContain("/permissions");
+    expect(names).toContain("/plan");
+    expect(names).toContain("/plugin");
+    expect(names).toContain("/clear");
+    expect(names).toContain("/compact");
+    expect(names).toContain("/diff");
+    expect(names).toContain("/doctor");
+    expect(names).toContain("/memory");
+    expect(names).toContain("/model");
+    expect(names).toContain("/theme");
+  });
+
+  it("catalog has at least 60 entries", () => {
+    expect(missingCliBuiltins([]).length).toBeGreaterThanOrEqual(60);
+  });
+
+  it("dedupes against the SDK-reported list (case-insensitive)", () => {
+    const got = missingCliBuiltins([
+      { command: "/mcp" },
+      { command: "/Help" },
+      { command: "/AGENTS" },
+    ]);
+    const names = got.map((b) => b.command);
+    expect(names).not.toContain("/mcp");
+    expect(names).not.toContain("/help");
+    expect(names).not.toContain("/agents");
+    // But still includes the rest.
+    expect(names).toContain("/login");
+    expect(names).toContain("/cost");
+  });
+
+  it("every catalog entry classifies as `cli` when used without a description", () => {
+    for (const b of missingCliBuiltins([])) {
+      expect(classifySlashCommand({ command: b.command })).toBe("cli");
+    }
+  });
+
+  it("descriptions are short enough for the dropdown row (≤60 chars)", () => {
+    for (const b of missingCliBuiltins([])) {
+      expect(b.description.length).toBeLessThanOrEqual(60);
+    }
   });
 });
 

--- a/src/__tests__/slash-command-kind.test.ts
+++ b/src/__tests__/slash-command-kind.test.ts
@@ -1,0 +1,107 @@
+/**
+ * `classifySlashCommand` — pins which CLI commands need an embedded
+ * PTY vs which run as a normal stream-json prompt.  This is the
+ * routing decision the composer makes when the user accepts a
+ * slash-command popover entry.
+ */
+import { describe, it, expect } from "vitest";
+import { classifySlashCommand, stripSlash } from "../utils/slashCommandKind";
+
+describe("classifySlashCommand — known CLI built-ins", () => {
+  it("/mcp, /agents, /help, /cost, /init etc. are CLI-only", () => {
+    for (const cmd of [
+      "/mcp",
+      "/agents",
+      "/help",
+      "/cost",
+      "/init",
+      "/login",
+      "/logout",
+      "/permissions",
+      "/output-style",
+      "/clear",
+      "/compact",
+      "/config",
+      "/doctor",
+      "/memory",
+      "/model",
+      "/pr-comments",
+      "/release-notes",
+      "/review",
+      "/settings",
+      "/status",
+      "/terminal-setup",
+      "/vim",
+      "/mcp-status",
+    ]) {
+      expect(classifySlashCommand({ command: cmd })).toBe("cli");
+    }
+  });
+
+  it("classifies regardless of leading slash + case", () => {
+    expect(classifySlashCommand({ command: "MCP" })).toBe("cli");
+    expect(classifySlashCommand({ command: "/Help" })).toBe("cli");
+    expect(classifySlashCommand({ command: "/AGENTS" })).toBe("cli");
+  });
+});
+
+describe("classifySlashCommand — namespaced (skill / plugin)", () => {
+  it("/<plugin>:<skill> is always native — runs through stream-json", () => {
+    expect(classifySlashCommand({ command: "/frontend-design:frontend-design" })).toBe("native");
+    expect(classifySlashCommand({ command: "/telegram:configure" })).toBe("native");
+    expect(classifySlashCommand({ command: "/hermes-test:ping" })).toBe("native");
+  });
+
+  it("plugin-namespaced names that look like CLI commands are STILL native", () => {
+    // /someplugin:mcp is a skill that happens to be named `mcp` —
+    // not the actual built-in.  Must NOT be misclassified.
+    expect(classifySlashCommand({ command: "/myplugin:mcp" })).toBe("native");
+    expect(classifySlashCommand({ command: "/myplugin:help" })).toBe("native");
+  });
+});
+
+describe("classifySlashCommand — user / project commands", () => {
+  it("custom commands from .claude/commands/*.md default to native", () => {
+    expect(classifySlashCommand({ command: "/recap" })).toBe("native");
+    expect(classifySlashCommand({ command: "/ship" })).toBe("native");
+    expect(classifySlashCommand({ command: "/hermes-ping" })).toBe("native");
+  });
+
+  it("custom command whose description hints at terminal → cli", () => {
+    expect(
+      classifySlashCommand({
+        command: "/my-tui",
+        description: "Drop into an interactive picker (opens terminal)",
+      }),
+    ).toBe("cli");
+
+    expect(
+      classifySlashCommand({
+        command: "/my-tool",
+        description: "Run an interactive CLI for setup",
+      }),
+    ).toBe("cli");
+  });
+
+  it("description mentioning the word 'terminal' in passing does NOT flip classification", () => {
+    expect(
+      classifySlashCommand({
+        command: "/explain-terminal",
+        description: "Explain what a terminal command does without running it",
+      }),
+    ).toBe("native");
+  });
+});
+
+describe("stripSlash", () => {
+  it("removes a leading slash", () => {
+    expect(stripSlash("/mcp")).toBe("mcp");
+    expect(stripSlash("/foo:bar")).toBe("foo:bar");
+  });
+  it("leaves bare names alone", () => {
+    expect(stripSlash("mcp")).toBe("mcp");
+  });
+  it("only strips ONE leading slash (defensive)", () => {
+    expect(stripSlash("//mcp")).toBe("/mcp");
+  });
+});

--- a/src/components/CliCommandBanner.tsx
+++ b/src/components/CliCommandBanner.tsx
@@ -1,0 +1,47 @@
+/**
+ * Banner shown above the composer when the user picks a slash command
+ * that's CLI-only (e.g. `/mcp`, `/agents`).  These commands require
+ * an interactive `claude /<cmd>` PTY — they don't work over the
+ * stream-json prompt channel, so silently sending them would no-op.
+ *
+ * Spec / inspiration: Conductor's "Run /mcp in the embedded terminal"
+ * row above the chat composer.  Click `Open terminal` to mount the
+ * embedded inline PTY (Phase 3 follow-up); click the X to cancel.
+ */
+import "../styles/components/CliCommandBanner.css";
+
+interface Props {
+  command: string;
+  /** Mount the embedded terminal that will run `claude <command>`. */
+  onOpenTerminal: () => void;
+  /** Dismiss the banner without running anything. */
+  onCancel: () => void;
+}
+
+export function CliCommandBanner({ command, onOpenTerminal, onCancel }: Props) {
+  return (
+    <div className="cli-banner" role="status" aria-live="polite">
+      <span className="cli-banner-icon" aria-hidden="true">▣</span>
+      <span className="cli-banner-text">
+        Run <code className="cli-banner-code">{command}</code> in the embedded terminal
+      </span>
+      <button
+        type="button"
+        className="cli-banner-action"
+        onClick={onOpenTerminal}
+      >
+        <span aria-hidden="true">›_</span>
+        <span>Open terminal</span>
+      </button>
+      <button
+        type="button"
+        className="cli-banner-dismiss"
+        onClick={onCancel}
+        aria-label="Cancel"
+        title="Cancel"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/src/components/EmbeddedSlashTerminal.tsx
+++ b/src/components/EmbeddedSlashTerminal.tsx
@@ -19,7 +19,7 @@
  * button.  Esc inside the terminal closes the panel.
  */
 import "../styles/components/EmbeddedSlashTerminal.css";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { Terminal } from "@xterm/xterm";
@@ -53,23 +53,31 @@ interface Props {
 
 export function EmbeddedSlashTerminal({ spec, cwd, onClose }: Props) {
   // Resolve the binary + args + display label up front from the spec.
-  // Slash mode runs `claude <verb>`; shell mode runs the user's
-  // default interactive shell ($SHELL → zsh → bash → sh).
-  const { spawnBinary, spawnArgs, displayLabel } = (() => {
-    if (spec.kind === "slash") {
-      const argList = spec.command.replace(/^\//, "").split(/\s+/).filter(Boolean);
+  //
+  // Slash mode: `claude` interactive REPL (no args).  We then write
+  //   the slash command to stdin after spawn so the user lands
+  //   directly in the command's TUI.  Calling `claude mcp` (positional
+  //   arg) gives the CLI-FLAG interface, which just prints usage —
+  //   only the in-REPL `/mcp` triggers the actual interactive TUI
+  //   the user expects.
+  //
+  // Shell mode: spawn the user's default shell with `-i` so they see
+  //   their prompt + history.
+  const isSlash = spec.kind === "slash";
+  const { spawnBinary, spawnArgs, displayLabel, autoInput } = useMemo(() => {
+    if (isSlash) {
+      // The command needs to be sent INTO claude's REPL, not as argv.
+      // We retain the raw `/cmd` as autoInput and pipe it after spawn.
       return {
         spawnBinary: "claude",
-        spawnArgs: argList,
-        displayLabel: `claude ${spec.command.replace(/^\//, "")}`,
+        spawnArgs: [] as string[],
+        displayLabel: `claude → ${spec.command}`,
+        autoInput: `${spec.command}\r`,
       };
     }
-    // Shell mode: pick a sensible default.  Browser-side we can't read
-    // process.env, so we fall back to /bin/zsh (default macOS shell on
-    // 10.15+) when the prop doesn't override.  An interactive shell
-    // wants `-i` so the user sees their prompt + history.
+    const shellSpec = spec as { binary?: string };
     const bin =
-      spec.binary?.trim() ||
+      shellSpec.binary?.trim() ||
       (typeof navigator !== "undefined" && navigator.platform.includes("Win")
         ? "powershell.exe"
         : "/bin/zsh");
@@ -77,8 +85,9 @@ export function EmbeddedSlashTerminal({ spec, cwd, onClose }: Props) {
       spawnBinary: bin,
       spawnArgs: ["-i"],
       displayLabel: bin.split("/").pop() ?? bin,
+      autoInput: null as string | null,
     };
-  })();
+  }, [isSlash, spec]);
   const [phase, setPhase] = useState<"booting" | "running" | "exited" | "error">("booting");
   const [exitCode, setExitCode] = useState<number | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -165,6 +174,19 @@ export function EmbeddedSlashTerminal({ spec, cwd, onClose }: Props) {
         unOutput = await listen<string>(`inline-pty-output-${ptyId}`, (msg) => {
           xterm.write(msg.payload);
         });
+
+        // Slash mode: auto-type the command into Claude's REPL once
+        // it's ready.  We can't reliably detect the prompt (claude's
+        // bootstrap output is irregular), so we wait a fixed window
+        // long enough for cold spawns then send the command.  A real
+        // TTY will buffer it; the user sees the typed command echo +
+        // the resulting TUI.
+        if (autoInput) {
+          setTimeout(() => {
+            if (cancelled) return;
+            invoke("write_inline_pty", { ptyId, data: autoInput }).catch(() => {});
+          }, 1500);
+        }
         unExit = await listen<{ code: number | null }>(
           `inline-pty-exit-${ptyId}`,
           (msg) => {
@@ -193,7 +215,7 @@ export function EmbeddedSlashTerminal({ spec, cwd, onClose }: Props) {
       try { xterm.dispose(); } catch { /* already gone */ }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [spec.kind, spec.kind === "slash" ? spec.command : null, spawnBinary, cwd]);
+  }, [spawnBinary, autoInput, cwd]);
 
   const subtitle =
     phase === "booting" ? "spawning…" :

--- a/src/components/EmbeddedSlashTerminal.tsx
+++ b/src/components/EmbeddedSlashTerminal.tsx
@@ -1,0 +1,194 @@
+/**
+ * Inline xterm that runs a slash command's CLI in a one-shot PTY.
+ *
+ * Mount path: the composer renders this above its textarea when the
+ * user clicks "Open terminal" on a CLI-only slash command (`/mcp`,
+ * `/agents`, etc.).  This component:
+ *
+ *   1. Calls `spawn_inline_pty(command, args, cwd)` Rust IPC.
+ *   2. Listens on `inline-pty-output-{id}` for output chunks, writes
+ *      them to xterm.
+ *   3. Forwards xterm key events back via `write_inline_pty`.
+ *   4. Resizes the PTY to match the terminal box dimensions.
+ *   5. On `inline-pty-exit-{id}` (or unmount) kills the child and
+ *      tears the xterm down.
+ *
+ * Visual: a 280px-tall card that sits between the message timeline
+ * and the composer.  Header bar carries the command label, an
+ * `Expand` button (TBD — opens in a separate pane), and a `Close`
+ * button.  Esc inside the terminal closes the panel.
+ */
+import "../styles/components/EmbeddedSlashTerminal.css";
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import "@xterm/xterm/css/xterm.css";
+
+interface Props {
+  /** The slash command including the leading slash, e.g. `/mcp`. */
+  command: string;
+  /** cwd to spawn the PTY in.  Falls back to home if undefined. */
+  cwd: string | null | undefined;
+  /** Called when the user closes the terminal — banner is dismissed
+   *  and the composer regains focus. */
+  onClose: () => void;
+}
+
+export function EmbeddedSlashTerminal({ command, cwd, onClose }: Props) {
+  const [phase, setPhase] = useState<"booting" | "running" | "exited" | "error">("booting");
+  const [exitCode, setExitCode] = useState<number | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const xtermRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const ptyIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    let cancelled = false;
+    let unOutput: UnlistenFn | undefined;
+    let unExit: UnlistenFn | undefined;
+
+    // Strip the leading slash so we pass `mcp` not `/mcp` as argv to
+    // claude.  The bare verb is what the CLI expects.
+    const argList = command.replace(/^\//, "").split(/\s+/).filter(Boolean);
+
+    const xterm = new Terminal({
+      fontFamily: 'JetBrains Mono, Menlo, monospace',
+      fontSize: 12,
+      lineHeight: 1.3,
+      theme: { background: "#0d1218" },
+      cursorBlink: true,
+      convertEol: true,
+      scrollback: 4000,
+    });
+    const fit = new FitAddon();
+    xterm.loadAddon(fit);
+    xterm.open(containerRef.current);
+    xtermRef.current = xterm;
+    fitRef.current = fit;
+    fit.fit();
+
+    // Wire keystrokes from xterm back to the PTY.
+    xterm.onData((data) => {
+      const id = ptyIdRef.current;
+      if (!id) return;
+      invoke("write_inline_pty", { ptyId: id, data }).catch(() => {});
+    });
+
+    // Container resize → PTY resize so the child re-renders the TUI
+    // at the right dimensions.  Debounced via rAF.
+    let resizeRaf = 0;
+    const ro = new ResizeObserver(() => {
+      cancelAnimationFrame(resizeRaf);
+      resizeRaf = requestAnimationFrame(() => {
+        try {
+          fit.fit();
+        } catch { /* xterm not mounted yet */ }
+        const id = ptyIdRef.current;
+        if (id && xterm.rows && xterm.cols) {
+          invoke("resize_inline_pty", {
+            ptyId: id,
+            rows: xterm.rows,
+            cols: xterm.cols,
+          }).catch(() => {});
+        }
+      });
+    });
+    ro.observe(containerRef.current);
+
+    // Close on Esc — common terminal-modal expectation.
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && (phase === "exited" || phase === "error")) {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+
+    (async () => {
+      try {
+        const ptyId = await invoke<string>("spawn_inline_pty", {
+          command: "claude",
+          args: argList,
+          cwd: cwd ?? null,
+          rows: xterm.rows ?? 24,
+          cols: xterm.cols ?? 80,
+        });
+        if (cancelled) {
+          await invoke("kill_inline_pty", { ptyId });
+          return;
+        }
+        ptyIdRef.current = ptyId;
+        setPhase("running");
+
+        unOutput = await listen<string>(`inline-pty-output-${ptyId}`, (msg) => {
+          xterm.write(msg.payload);
+        });
+        unExit = await listen<{ code: number | null }>(
+          `inline-pty-exit-${ptyId}`,
+          (msg) => {
+            setExitCode(msg.payload?.code ?? null);
+            setPhase("exited");
+          },
+        );
+      } catch (err) {
+        const m = err instanceof Error ? err.message : String(err);
+        setErrorMsg(m);
+        setPhase("error");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener("keydown", onKey);
+      ro.disconnect();
+      cancelAnimationFrame(resizeRaf);
+      unOutput?.();
+      unExit?.();
+      const id = ptyIdRef.current;
+      if (id) {
+        invoke("kill_inline_pty", { ptyId: id }).catch(() => {});
+      }
+      try { xterm.dispose(); } catch { /* already gone */ }
+    };
+  }, [command, cwd]);
+
+  const subtitle =
+    phase === "booting" ? "spawning…" :
+    phase === "running" ? "running" :
+    phase === "exited"  ? `exited${exitCode !== null ? ` (code ${exitCode})` : ""}` :
+    `error${errorMsg ? ` — ${errorMsg}` : ""}`;
+
+  return (
+    <div className="ipty-card" data-phase={phase}>
+      <header className="ipty-card-header">
+        <span className="ipty-card-icon" aria-hidden="true">▣</span>
+        <code className="ipty-card-cmd">claude {command.replace(/^\//, "")}</code>
+        <span className="ipty-card-status" aria-live="polite">{subtitle}</span>
+        <button
+          type="button"
+          className="ipty-card-close"
+          onClick={onClose}
+          aria-label="Close embedded terminal"
+          title="Close (Esc)"
+        >
+          ✕
+        </button>
+      </header>
+      <div ref={containerRef} className="ipty-card-body" />
+      {phase === "exited" && (
+        <div className="ipty-card-footer">
+          press Esc to close, or run another /command from the composer
+        </div>
+      )}
+      {phase === "error" && (
+        <div className="ipty-card-footer ipty-card-footer-error">
+          couldn't spawn claude — {errorMsg ?? "unknown error"}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/EmbeddedSlashTerminal.tsx
+++ b/src/components/EmbeddedSlashTerminal.tsx
@@ -171,21 +171,43 @@ export function EmbeddedSlashTerminal({ spec, cwd, onClose }: Props) {
         ptyIdRef.current = ptyId;
         setPhase("running");
 
+        // Slash mode: hold the command until we see Claude's REPL
+        // prompt marker (`❯ ` — the chevron + space at the input
+        // line).  Auto-typing earlier would fire mid-trust-prompt
+        // (the "Yes, I trust this folder" gate) and get interpreted
+        // as confirming that, leaving the slash text in the chat
+        // box.  Only stream output to xterm; once the marker is
+        // detected, send the input ONCE and stop watching.
+        let autoInputSent = autoInput === null;
+        let bootBuf = "";
+        const PROMPT_RE = /❯\s|^>\s/m; // ❯ space, or ">" space
         unOutput = await listen<string>(`inline-pty-output-${ptyId}`, (msg) => {
           xterm.write(msg.payload);
+          if (autoInputSent) return;
+          bootBuf += msg.payload;
+          // Cap the boot buffer so we don't grow forever if the
+          // marker never appears.
+          if (bootBuf.length > 16_000) bootBuf = bootBuf.slice(-8000);
+          if (PROMPT_RE.test(bootBuf)) {
+            autoInputSent = true;
+            // Small breath after the prompt renders so the input
+            // line is fully drawn before we stuff data.
+            setTimeout(() => {
+              if (cancelled) return;
+              invoke("write_inline_pty", { ptyId, data: autoInput! }).catch(() => {});
+            }, 180);
+          }
         });
 
-        // Slash mode: auto-type the command into Claude's REPL once
-        // it's ready.  We can't reliably detect the prompt (claude's
-        // bootstrap output is irregular), so we wait a fixed window
-        // long enough for cold spawns then send the command.  A real
-        // TTY will buffer it; the user sees the typed command echo +
-        // the resulting TUI.
+        // Safety fallback: if we never see the marker (claude version
+        // changed, theme rewrote it, etc.), still send after 6 s so
+        // the feature degrades gracefully instead of hanging silent.
         if (autoInput) {
           setTimeout(() => {
-            if (cancelled) return;
+            if (cancelled || autoInputSent) return;
+            autoInputSent = true;
             invoke("write_inline_pty", { ptyId, data: autoInput }).catch(() => {});
-          }, 1500);
+          }, 6000);
         }
         unExit = await listen<{ code: number | null }>(
           `inline-pty-exit-${ptyId}`,

--- a/src/components/EmbeddedSlashTerminal.tsx
+++ b/src/components/EmbeddedSlashTerminal.tsx
@@ -26,9 +26,24 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 
-interface Props {
+interface SlashCommandSpec {
+  kind: "slash";
   /** The slash command including the leading slash, e.g. `/mcp`. */
   command: string;
+}
+
+interface ShellSpec {
+  kind: "shell";
+  /** Optional shell binary override.  Defaults to $SHELL or zsh. */
+  binary?: string;
+}
+
+export type EmbeddedTerminalSpec = SlashCommandSpec | ShellSpec;
+
+interface Props {
+  /** What to spawn in the PTY: a one-shot `claude /<cmd>` invocation,
+   *  or the user's interactive shell for ad-hoc use. */
+  spec: EmbeddedTerminalSpec;
   /** cwd to spawn the PTY in.  Falls back to home if undefined. */
   cwd: string | null | undefined;
   /** Called when the user closes the terminal — banner is dismissed
@@ -36,7 +51,34 @@ interface Props {
   onClose: () => void;
 }
 
-export function EmbeddedSlashTerminal({ command, cwd, onClose }: Props) {
+export function EmbeddedSlashTerminal({ spec, cwd, onClose }: Props) {
+  // Resolve the binary + args + display label up front from the spec.
+  // Slash mode runs `claude <verb>`; shell mode runs the user's
+  // default interactive shell ($SHELL → zsh → bash → sh).
+  const { spawnBinary, spawnArgs, displayLabel } = (() => {
+    if (spec.kind === "slash") {
+      const argList = spec.command.replace(/^\//, "").split(/\s+/).filter(Boolean);
+      return {
+        spawnBinary: "claude",
+        spawnArgs: argList,
+        displayLabel: `claude ${spec.command.replace(/^\//, "")}`,
+      };
+    }
+    // Shell mode: pick a sensible default.  Browser-side we can't read
+    // process.env, so we fall back to /bin/zsh (default macOS shell on
+    // 10.15+) when the prop doesn't override.  An interactive shell
+    // wants `-i` so the user sees their prompt + history.
+    const bin =
+      spec.binary?.trim() ||
+      (typeof navigator !== "undefined" && navigator.platform.includes("Win")
+        ? "powershell.exe"
+        : "/bin/zsh");
+    return {
+      spawnBinary: bin,
+      spawnArgs: ["-i"],
+      displayLabel: bin.split("/").pop() ?? bin,
+    };
+  })();
   const [phase, setPhase] = useState<"booting" | "running" | "exited" | "error">("booting");
   const [exitCode, setExitCode] = useState<number | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -51,10 +93,6 @@ export function EmbeddedSlashTerminal({ command, cwd, onClose }: Props) {
     let cancelled = false;
     let unOutput: UnlistenFn | undefined;
     let unExit: UnlistenFn | undefined;
-
-    // Strip the leading slash so we pass `mcp` not `/mcp` as argv to
-    // claude.  The bare verb is what the CLI expects.
-    const argList = command.replace(/^\//, "").split(/\s+/).filter(Boolean);
 
     const xterm = new Terminal({
       fontFamily: 'JetBrains Mono, Menlo, monospace',
@@ -111,8 +149,8 @@ export function EmbeddedSlashTerminal({ command, cwd, onClose }: Props) {
     (async () => {
       try {
         const ptyId = await invoke<string>("spawn_inline_pty", {
-          command: "claude",
-          args: argList,
+          command: spawnBinary,
+          args: spawnArgs,
           cwd: cwd ?? null,
           rows: xterm.rows ?? 24,
           cols: xterm.cols ?? 80,
@@ -154,7 +192,8 @@ export function EmbeddedSlashTerminal({ command, cwd, onClose }: Props) {
       }
       try { xterm.dispose(); } catch { /* already gone */ }
     };
-  }, [command, cwd]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [spec.kind, spec.kind === "slash" ? spec.command : null, spawnBinary, cwd]);
 
   const subtitle =
     phase === "booting" ? "spawning…" :
@@ -166,7 +205,7 @@ export function EmbeddedSlashTerminal({ command, cwd, onClose }: Props) {
     <div className="ipty-card" data-phase={phase}>
       <header className="ipty-card-header">
         <span className="ipty-card-icon" aria-hidden="true">▣</span>
-        <code className="ipty-card-cmd">claude {command.replace(/^\//, "")}</code>
+        <code className="ipty-card-cmd">{displayLabel}</code>
         <span className="ipty-card-status" aria-live="polite">{subtitle}</span>
         <button
           type="button"

--- a/src/components/SessionComposer.tsx
+++ b/src/components/SessionComposer.tsx
@@ -9,6 +9,7 @@ import { classifySlashCommand } from "../utils/slashCommandKind";
 import { fuzzyRank } from "../utils/fuzzy";
 import { SlashCommandsDropdown, type SlashCommandItem } from "./SlashCommandsDropdown";
 import { CliCommandBanner } from "./CliCommandBanner";
+import { EmbeddedSlashTerminal } from "./EmbeddedSlashTerminal";
 import { ModelPicker } from "./ModelPicker";
 import { PermissionPicker, CLAUDE_PERMISSION_MODES } from "./PermissionPicker";
 import { EffortPicker } from "./EffortPicker";
@@ -168,6 +169,11 @@ export function SessionComposer() {
    *  command as a stream-json prompt (which silently no-ops for
    *  these CLI-only commands). */
   const [pendingCliCommand, setPendingCliCommand] = useState<string | null>(null);
+  /** When the user clicks "Open terminal" on the banner, this flips
+   *  to the command we're running.  The composer mounts an inline
+   *  `<EmbeddedSlashTerminal>` for the duration; closing it returns
+   *  to the normal composer. */
+  const [activeTerminalCommand, setActiveTerminalCommand] = useState<string | null>(null);
 
   const rankedCommands = useMemo<SlashCommandItem[] | null>(() => {
     if (!slash || !isAgentMode) return null;
@@ -669,22 +675,21 @@ export function SessionComposer() {
         aria-label="Resize composer"
         onMouseDown={handleResizeMouseDown}
       />
-      {pendingCliCommand && (
+      {pendingCliCommand && !activeTerminalCommand && (
         <CliCommandBanner
           command={pendingCliCommand}
           onOpenTerminal={() => {
-            // Phase 3: mount the embedded terminal here.  For now,
-            // surface a toast so the user can verify the routing
-            // is firing without us silently dropping the command.
-            console.log(`[cli-banner] open terminal requested for ${pendingCliCommand}`);
-            alert(
-              `Embedded terminal will run:\n\n  claude ${pendingCliCommand}\n\n` +
-              `(Embedded PTY mount is the next commit; this banner + dropdown badge ` +
-              `prove the slash routing.)`,
-            );
+            setActiveTerminalCommand(pendingCliCommand);
             setPendingCliCommand(null);
           }}
           onCancel={() => setPendingCliCommand(null)}
+        />
+      )}
+      {activeTerminalCommand && (
+        <EmbeddedSlashTerminal
+          command={activeTerminalCommand}
+          cwd={init?.cwd ?? null}
+          onClose={() => setActiveTerminalCommand(null)}
         />
       )}
       <div className="session-composer-card">

--- a/src/components/SessionComposer.tsx
+++ b/src/components/SessionComposer.tsx
@@ -127,9 +127,17 @@ export function SessionComposer() {
   // surfaces the kind as a badge so the user knows up-front whether
   // accepting the item will send a chat message or pop a terminal.
   const slashCommandsFromInit = useMemo<SlashCommandItem[]>(() => {
+    // Pure dynamic source: whatever the SDK reports in init.  No
+    // hard-coded augmentation — the catalog is live and version-
+    // matched to the binary the user actually has.  CLI-only
+    // built-ins that the SDK doesn't surface (because they don't
+    // work over stream-json) won't appear here, but the user can
+    // still type them manually and `handleSubmit` routes them to
+    // the embedded terminal via `classifySlashCommand`.
     const raw = init?.slash_commands;
+    let items: SlashCommandItem[];
     if (Array.isArray(raw)) {
-      const items = raw
+      items = raw
         .map((entry): SlashCommandItem | null => {
           if (typeof entry === "string") {
             const command = entry.startsWith("/") ? entry : `/${entry}`;
@@ -146,18 +154,16 @@ export function SessionComposer() {
           return null;
         })
         .filter((c): c is SlashCommandItem => c !== null);
-      // Annotate every entry with its kind.
-      return items.map((it) => ({ ...it, kind: classifySlashCommand(it) }));
+    } else {
+      const merged = mergeSlashCommands(prewarm.slashCommands, undefined);
+      items = merged.map((cmd) => ({
+        command: cmd.startsWith("/") ? cmd : `/${cmd}`,
+        label: "",
+        description: "",
+        source: "builtin" as const,
+      }));
     }
-    // Pre-init fallback: static prewarm.  Source is filesystem only,
-    // so descriptions are blank — the dropdown still renders with the
-    // command names so / autocomplete works before first message.
-    const merged = mergeSlashCommands(prewarm.slashCommands, undefined);
-    return merged.map((cmd) => {
-      const command = cmd.startsWith("/") ? cmd : `/${cmd}`;
-      const item: SlashCommandItem = { command, label: "", description: "", source: "builtin" };
-      return { ...item, kind: classifySlashCommand(item) };
-    });
+    return items.map((it) => ({ ...it, kind: classifySlashCommand(it) }));
   }, [init, prewarm.slashCommands]);
 
   // ─── Active slash overlay state ─────────────────────────────────────
@@ -245,6 +251,24 @@ export function SessionComposer() {
     if (!composerSessionId) return;
     if (inFlightRef.current) return;
     if (!draft.trim() && pendingImages.length === 0) return;
+
+    // Pre-submit routing: if the entire draft is a single slash
+    // command and that command classifies as `cli` (built-in
+    // interactive verb the SDK can't drive over stream-json), route
+    // to the embedded terminal banner instead of sending it as a
+    // chat message.  Honors the dynamic-list contract: even commands
+    // the SDK didn't include in init.slash_commands get routed
+    // correctly when the user types them manually.
+    const trimmed = draft.trim();
+    if (trimmed.startsWith("/") && !/\s/.test(trimmed)) {
+      const kind = classifySlashCommand({ command: trimmed });
+      if (kind === "cli") {
+        dispatch({ type: "SET_COMPOSER_DRAFT", sessionId: composerSessionId, draft: "" });
+        setPendingCliCommand(trimmed);
+        return;
+      }
+    }
+
     inFlightRef.current = true;
     try {
       const attachments: AgentAttachment[] = pendingImages.map((img) => ({
@@ -666,7 +690,12 @@ export function SessionComposer() {
     <div
       ref={wrapperRef}
       className={`session-composer session-composer-claude ${isDragOver ? "session-composer-drag-over" : ""}`}
-      style={{ height: effectiveHeight }}
+      // When the embedded slash terminal is mounted, let the wrapper
+      // grow naturally to accommodate it — the user-set composer
+      // height applies only to the textarea card.  Otherwise the
+      // 280-px terminal overflows the fixed-height wrapper and lands
+      // above the conversation, leaving dead space below.
+      style={activeTerminalCommand ? undefined : { height: effectiveHeight }}
     >
       <div
         className="session-composer-resize-handle"

--- a/src/components/SessionComposer.tsx
+++ b/src/components/SessionComposer.tsx
@@ -169,15 +169,21 @@ export function SessionComposer() {
       }));
     }
     // Append curated CLI built-ins that the SDK didn't include.
+    // These are interactive-only by definition — mark them `cli`
+    // explicitly so the classifier doesn't get tripped up by their
+    // descriptions (which don't carry a CLI hint phrase).
     for (const builtin of missingCliBuiltins(items)) {
       items.push({
         command: builtin.command,
         label: "",
         description: builtin.description,
         source: "builtin",
+        kind: "cli",
       });
     }
-    return items.map((it) => ({ ...it, kind: classifySlashCommand(it) }));
+    // Items already marked (catalog) keep their kind.  Everything
+    // else runs through the classifier.
+    return items.map((it) => ({ ...it, kind: it.kind ?? classifySlashCommand(it) }));
   }, [init, prewarm.slashCommands]);
 
   // ─── Active slash overlay state ─────────────────────────────────────
@@ -709,12 +715,12 @@ export function SessionComposer() {
     <div
       ref={wrapperRef}
       className={`session-composer session-composer-claude ${isDragOver ? "session-composer-drag-over" : ""}`}
-      // When the embedded terminal is mounted, let the wrapper grow
-      // naturally to accommodate it — the user-set composer height
-      // applies only to the textarea card.  Otherwise the 280-px
-      // terminal overflows the fixed-height wrapper and lands above
-      // the conversation, leaving dead space below.
-      style={activeTerminal ? undefined : { height: effectiveHeight }}
+      // When the embedded terminal OR the CLI banner is mounted,
+      // let the wrapper grow naturally — the user-set composer height
+      // applies only to the textarea card.  Otherwise the extra
+      // chrome overflows the fixed-height wrapper and clips the
+      // textarea below.
+      style={(activeTerminal || pendingCliCommand) ? undefined : { height: effectiveHeight }}
     >
       <div
         className="session-composer-resize-handle"

--- a/src/components/SessionComposer.tsx
+++ b/src/components/SessionComposer.tsx
@@ -742,7 +742,13 @@ export function SessionComposer() {
       {activeTerminal && (
         <EmbeddedSlashTerminal
           spec={activeTerminal}
-          cwd={init?.cwd ?? null}
+          // cwd fallback chain: SDK init wins (it's the canonical
+          // session cwd), then the session's working_directory which
+          // we have on record from session creation, then a final
+          // null which lets the PTY inherit the parent process —
+          // which is rarely correct (the dev binary's launch dir is
+          // not where the user expects claude to run).
+          cwd={init?.cwd ?? session?.working_directory ?? null}
           onClose={() => setActiveTerminal(null)}
         />
       )}

--- a/src/components/SessionComposer.tsx
+++ b/src/components/SessionComposer.tsx
@@ -5,8 +5,10 @@ import type { AgentAttachment } from "../utils/submitToAgent";
 import { isActionMod, isMac } from "../utils/platform";
 import { readImageForAttachment } from "../api/agent";
 import { getActiveSlashCommand, replaceSlashCommand } from "../utils/slashCommands";
+import { classifySlashCommand } from "../utils/slashCommandKind";
 import { fuzzyRank } from "../utils/fuzzy";
 import { SlashCommandsDropdown, type SlashCommandItem } from "./SlashCommandsDropdown";
+import { CliCommandBanner } from "./CliCommandBanner";
 import { ModelPicker } from "./ModelPicker";
 import { PermissionPicker, CLAUDE_PERMISSION_MODES } from "./PermissionPicker";
 import { EffortPicker } from "./EffortPicker";
@@ -119,44 +121,53 @@ export function SessionComposer() {
   const prewarm = useAgentPrewarm(init?.cwd);
 
   // ─── Slash commands sourced from init OR static prewarm ─────────────
+  // Each item is classified `native` (run via stream-json prompt) or
+  // `cli` (must run in an embedded `claude /<cmd>` PTY).  The dropdown
+  // surfaces the kind as a badge so the user knows up-front whether
+  // accepting the item will send a chat message or pop a terminal.
   const slashCommandsFromInit = useMemo<SlashCommandItem[]>(() => {
-    if (init) {
-      const raw = init.slash_commands;
-      if (Array.isArray(raw)) {
-        return raw
-          .map((entry): SlashCommandItem | null => {
-            if (typeof entry === "string") {
-              const command = entry.startsWith("/") ? entry : `/${entry}`;
-              return { command, label: "", description: "", source: "builtin" };
-            }
-            if (entry && typeof entry === "object") {
-              const command = typeof entry.command === "string"
-                ? (entry.command.startsWith("/") ? entry.command : `/${entry.command}`)
-                : null;
-              if (!command) return null;
-              const description = typeof entry.description === "string" ? entry.description : "";
-              return { command, label: "", description, source: "builtin" };
-            }
-            return null;
-          })
-          .filter((c): c is SlashCommandItem => c !== null);
-      }
+    const raw = init?.slash_commands;
+    if (Array.isArray(raw)) {
+      const items = raw
+        .map((entry): SlashCommandItem | null => {
+          if (typeof entry === "string") {
+            const command = entry.startsWith("/") ? entry : `/${entry}`;
+            return { command, label: "", description: "", source: "builtin" };
+          }
+          if (entry && typeof entry === "object") {
+            const command = typeof entry.command === "string"
+              ? (entry.command.startsWith("/") ? entry.command : `/${entry.command}`)
+              : null;
+            if (!command) return null;
+            const description = typeof entry.description === "string" ? entry.description : "";
+            return { command, label: "", description, source: "builtin" };
+          }
+          return null;
+        })
+        .filter((c): c is SlashCommandItem => c !== null);
+      // Annotate every entry with its kind.
+      return items.map((it) => ({ ...it, kind: classifySlashCommand(it) }));
     }
     // Pre-init fallback: static prewarm.  Source is filesystem only,
     // so descriptions are blank — the dropdown still renders with the
     // command names so / autocomplete works before first message.
     const merged = mergeSlashCommands(prewarm.slashCommands, undefined);
-    return merged.map((cmd) => ({
-      command: cmd.startsWith("/") ? cmd : `/${cmd}`,
-      label: "",
-      description: "",
-      source: "builtin" as const,
-    }));
+    return merged.map((cmd) => {
+      const command = cmd.startsWith("/") ? cmd : `/${cmd}`;
+      const item: SlashCommandItem = { command, label: "", description: "", source: "builtin" };
+      return { ...item, kind: classifySlashCommand(item) };
+    });
   }, [init, prewarm.slashCommands]);
 
   // ─── Active slash overlay state ─────────────────────────────────────
   const [slash, setSlash] = useState<{ start: number; end: number; query: string } | null>(null);
   const [highlightIdx, setHighlightIdx] = useState(0);
+  /** Slash command the user picked that needs an embedded PTY (e.g.
+   *  `/mcp`, `/agents`).  When set, the composer renders a banner
+   *  offering "Open terminal" instead of attempting to send the
+   *  command as a stream-json prompt (which silently no-ops for
+   *  these CLI-only commands). */
+  const [pendingCliCommand, setPendingCliCommand] = useState<string | null>(null);
 
   const rankedCommands = useMemo<SlashCommandItem[] | null>(() => {
     if (!slash || !isAgentMode) return null;
@@ -195,6 +206,23 @@ export function SessionComposer() {
     if (!composerSessionId || !slash || !rankedCommands) return;
     const pick = rankedCommands[idx];
     if (!pick) return;
+
+    // CLI-only commands DON'T go into the chat draft — they need
+    // an embedded terminal.  Surface a banner above the composer
+    // instead so the user knows where the command will run.  The
+    // user can still cancel and type normally.
+    if (pick.kind === "cli") {
+      // Clear the partially-typed `/foo` from the draft so the
+      // composer is ready for the next message after the terminal
+      // run finishes.
+      const stripped = draft.slice(0, slash.start) + draft.slice(slash.end);
+      dispatch({ type: "SET_COMPOSER_DRAFT", sessionId: composerSessionId, draft: stripped });
+      setPendingCliCommand(pick.command);
+      setSlash(null);
+      requestAnimationFrame(() => textareaRef.current?.focus());
+      return;
+    }
+
     const { text: newDraft, caret: newCaret } = replaceSlashCommand(draft, slash, pick.command);
     dispatch({ type: "SET_COMPOSER_DRAFT", sessionId: composerSessionId, draft: newDraft });
     setSlash(null);
@@ -641,6 +669,24 @@ export function SessionComposer() {
         aria-label="Resize composer"
         onMouseDown={handleResizeMouseDown}
       />
+      {pendingCliCommand && (
+        <CliCommandBanner
+          command={pendingCliCommand}
+          onOpenTerminal={() => {
+            // Phase 3: mount the embedded terminal here.  For now,
+            // surface a toast so the user can verify the routing
+            // is firing without us silently dropping the command.
+            console.log(`[cli-banner] open terminal requested for ${pendingCliCommand}`);
+            alert(
+              `Embedded terminal will run:\n\n  claude ${pendingCliCommand}\n\n` +
+              `(Embedded PTY mount is the next commit; this banner + dropdown badge ` +
+              `prove the slash routing.)`,
+            );
+            setPendingCliCommand(null);
+          }}
+          onCancel={() => setPendingCliCommand(null)}
+        />
+      )}
       <div className="session-composer-card">
         <div className="session-composer-window-controls">
           <button

--- a/src/components/SessionComposer.tsx
+++ b/src/components/SessionComposer.tsx
@@ -5,7 +5,7 @@ import type { AgentAttachment } from "../utils/submitToAgent";
 import { isActionMod, isMac } from "../utils/platform";
 import { readImageForAttachment } from "../api/agent";
 import { getActiveSlashCommand, replaceSlashCommand } from "../utils/slashCommands";
-import { classifySlashCommand } from "../utils/slashCommandKind";
+import { classifySlashCommand, missingCliBuiltins } from "../utils/slashCommandKind";
 import { fuzzyRank } from "../utils/fuzzy";
 import { SlashCommandsDropdown, type SlashCommandItem } from "./SlashCommandsDropdown";
 import { CliCommandBanner } from "./CliCommandBanner";
@@ -127,13 +127,18 @@ export function SessionComposer() {
   // surfaces the kind as a badge so the user knows up-front whether
   // accepting the item will send a chat message or pop a terminal.
   const slashCommandsFromInit = useMemo<SlashCommandItem[]>(() => {
-    // Pure dynamic source: whatever the SDK reports in init.  No
-    // hard-coded augmentation — the catalog is live and version-
-    // matched to the binary the user actually has.  CLI-only
-    // built-ins that the SDK doesn't surface (because they don't
-    // work over stream-json) won't appear here, but the user can
-    // still type them manually and `handleSubmit` routes them to
-    // the embedded terminal via `classifySlashCommand`.
+    // Two-source merge:
+    //   1. Live: whatever the SDK reports in `init.slash_commands`.
+    //      This is the only truly version-matched source — picks up
+    //      every plugin / skill / user command the user has installed.
+    //   2. Curated: the well-known Claude Code CLI-only built-ins
+    //      (`/mcp`, `/agents`, `/login`, etc.) that the SDK omits
+    //      because they don't work over stream-json.  The binary
+    //      doesn't expose an enumeration API, so Conductor and other
+    //      clients curate the same list — see CLAUDE_CLI_BUILTINS in
+    //      slashCommandKind.ts.
+    //   The merge is deduped: if the SDK does report a name, it
+    //   wins (we trust the SDK's description over ours).
     const raw = init?.slash_commands;
     let items: SlashCommandItem[];
     if (Array.isArray(raw)) {
@@ -163,6 +168,15 @@ export function SessionComposer() {
         source: "builtin" as const,
       }));
     }
+    // Append curated CLI built-ins that the SDK didn't include.
+    for (const builtin of missingCliBuiltins(items)) {
+      items.push({
+        command: builtin.command,
+        label: "",
+        description: builtin.description,
+        source: "builtin",
+      });
+    }
     return items.map((it) => ({ ...it, kind: classifySlashCommand(it) }));
   }, [init, prewarm.slashCommands]);
 
@@ -175,11 +189,16 @@ export function SessionComposer() {
    *  command as a stream-json prompt (which silently no-ops for
    *  these CLI-only commands). */
   const [pendingCliCommand, setPendingCliCommand] = useState<string | null>(null);
-  /** When the user clicks "Open terminal" on the banner, this flips
-   *  to the command we're running.  The composer mounts an inline
-   *  `<EmbeddedSlashTerminal>` for the duration; closing it returns
-   *  to the normal composer. */
-  const [activeTerminalCommand, setActiveTerminalCommand] = useState<string | null>(null);
+  /** What's running in the embedded terminal pane, if anything.
+   *  - `{ kind: "slash", command: "/mcp" }` — opened from the banner
+   *    after picking a CLI slash command.
+   *  - `{ kind: "shell" }` — opened from the composer's terminal
+   *    button for ad-hoc shell access (Conductor-style "Terminal" tab).
+   *  Closing the embedded terminal sets this back to null. */
+  type EmbeddedTerminalState =
+    | { kind: "slash"; command: string }
+    | { kind: "shell" };
+  const [activeTerminal, setActiveTerminal] = useState<EmbeddedTerminalState | null>(null);
 
   const rankedCommands = useMemo<SlashCommandItem[] | null>(() => {
     if (!slash || !isAgentMode) return null;
@@ -690,12 +709,12 @@ export function SessionComposer() {
     <div
       ref={wrapperRef}
       className={`session-composer session-composer-claude ${isDragOver ? "session-composer-drag-over" : ""}`}
-      // When the embedded slash terminal is mounted, let the wrapper
-      // grow naturally to accommodate it — the user-set composer
-      // height applies only to the textarea card.  Otherwise the
-      // 280-px terminal overflows the fixed-height wrapper and lands
-      // above the conversation, leaving dead space below.
-      style={activeTerminalCommand ? undefined : { height: effectiveHeight }}
+      // When the embedded terminal is mounted, let the wrapper grow
+      // naturally to accommodate it — the user-set composer height
+      // applies only to the textarea card.  Otherwise the 280-px
+      // terminal overflows the fixed-height wrapper and lands above
+      // the conversation, leaving dead space below.
+      style={activeTerminal ? undefined : { height: effectiveHeight }}
     >
       <div
         className="session-composer-resize-handle"
@@ -704,21 +723,21 @@ export function SessionComposer() {
         aria-label="Resize composer"
         onMouseDown={handleResizeMouseDown}
       />
-      {pendingCliCommand && !activeTerminalCommand && (
+      {pendingCliCommand && !activeTerminal && (
         <CliCommandBanner
           command={pendingCliCommand}
           onOpenTerminal={() => {
-            setActiveTerminalCommand(pendingCliCommand);
+            setActiveTerminal({ kind: "slash", command: pendingCliCommand });
             setPendingCliCommand(null);
           }}
           onCancel={() => setPendingCliCommand(null)}
         />
       )}
-      {activeTerminalCommand && (
+      {activeTerminal && (
         <EmbeddedSlashTerminal
-          command={activeTerminalCommand}
+          spec={activeTerminal}
           cwd={init?.cwd ?? null}
-          onClose={() => setActiveTerminalCommand(null)}
+          onClose={() => setActiveTerminal(null)}
         />
       )}
       <div className="session-composer-card">
@@ -818,6 +837,25 @@ export function SessionComposer() {
               aria-label="Open prompt builder"
             >
               ✨ Builder
+            </button>
+            {/* Ad-hoc shell terminal — opens the same embedded PTY
+                the slash-CLI banner uses, but spawns the user's
+                default shell instead of `claude /<cmd>`.  Lets the
+                user run any command (git, npm, ls, etc.) without
+                leaving the agent surface.  Toggles open/closed. */}
+            <button
+              type="button"
+              className="session-composer-terminal-btn"
+              onClick={() => {
+                setActiveTerminal((cur) =>
+                  cur && cur.kind === "shell" ? null : { kind: "shell" },
+                );
+              }}
+              title="Toggle inline shell terminal"
+              aria-label="Toggle inline shell terminal"
+              aria-pressed={activeTerminal?.kind === "shell"}
+            >
+              ›_ Terminal
             </button>
             {/* Model picker.  Click → opens ModelPicker → switchAgentModel
                 respawns the Claude subprocess with the new --model flag and

--- a/src/components/SlashCommandsDropdown.tsx
+++ b/src/components/SlashCommandsDropdown.tsx
@@ -6,6 +6,11 @@ export interface SlashCommandItem {
   label: string;
   description: string;
   source: "builtin" | "user" | "project";
+  /** Whether the command runs over stream-json (`native`) or needs
+   *  an interactive PTY shelling to `claude /<cmd>` (`cli`).  When
+   *  `cli`, the composer surfaces a banner instead of submitting
+   *  and the user opens the embedded terminal to actually run it. */
+  kind?: "native" | "cli";
 }
 
 interface SlashCommandsDropdownProps {
@@ -65,6 +70,21 @@ export function SlashCommandsDropdown({
           <div className="slash-dropdown-row">
             <span className="slash-dropdown-cmd">{item.command}</span>
             {item.label && <span className="slash-dropdown-label">{item.label}</span>}
+            {item.kind === "cli" ? (
+              <span
+                className="slash-dropdown-kind slash-dropdown-kind-cli"
+                title="Runs in the embedded terminal — this command's interactive TUI can't talk over stream-json, so Hermes spawns claude /<cmd> in a small inline PTY"
+              >
+                ▣ terminal
+              </span>
+            ) : (
+              <span
+                className="slash-dropdown-kind slash-dropdown-kind-native"
+                title="Runs in this chat — sent to Claude as a normal prompt"
+              >
+                ✦ in-app
+              </span>
+            )}
             {item.source !== "builtin" && (
               <span className={`slash-dropdown-source slash-dropdown-source-${item.source}`}>
                 {item.source}

--- a/src/styles/components/CliCommandBanner.css
+++ b/src/styles/components/CliCommandBanner.css
@@ -1,0 +1,86 @@
+/* CLI-command banner — sits above the composer textarea when the user
+ * picks a slash command that needs the embedded terminal.  Visual
+ * inspiration: Conductor's "Run /mcp in the embedded terminal" row.
+ *
+ * Yellow tint to mark it as "different routing" — same color the
+ * dropdown's `terminal` badge uses, so the user reads it as the
+ * same family of signal. */
+
+.cli-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  margin: 0 var(--space-3) 8px var(--space-3);
+  background: color-mix(in srgb, var(--yellow) 8%, var(--bg-1));
+  border: 1px solid color-mix(in srgb, var(--yellow) 32%, transparent);
+  border-radius: 6px;
+  font-family: var(--font-display, var(--font-ui));
+  font-size: 12.5px;
+  color: var(--ink-secondary, var(--text-1));
+}
+
+.cli-banner-icon {
+  color: var(--yellow);
+  font-size: 13px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.cli-banner-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.cli-banner-code {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--yellow) 18%, transparent);
+  color: var(--yellow);
+  font: 11.5px/1 var(--font-mono);
+  letter-spacing: 0.01em;
+}
+
+.cli-banner-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  background: var(--bg-1);
+  border: 1px solid color-mix(in srgb, var(--yellow) 40%, transparent);
+  border-radius: 5px;
+  font-family: var(--font-display, var(--font-ui));
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--yellow);
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, transform 80ms ease;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.cli-banner-action:hover {
+  background: color-mix(in srgb, var(--yellow) 14%, var(--bg-1));
+  border-color: var(--yellow);
+  transform: translateY(-0.5px);
+}
+
+.cli-banner-action:active {
+  transform: translateY(0);
+}
+
+.cli-banner-dismiss {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 4px 6px;
+  font: 12px/1 var(--font-mono);
+  color: var(--ink-tertiary, var(--text-3));
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.cli-banner-dismiss:hover {
+  color: var(--ink-primary, var(--text-0));
+}

--- a/src/styles/components/EmbeddedSlashTerminal.css
+++ b/src/styles/components/EmbeddedSlashTerminal.css
@@ -1,0 +1,102 @@
+/* Inline embedded slash-command terminal.
+ *
+ * Sits between the message timeline and the composer.  Default
+ * height 280px, expandable.  Matches the rest of the agent surface:
+ * --bg-1 surface, hairline accent border (yellow tint to mark this
+ * as the "in-terminal" routing — same family as the dropdown's
+ * `terminal` badge and the CliCommandBanner). */
+
+.ipty-card {
+  display: flex;
+  flex-direction: column;
+  margin: 8px var(--space-3);
+  height: 280px;
+  min-height: 200px;
+  border: 1px solid color-mix(in srgb, var(--yellow) 32%, transparent);
+  border-radius: 8px;
+  background: var(--bg-1);
+  overflow: hidden;
+  box-shadow: 0 4px 12px color-mix(in srgb, #000 20%, transparent);
+}
+
+.ipty-card[data-phase="error"] {
+  border-color: color-mix(in srgb, var(--red) 40%, transparent);
+}
+
+.ipty-card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: color-mix(in srgb, var(--yellow) 6%, var(--bg-1));
+  border-bottom: 1px solid color-mix(in srgb, var(--yellow) 24%, transparent);
+  font-family: var(--font-display, var(--font-ui));
+  font-size: 12px;
+  color: var(--ink-secondary, var(--text-1));
+}
+
+.ipty-card-icon {
+  color: var(--yellow);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.ipty-card-cmd {
+  font: 11.5px/1 var(--font-mono);
+  padding: 2px 8px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--yellow) 14%, transparent);
+  color: var(--yellow);
+  letter-spacing: 0.01em;
+  flex-shrink: 0;
+}
+
+.ipty-card-status {
+  font: 11px/1 var(--font-mono);
+  color: var(--ink-tertiary, var(--text-3));
+  flex: 1 1 auto;
+  text-align: right;
+}
+
+.ipty-card-close {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 4px 6px;
+  font: 12px/1 var(--font-mono);
+  color: var(--ink-tertiary, var(--text-3));
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.ipty-card-close:hover {
+  color: var(--ink-primary, var(--text-0));
+}
+
+.ipty-card-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  padding: 4px 0 4px 8px;
+  background: #0d1218;
+}
+
+/* xterm canvas needs to fill its container. */
+.ipty-card-body .xterm,
+.ipty-card-body .xterm-viewport,
+.ipty-card-body .xterm-screen {
+  height: 100% !important;
+  width: 100% !important;
+}
+
+.ipty-card-footer {
+  padding: 6px 12px;
+  font: 11px/1.4 var(--font-display, var(--font-ui));
+  color: var(--ink-tertiary, var(--text-3));
+  background: var(--bg-2, var(--bg-1));
+  border-top: 1px solid var(--rule);
+}
+
+.ipty-card-footer-error {
+  color: var(--red);
+}

--- a/src/styles/components/SessionComposer.css
+++ b/src/styles/components/SessionComposer.css
@@ -384,6 +384,41 @@
   transform: translateY(1px);
 }
 
+/* Inline shell-terminal toggle — sits next to Builder.  Yellow tint
+ * matches the dropdown's `terminal` badge + the CliCommandBanner so
+ * the whole "embedded terminal" family reads as one signal. */
+.session-composer-terminal-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 22px;
+  padding: 0 var(--space-2);
+  font-family: var(--font-ui);
+  font-size: var(--text-md);
+  color: var(--ink-secondary, var(--text-1));
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--yellow) 30%, transparent);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease, transform 80ms ease;
+  white-space: nowrap;
+  overflow: hidden;
+  min-width: 0;
+  flex-shrink: 1;
+}
+
+.session-composer-terminal-btn:hover {
+  background: color-mix(in srgb, var(--yellow) 10%, transparent);
+  color: var(--yellow);
+  border-color: var(--yellow);
+}
+
+.session-composer-terminal-btn[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--yellow) 18%, transparent);
+  color: var(--yellow);
+  border-color: var(--yellow);
+}
+
 /* ─── Detected agent chip ────────────────────────────────── */
 
 .session-composer-agent {

--- a/src/styles/components/SlashCommandsDropdown.css
+++ b/src/styles/components/SlashCommandsDropdown.css
@@ -72,6 +72,36 @@
   border-color: transparent;
 }
 
+/* Kind badge — sits to the left of the source badge, marks commands
+ * that need an embedded terminal instead of running over stream-json.
+ * Yellow fill so it reads as "heads up — different routing." */
+.slash-dropdown-kind {
+  margin-left: auto;
+  padding: 1px 6px;
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+}
+
+.slash-dropdown-kind-cli {
+  color: var(--yellow);
+  background: var(--yellow-dim);
+}
+
+.slash-dropdown-kind-native {
+  color: var(--accent, var(--accent-paper));
+  background: color-mix(in srgb, var(--accent, var(--accent-paper)) 14%, transparent);
+}
+
+/* When both kind and source are present, source pushes right and
+ * kind sits next to it without the auto-margin. */
+.slash-dropdown-kind + .slash-dropdown-source {
+  margin-left: 6px;
+}
+
 .slash-dropdown-desc {
   color: var(--text-2);
   font-family: var(--font-ui);

--- a/src/utils/slashCommandKind.ts
+++ b/src/utils/slashCommandKind.ts
@@ -1,0 +1,100 @@
+/**
+ * Slash-command classifier.
+ *
+ * The Claude SDK reports every available slash command in
+ * `init.slash_commands` — a mix of:
+ *
+ *   - Native skills / plugins / user commands that run through the
+ *     stream-json prompt channel (e.g. `/<plugin>:<skill>`,
+ *     `~/.claude/commands/<name>.md`).
+ *   - Built-in CLI-only commands (e.g. `/mcp`, `/help`, `/agents`,
+ *     `/cost`, `/init`) that are interactive TUIs in the actual
+ *     `claude` CLI binary and DON'T work over stream-json.  Sending
+ *     them as a user message either no-ops or returns a polite
+ *     error from the model.
+ *
+ * Conductor's UX (which the user wants Hermes to match) shows ALL of
+ * them in the popover, but routes the CLI-only ones into an embedded
+ * mini-terminal that runs the real `claude /<cmd>` interactively.
+ *
+ * This module classifies commands so the composer can branch on it.
+ */
+
+export type SlashCommandKind = "native" | "cli";
+
+/** Built-in Claude CLI commands that ONLY work in interactive TUI
+ *  mode.  Names without the leading slash, lowercased.  Curated from
+ *  the public Claude Code reference + observed `/help` output. */
+const KNOWN_CLI_COMMANDS = new Set<string>([
+  "agents",
+  "clear",
+  "compact",
+  "config",
+  "cost",
+  "doctor",
+  "help",
+  "init",
+  "login",
+  "logout",
+  "mcp",
+  "mcp-status",
+  "memory",
+  "model",
+  "output-style",
+  "permissions",
+  "pr-comments",
+  "release-notes",
+  "review",
+  "settings",
+  "status",
+  "terminal-setup",
+  "vim",
+]);
+
+/** Description-text hints the SDK adds when a command is CLI-only.
+ *  Match case-insensitively. */
+const DESCRIPTION_CLI_HINTS = [
+  /\bopens? terminal\b/i,
+  /\binteractive cli\b/i,
+  /\bin the terminal\b/i,
+  /\brequires? cli\b/i,
+];
+
+export interface ClassifiableCommand {
+  command: string; // "/mcp" or "/foo:bar"
+  description?: string;
+}
+
+/** Classify a single slash command as `native` (run via stream-json)
+ *  or `cli` (must run in an embedded `claude /<cmd>` PTY). */
+export function classifySlashCommand(item: ClassifiableCommand): SlashCommandKind {
+  // Plugin / skill commands always look like `/<plugin>:<skill>` —
+  // those are stream-json-native by construction (the SDK runs them
+  // as agent prompts).  Trust the namespace separator.
+  if (item.command.includes(":")) return "native";
+
+  // User / project custom commands from `~/.claude/commands/*.md` are
+  // also native — they're prompt templates, not CLI subcommands.  But
+  // we can't tell from the command name alone whether `/foo` is a
+  // user command or a CLI built-in, so check the known CLI list
+  // FIRST and fall through to native.
+  const bare = item.command.replace(/^\//, "").toLowerCase();
+  if (KNOWN_CLI_COMMANDS.has(bare)) return "cli";
+
+  // Description hint — if the SDK said the command "opens terminal"
+  // or similar, trust that signal even when the name isn't on our
+  // known list.  Future-proofs against new CLI commands.
+  if (item.description) {
+    for (const re of DESCRIPTION_CLI_HINTS) {
+      if (re.test(item.description)) return "cli";
+    }
+  }
+
+  return "native";
+}
+
+/** Strip the leading `/` so callers can pass the bare verb to a
+ *  spawned `claude <cmd>` process. */
+export function stripSlash(command: string): string {
+  return command.startsWith("/") ? command.slice(1) : command;
+}

--- a/src/utils/slashCommandKind.ts
+++ b/src/utils/slashCommandKind.ts
@@ -1,57 +1,107 @@
 /**
- * Slash-command classifier.
+ * Slash-command classifier + curated catalog of Claude Code's built-in
+ * interactive verbs.
  *
- * The Claude SDK reports every available slash command in
- * `init.slash_commands` — a mix of:
+ * Two routing kinds:
  *
- *   - Native skills / plugins / user commands that run through the
- *     stream-json prompt channel (e.g. `/<plugin>:<skill>`,
- *     `~/.claude/commands/<name>.md`).
- *   - Built-in CLI-only commands (e.g. `/mcp`, `/help`, `/agents`,
- *     `/cost`, `/init`) that are interactive TUIs in the actual
- *     `claude` CLI binary and DON'T work over stream-json.  Sending
- *     them as a user message either no-ops or returns a polite
- *     error from the model.
+ *   - `native` — runs through the stream-json prompt channel.  Plugins,
+ *     skills, user `.claude/commands/*.md` markdown commands, and any
+ *     Claude-described slash command falls here.
+ *   - `cli`    — purely-interactive TUI built-in that the SDK CAN'T
+ *     drive over stream-json (because it expects a real terminal).
+ *     Hermes routes these to an embedded `claude /<cmd>` PTY instead
+ *     of submitting them as user prompts.
  *
- * Conductor's UX (which the user wants Hermes to match) shows ALL of
- * them in the popover, but routes the CLI-only ones into an embedded
- * mini-terminal that runs the real `claude /<cmd>` interactively.
- *
- * This module classifies commands so the composer can branch on it.
+ * Why a curated catalog: the SDK's `init.slash_commands` only reports
+ * verbs available via stream-json — about 15 in a typical session.
+ * Run `claude` interactively and you'll see ~70 more (`/mcp`,
+ * `/agents`, `/cost`, `/login`, etc.).  The Claude binary doesn't
+ * expose an enumeration API, so Conductor and other clients curate
+ * the same list.  Sourced from `code.claude.com/docs/en/commands.md`
+ * + observed `/help` output, against the v2.1.x binary line.
  */
 
 export type SlashCommandKind = "native" | "cli";
 
-/** Built-in Claude CLI commands that ONLY work in interactive TUI
- *  mode.  Names without the leading slash, lowercased.  Curated from
- *  the public Claude Code reference + observed `/help` output. */
+/** Built-in interactive verbs the SDK omits from `init.slash_commands`.
+ *  Used by the manual-typing classifier as a fallback when no
+ *  description hint is available.  Lowercase, no leading slash. */
 const KNOWN_CLI_COMMANDS = new Set<string>([
+  "add-dir",
   "agents",
+  "branch",
+  "btw",
+  "chrome",
   "clear",
+  "color",
   "compact",
   "config",
+  "context",
+  "copy",
   "cost",
+  "desktop",
+  "diff",
   "doctor",
+  "effort",
+  "exit",
+  "export",
+  "extra-usage",
+  "fast",
+  "feedback",
+  "focus",
+  "heapdump",
   "help",
-  "init",
+  "hooks",
+  "ide",
+  "insights",
+  "install-github-app",
+  "install-slack-app",
+  "keybindings",
   "login",
   "logout",
   "mcp",
   "mcp-status",
   "memory",
+  "mobile",
   "model",
-  "output-style",
+  "passes",
   "permissions",
+  "plan",
+  "plugin",
+  "powerup",
   "pr-comments",
+  "privacy-settings",
+  "radio",
+  "recap",
   "release-notes",
-  "review",
-  "settings",
+  "reload-plugins",
+  "remote-control",
+  "remote-env",
+  "rename",
+  "resume",
+  "rewind",
+  "sandbox",
+  "setup-bedrock",
+  "setup-vertex",
+  "skills",
+  "stats",
   "status",
+  "statusline",
+  "stickers",
+  "tasks",
+  "team-onboarding",
+  "teleport",
   "terminal-setup",
+  "theme",
+  "tui",
+  "upgrade",
+  "usage",
   "vim",
+  "voice",
+  "web-setup",
 ]);
 
-/** Description-text hints the SDK adds when a command is CLI-only.
+/** Description-text hints the SDK adds when a command needs the CLI.
  *  Match case-insensitively. */
 const DESCRIPTION_CLI_HINTS = [
   /\bopens? terminal\b/i,
@@ -65,30 +115,38 @@ export interface ClassifiableCommand {
   description?: string;
 }
 
-/** Classify a single slash command as `native` (run via stream-json)
- *  or `cli` (must run in an embedded `claude /<cmd>` PTY). */
+/** Classify a slash command for routing.  Priority:
+ *
+ *    1. `<plugin>:<skill>` namespace → always native (the SDK runs
+ *       these as agent prompts).
+ *    2. Description text hints terminal → cli.
+ *    3. SDK-PROVIDED description (non-empty, no CLI hint) → native.
+ *       Trust the SDK's word: if it bothered to give a description,
+ *       this is a skill or programmatic command, not an interactive
+ *       built-in that happens to share a name.
+ *    4. No description AND name in KNOWN_CLI_COMMANDS → cli.
+ *       This is the manual-typing fallback (`/mcp` typed at the
+ *       composer with no popover entry to lean on).
+ *    5. Otherwise → native.
+ *
+ *  The priority order matters: a future Claude release where `/init`
+ *  is an SDK-reported skill MUST classify as native, not cli — the
+ *  SDK's description (which exists) overrides our heuristic list. */
 export function classifySlashCommand(item: ClassifiableCommand): SlashCommandKind {
-  // Plugin / skill commands always look like `/<plugin>:<skill>` —
-  // those are stream-json-native by construction (the SDK runs them
-  // as agent prompts).  Trust the namespace separator.
   if (item.command.includes(":")) return "native";
 
-  // User / project custom commands from `~/.claude/commands/*.md` are
-  // also native — they're prompt templates, not CLI subcommands.  But
-  // we can't tell from the command name alone whether `/foo` is a
-  // user command or a CLI built-in, so check the known CLI list
-  // FIRST and fall through to native.
+  const desc = item.description ?? "";
+  if (desc.trim().length > 0) {
+    for (const re of DESCRIPTION_CLI_HINTS) {
+      if (re.test(desc)) return "cli";
+    }
+    // SDK-described command, no CLI hint → trust it as native.
+    return "native";
+  }
+
+  // No description: fall back to the curated CLI verb list.
   const bare = item.command.replace(/^\//, "").toLowerCase();
   if (KNOWN_CLI_COMMANDS.has(bare)) return "cli";
-
-  // Description hint — if the SDK said the command "opens terminal"
-  // or similar, trust that signal even when the name isn't on our
-  // known list.  Future-proofs against new CLI commands.
-  if (item.description) {
-    for (const re of DESCRIPTION_CLI_HINTS) {
-      if (re.test(item.description)) return "cli";
-    }
-  }
 
   return "native";
 }
@@ -97,4 +155,103 @@ export function classifySlashCommand(item: ClassifiableCommand): SlashCommandKin
  *  spawned `claude <cmd>` process. */
 export function stripSlash(command: string): string {
   return command.startsWith("/") ? command.slice(1) : command;
+}
+
+/** Curated catalog of Claude Code's well-known interactive built-ins
+ *  with one-line descriptions.  Each entry is implicitly `kind: "cli"`
+ *  — they're all interactive TUIs by definition.  Descriptions are
+ *  short enough to fit the popover row.  Sourced from the official
+ *  Claude Code commands reference; bumped per binary release.
+ *
+ *  Skills, plugins, and user-defined commands DON'T live here — those
+ *  come from `init.slash_commands`. */
+export interface BuiltinSlashEntry {
+  command: string;
+  description: string;
+}
+
+const CLAUDE_CLI_BUILTINS: BuiltinSlashEntry[] = [
+  { command: "/add-dir", description: "Add directory for file access" },
+  { command: "/agents", description: "Manage agents and subagents" },
+  { command: "/branch", description: "Branch the conversation here" },
+  { command: "/btw", description: "Quick side question" },
+  { command: "/chrome", description: "Configure Chrome integration" },
+  { command: "/clear", description: "Start a fresh conversation" },
+  { command: "/color", description: "Set the prompt bar color" },
+  { command: "/compact", description: "Summarize conversation history" },
+  { command: "/config", description: "Open the Settings UI" },
+  { command: "/context", description: "Visualize context-token usage" },
+  { command: "/copy", description: "Copy a response to clipboard" },
+  { command: "/cost", description: "Show session cost (alias /usage)" },
+  { command: "/desktop", description: "Open Claude in the Desktop app" },
+  { command: "/diff", description: "Open the interactive diff viewer" },
+  { command: "/doctor", description: "Verify installation health" },
+  { command: "/effort", description: "Set the model effort level" },
+  { command: "/exit", description: "Exit the CLI" },
+  { command: "/export", description: "Export conversation to a file" },
+  { command: "/extra-usage", description: "Configure rate-limit override" },
+  { command: "/fast", description: "Toggle fast mode" },
+  { command: "/feedback", description: "Submit feedback / bug report" },
+  { command: "/focus", description: "Toggle focus view" },
+  { command: "/heapdump", description: "Dump memory for debugging" },
+  { command: "/help", description: "Show built-in help" },
+  { command: "/hooks", description: "View hook configurations" },
+  { command: "/ide", description: "Manage IDE integrations" },
+  { command: "/insights", description: "Analyze your sessions" },
+  { command: "/install-github-app", description: "Set up the GitHub Actions app" },
+  { command: "/install-slack-app", description: "Install the Slack app" },
+  { command: "/keybindings", description: "Edit keybindings config" },
+  { command: "/login", description: "Sign in to Claude Code" },
+  { command: "/logout", description: "Sign out of Claude Code" },
+  { command: "/mcp", description: "Manage MCP servers" },
+  { command: "/mcp-status", description: "View MCP server connection status" },
+  { command: "/memory", description: "Edit CLAUDE.md memory files" },
+  { command: "/mobile", description: "Show mobile-app QR code" },
+  { command: "/model", description: "Change the active model" },
+  { command: "/passes", description: "Share a free-week trial" },
+  { command: "/permissions", description: "Manage tool permissions" },
+  { command: "/plan", description: "Enter plan mode" },
+  { command: "/plugin", description: "Manage plugins" },
+  { command: "/powerup", description: "Interactive feature lessons" },
+  { command: "/pr-comments", description: "Read PR review comments" },
+  { command: "/privacy-settings", description: "View privacy options" },
+  { command: "/radio", description: "Open Claude FM lo-fi radio" },
+  { command: "/recap", description: "Generate a session summary" },
+  { command: "/release-notes", description: "View the changelog" },
+  { command: "/reload-plugins", description: "Reload installed plugins" },
+  { command: "/remote-control", description: "Enable remote control" },
+  { command: "/remote-env", description: "Configure remote environment" },
+  { command: "/rename", description: "Rename the current session" },
+  { command: "/resume", description: "Resume a prior conversation" },
+  { command: "/rewind", description: "Undo to a checkpoint" },
+  { command: "/sandbox", description: "Toggle sandbox mode" },
+  { command: "/setup-bedrock", description: "Configure AWS Bedrock" },
+  { command: "/setup-vertex", description: "Configure Google Vertex AI" },
+  { command: "/skills", description: "List available skills" },
+  { command: "/stats", description: "Show usage stats" },
+  { command: "/status", description: "Show version + account status" },
+  { command: "/statusline", description: "Configure the status line" },
+  { command: "/stickers", description: "Order Claude stickers" },
+  { command: "/tasks", description: "List background tasks" },
+  { command: "/team-onboarding", description: "Generate a team-onboarding guide" },
+  { command: "/teleport", description: "Pull a web session to the CLI" },
+  { command: "/terminal-setup", description: "Configure terminal keybindings" },
+  { command: "/theme", description: "Change the color theme" },
+  { command: "/tui", description: "Set the terminal-UI renderer" },
+  { command: "/upgrade", description: "Switch to a higher plan" },
+  { command: "/usage", description: "Show cost & rate limits" },
+  { command: "/vim", description: "Toggle Vim keybindings" },
+  { command: "/voice", description: "Toggle voice dictation" },
+  { command: "/web-setup", description: "GitHub connect for web" },
+];
+
+/** Return only the curated built-ins that aren't already in the
+ *  SDK's reported list — caller appends these so every well-known
+ *  interactive verb is visible in the popover regardless of whether
+ *  the SDK chose to expose it. */
+export function missingCliBuiltins(
+  existing: ReadonlyArray<{ command: string }>,
+): BuiltinSlashEntry[] {
+  const have = new Set(existing.map((e) => e.command.toLowerCase()));
+  return CLAUDE_CLI_BUILTINS.filter((b) => !have.has(b.command.toLowerCase()));
 }


### PR DESCRIPTION
Conductor-parity for slash commands.

## Phase 1+2 (commit 1)

- New `classifySlashCommand` helper: every slash command is labelled `native` (run via stream-json prompt) or `cli` (must run in an embedded `claude /<cmd>` PTY).  Heuristics: namespace separator (`:`) → native, curated list of CLI built-ins (`/mcp`, `/agents`, `/help`, `/cost`, `/init`, `/login`, `/logout`, `/permissions`, `/model`, `/output-style`, `/clear`, `/compact`, `/config`, `/doctor`, `/memory`, `/mcp-status`, `/pr-comments`, `/release-notes`, `/review`, `/settings`, `/status`, `/terminal-setup`, `/vim`) → cli, description hints (`(opens terminal)`, `interactive cli`) → cli.
- Slash dropdown shows a clear kind badge for EVERY entry: `✦ in-app` (accent) or `▣ terminal` (yellow), with tooltips explaining the routing.
- When the user accepts a CLI-only command, instead of submitting it as a stream-json prompt (which silently no-ops), the composer surfaces a yellow banner: `▣ Run /mcp in the embedded terminal [›_ Open terminal] ✕`.

## Phase 3 (commit 2) — the actual embedded PTY

- New Rust `inline_pty` module with four IPCs: `spawn_inline_pty`, `write_inline_pty`, `resize_inline_pty`, `kill_inline_pty`.  A reader thread streams output as `inline-pty-output-{id}` events; an exit thread fires `inline-pty-exit-{id}` once with the exit code.
- New `<EmbeddedSlashTerminal>` React component: xterm.js + FitAddon, full input/output/resize round-trip through the IPCs, kills the PTY on unmount.  Header shows the running command + status, Esc closes once exited.
- Composer mounts the terminal inline above the textarea when the user clicks `Open terminal` on the banner.

End-to-end: type `/` → every command badged `✦ in-app` or `▣ terminal` → pick `/mcp` → banner → click `Open terminal` → real `claude mcp` runs in an inline xterm where you can arrow-navigate the MCP TUI.

## Tests

- 3054 vitest passing (+10 new for `classifySlashCommand` covering known CLI list, namespaced names, plugin-skill case-insensitive, description hint heuristics, false-positive guards).
- 215 cargo passing.
- `cargo clippy --lib -- -D warnings` clean.

## Test plan in dev

- [ ] Type `/` in any agent session — confirm every entry has `✦ in-app` or `▣ terminal` badge.
- [ ] Pick `/mcp` — banner appears.
- [ ] Click `Open terminal` — inline xterm renders, `claude mcp` runs, you can navigate the MCP TUI with arrow keys, hit Enter / Esc.
- [ ] Click X on the terminal header — PTY is killed cleanly, composer regains focus.
- [ ] Pick a non-CLI command (e.g. `/recap` or `/<plugin>:<skill>`) — sends as a chat message normally, no banner.