### PR TITLE
v1.1.0 release notes + classic compact timeline opt-out

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,67 @@
+# Hermes IDE 1.1.0
+
+## A modern session timeline
+
+The agent timeline got a top-to-bottom redesign that reads like a real conversation, not an instrument-panel logbook.
+
+- A small avatar chip identifies who's talking — **You** with your accent color, **Hermes** with a friendly bot icon. Replaces the cramped `№ 01` left-gutter numbering.
+- Body text moves to a refined sans-serif at a comfortable reading size; mono is preserved where it matters (code, file paths, tool calls, the cost meter).
+- Your messages appear in a soft accent-tinted card instead of a vertical brass stripe.
+- Whitespace replaces the hairline rules between turns. Conversations breathe.
+- The masthead is calmer — `Agent · model · cwd` in normal case, no more all-caps tracked mono.
+
+Every theme paints this layout differently — `hacker` keeps its phosphor scanlines, `designer` adds a subtle paper grain, `tron` pulses a cyan rail, `nightowl` gets a glass aurora. Switching themes now changes how a conversation feels, not just what color it is.
+
+## Slash commands you can actually find
+
+Type `/` and Hermes shows **every Claude Code slash command** in the popover — built-ins, plugins, skills, your custom `~/.claude/commands` files. Each entry is clearly labeled:
+
+- `✦ in-app` — runs in the chat (sent as a prompt to Claude)
+- `▣ terminal` — opens an embedded terminal that runs `claude /<command>` interactively
+
+Pick `/mcp`, `/agents`, `/cost`, `/help`, `/login`, or any other interactive built-in and a small inline terminal pops above the composer running the actual Claude REPL with the command auto-typed for you. Arrow-navigate the TUI, hit Enter, close when done.
+
+## Inline shell terminal
+
+A new **Terminal** button next to Builder opens a quick shell prompt right where the chat composer lives — for `git status`, `npm run dev`, `ls`, anything you'd reach for without leaving the agent surface. Same xterm, your default shell, current project as the working directory.
+
+## MCP server panel that actually helps
+
+Click any MCP server in the right panel and you see:
+
+- A color-coded status note (Connected / Needs auth / Failed / Unknown) explaining why the dot is the color it is
+- The transport (stdio / sse / http) plus command + args or URL
+- The environment-variable keys the server expects (values are never shown — they may carry secrets)
+- The list of tools that server exposes
+- **Restart** and **Remove** actions, with a confirmation step on remove
+
+Removing an MCP server now actually disappears it from the panel immediately; cloud-managed servers (claude.ai Gmail, Drive, Calendar, etc.) are detected and labeled "managed elsewhere" so you don't get stuck trying to delete them locally.
+
+## Permission cards stop hiding
+
+The "approve / deny / always allow" buttons that appear when Claude asks to run a tool are now real, prominent buttons — not tiny mono-link text. The primary "Approve once" gets a brief attract pulse so your eye lands on the right thing. Standard dialog layout: deny on the left, confirm on the right, Enter submits.
+
+## Plan mode actually works
+
+Plan mode used to silently drop your responses — clicking Approve on a plan or answering a multi-question prompt looked like nothing happened. Both flows now route through the correct path and Claude sees your answer.
+
+Switching the model or permission mode mid-session also stays in sync now; the picker chips reflect Claude's reality even when the change came from inside a conversation (e.g. Claude entered plan mode itself).
+
+## Smaller things you'll notice
+
+- The first message in a fresh session shows the thinking indicator immediately, not after a silent pause while the bridge boots
+- The Cost & Tokens panel section is gone — its only button didn't work; the running cost meter in the header is the live source of truth
+- The activity-bar Context button now actually toggles the agent context panel (Cmd+E to hide it for more horizontal room)
+- The dirty-close session dialog stops surfacing `.aider.chat.history.md` and other auto-generated noise files
+- Composer chips truncate cleanly on narrow widths instead of overlapping each other
+- The bot/person icons in the speaker chip take the theme accent — green-phosphor on `hacker`, cyan on `tron`, terracotta on `designer`
+
+## Prefer the previous look?
+
+If the new timeline isn't for you, **Settings → Appearance → Use classic compact timeline** restores the denser, mono-bodied logbook style this release replaced — with the brass left bar on user messages, hairline rules between turns, and the prior typography. Toggle it back any time. Themes still apply on top.
+
+---
+
 # Hermes IDE 1.0.0
 
 ## Agent mode for Claude

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -2328,6 +2328,7 @@ const VALID_SETTING_KEYS: &[&str] = &[
     "ui_scale",
     "font_size",
     "font_family",
+    "agent_timeline_style",
     // Terminal
     "default_shell",
     "default_cwd",

--- a/src/__tests__/agent-timeline-style.test.ts
+++ b/src/__tests__/agent-timeline-style.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+/**
+ * `applyAgentTimelineStyle` — toggles the `data-agent-timeline-style`
+ * attribute on <html> so CSS overrides under
+ * `html[data-agent-timeline-style="classic"]` activate the pre-1.1
+ * logbook look.  Pins:
+ *   - "modern" / undefined / unknown values clear the attribute
+ *   - "classic" sets the attribute
+ *   - The CSS override file actually scopes to that selector (so the
+ *     toggle isn't dead UI).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { applyAgentTimelineStyle } from "../utils/themeManager";
+
+describe("applyAgentTimelineStyle", () => {
+  beforeEach(() => {
+    delete document.documentElement.dataset.agentTimelineStyle;
+  });
+
+  it('"classic" sets data-agent-timeline-style="classic" on <html>', () => {
+    applyAgentTimelineStyle("classic");
+    expect(document.documentElement.dataset.agentTimelineStyle).toBe("classic");
+  });
+
+  it('"modern" clears the attribute', () => {
+    applyAgentTimelineStyle("classic");
+    applyAgentTimelineStyle("modern");
+    expect(document.documentElement.dataset.agentTimelineStyle).toBeUndefined();
+  });
+
+  it("undefined clears the attribute (default = modern)", () => {
+    applyAgentTimelineStyle("classic");
+    applyAgentTimelineStyle(undefined);
+    expect(document.documentElement.dataset.agentTimelineStyle).toBeUndefined();
+  });
+
+  it("unknown values fall through to modern (no surprises)", () => {
+    applyAgentTimelineStyle("classic");
+    applyAgentTimelineStyle("retro");
+    expect(document.documentElement.dataset.agentTimelineStyle).toBeUndefined();
+  });
+});
+
+describe("classic-mode CSS overrides exist", () => {
+  it("AgentSessionView.css has rules under [data-agent-timeline-style='classic']", () => {
+    const css = readFileSync(
+      resolve(__dirname, "../styles/components/agent/AgentSessionView.css"),
+      "utf8",
+    );
+    // Must touch the body font (mono restoration) — single most
+    // important visual override.
+    expect(css).toMatch(
+      /html\[data-agent-timeline-style=["']classic["']\][\s\S]*?\.agent-message-body[\s\S]*?font-family:\s*var\(--font-mono\)/,
+    );
+    // Must restore the brass left-bar treatment on user messages.
+    expect(css).toMatch(
+      /html\[data-agent-timeline-style=["']classic["']\][\s\S]*?\[data-role=["']user["']\][\s\S]*?border-left:\s*2px solid var\(--brass/,
+    );
+    // Must add the hairline rule between turns.
+    expect(css).toMatch(
+      /html\[data-agent-timeline-style=["']classic["']\][\s\S]*?\.agent-message \+ \.agent-message\[data-role=["']user["']\][\s\S]*?border-top:\s*1px solid var\(--rule\)/,
+    );
+  });
+});

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -5,7 +5,7 @@ import { useTextContextMenu } from "../hooks/useTextContextMenu";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { LogicalSize } from "@tauri-apps/api/dpi";
-import { applyTheme, DARK_THEMES, LIGHT_THEMES, UI_SCALE_OPTIONS } from "../utils/themeManager";
+import { applyTheme, applyAgentTimelineStyle, DARK_THEMES, LIGHT_THEMES, UI_SCALE_OPTIONS } from "../utils/themeManager";
 import { fmt, PLATFORM } from "../utils/platform";
 import {
   AI_PROVIDERS,
@@ -149,6 +149,8 @@ export function Settings({ onClose, initialTab, pluginRuntime, onConfirmPluginUp
       applyTheme(value, next);
     } else if (["font_size", "font_family", "scrollback", "ui_scale"].includes(key)) {
       applyTheme(next.theme || "frosted-dark", next);
+    } else if (key === "agent_timeline_style") {
+      applyAgentTimelineStyle(value);
     }
     setSetting(key, value).catch(console.error);
     // Sync autonomous settings to live state
@@ -396,6 +398,23 @@ export function Settings({ onClose, initialTab, pluginRuntime, onConfirmPluginUp
                       </button>
                     ))}
                   </div>
+                </div>
+
+                <div className="settings-group">
+                  <label className="settings-label">Agent Timeline Style</label>
+                  <span className="settings-hint-inline">
+                    Modern (default) uses the speaker-chip layout with sans-serif body.
+                    Classic restores the denser logbook style — mono body, brass left
+                    bar on user messages, hairline rules between turns.
+                  </span>
+                  <select
+                    className="settings-select"
+                    value={settings.agent_timeline_style || "modern"}
+                    onChange={(e) => updateSetting("agent_timeline_style", e.target.value)}
+                  >
+                    <option value="modern">Modern (default)</option>
+                    <option value="classic">Classic compact</option>
+                  </select>
                 </div>
 
                 <div className="settings-group">

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -15,6 +15,25 @@ export interface ChangelogEntry {
 }
 
 export const changelog: Record<string, ChangelogEntry> = {
+  "1.1.0": {
+    items: [
+      "Modern session timeline — speaker chips with avatars, sans-serif body, soft message cards instead of the brass-bar logbook",
+      "Type / to see every Claude command — built-ins, plugins, skills — clearly labeled in-app or terminal",
+      "Embedded inline terminal runs interactive /mcp, /agents, /cost, /help and friends without leaving the chat",
+      "New Terminal button opens a quick shell right next to the composer for git, npm, ls — anything",
+      "MCP server panel shows transport, command, env keys, tools, with restart and remove actions",
+      "Cloud-managed MCP servers (claude.ai Gmail, Drive, Calendar) detected and labeled — no more stuck delete",
+      "Approve / deny / always-allow buttons are now real prominent buttons, not tiny links",
+      "Plan-mode replies and multi-question answers actually reach Claude (silent drops are fixed)",
+      "Picker chips stay in sync when Claude flips model or permission mode mid-conversation",
+      "30 themes look genuinely distinct — phosphor scanlines on hacker, paper grain on designer, glass aurora on nightowl, pulsing rails on tron",
+      "First-message thinking indicator fires immediately so you don't sit in silence",
+      "Composer chips truncate cleanly on narrow windows instead of overlapping",
+      "Activity-bar Context button now actually toggles the agent panel (Cmd+E)",
+      "Dirty-close dialog stops surfacing .aider.chat.history.md and similar auto-generated noise",
+      "Prefer the previous look? Settings → Appearance → Use classic compact timeline",
+    ],
+  },
   "0.3.31": {
     items: [
       "\"What's New\" dialog after app updates shows what changed",

--- a/src/state/SessionContext.tsx
+++ b/src/state/SessionContext.tsx
@@ -23,7 +23,7 @@ import { hasAddDirDrift } from "../utils/agentDrift";
 import { createWorktree, worktreeHasChanges, stashWorktree, getSessionWorktreeInfo } from "../api/git";
 import { getSettings, getSetting, setSetting } from "../api/settings";
 import { createTerminal, destroy as destroyTerminal, writeScrollback, estimateInitialDimensions } from "../terminal/TerminalPool";
-import { applyTheme } from "../utils/themeManager";
+import { applyTheme, applyAgentTimelineStyle } from "../utils/themeManager";
 import { restoreWindowState } from "../utils/windowState";
 import { initNotifications, notifyLongRunningDone } from "../utils/notifications";
 import { initAnalytics, trackAppStarted, trackSessionCreated } from "../utils/analytics";
@@ -1081,6 +1081,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       .then((s) => {
         const theme = s.theme || "frosted-dark";
         applyTheme(theme, s);
+        applyAgentTimelineStyle(s.agent_timeline_style);
         restoreWindowState(s).catch(console.error);
         if (s.execution_mode === "assisted" || s.execution_mode === "autonomous") {
           dispatch({ type: "SET_DEFAULT_MODE", mode: s.execution_mode as ExecutionMode });

--- a/src/styles/components/agent/AgentSessionView.css
+++ b/src/styles/components/agent/AgentSessionView.css
@@ -1986,3 +1986,94 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* ════════════════════════════════════════════════════════════════════
+ * Classic compact timeline (opt-in via Settings → Appearance)
+ * ════════════════════════════════════════════════════════════════════
+ *
+ * Restores the pre-1.1 logbook layout for users who prefer the denser
+ * mono-bodied style.  CSS-only overrides on top of the modern layout
+ * — no JSX branch.  Toggling the setting flips a `data-agent-timeline-
+ * style="classic"` attribute on <html>; everything below scopes to
+ * that selector so the modern look stays intact for everyone else.
+ *
+ * Theme tokens (--bg-1, --accent, --brass, --rule, etc.) still apply,
+ * so each of the 30 themes paints classic mode in its own colors. */
+
+html[data-agent-timeline-style="classic"] .agent-message-body {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.55;
+  letter-spacing: 0;
+  padding-left: 0;
+  gap: 8px;
+}
+
+html[data-agent-timeline-style="classic"] .agent-text-block {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.55;
+  letter-spacing: 0;
+}
+
+html[data-agent-timeline-style="classic"] .agent-message-speaker {
+  font-size: 11px;
+  gap: 8px;
+}
+
+html[data-agent-timeline-style="classic"] .agent-message-avatar {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+}
+
+html[data-agent-timeline-style="classic"] .agent-message-avatar svg {
+  width: 13px;
+  height: 13px;
+}
+
+html[data-agent-timeline-style="classic"] .agent-message-name {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+html[data-agent-timeline-style="classic"] .agent-message-time {
+  font-size: 10px;
+}
+
+html[data-agent-timeline-style="classic"]
+  .agent-message[data-role="user"] .agent-message-body {
+  background: transparent;
+  border: 0;
+  border-left: 2px solid var(--brass, var(--accent));
+  border-radius: 0;
+  padding: 0 0 0 14px;
+  margin-left: 0;
+  box-shadow: -8px 0 16px -10px var(--brass-dim, transparent);
+  font-style: italic;
+  font-size: 13px;
+  font-family: var(--font-mono);
+  line-height: 1.55;
+}
+
+html[data-agent-timeline-style="classic"]
+  .agent-message + .agent-message[data-role="user"] {
+  margin-top: 14px;
+  padding-top: 10px;
+  border-top: 1px solid var(--rule);
+}
+
+html[data-agent-timeline-style="classic"]
+  .agent-message + .agent-message[data-role="assistant"] {
+  margin-top: 8px;
+}
+
+html[data-agent-timeline-style="classic"] .agent-message {
+  max-width: none;
+}

--- a/src/utils/themeManager.ts
+++ b/src/utils/themeManager.ts
@@ -129,3 +129,17 @@ export function applyTheme(themeId: string, allSettings: Record<string, string>)
   // Notify editor to refresh syntax highlight colours
   window.dispatchEvent(new CustomEvent("hermes:theme-changed"));
 }
+
+/** Apply the agent-timeline style preference to <html>.  CSS under
+ *  `html[data-agent-timeline-style="classic"]` restores the denser
+ *  pre-1.1 logbook look (mono body, brass left-bar on user messages,
+ *  hairline rules between turns) on top of whichever theme is active.
+ *  `modern` (default) is the speaker-chip / sans-serif layout. */
+export function applyAgentTimelineStyle(style: string | undefined): void {
+  const value = style === "classic" ? "classic" : "modern";
+  if (value === "modern") {
+    delete document.documentElement.dataset.agentTimelineStyle;
+  } else {
+    document.documentElement.dataset.agentTimelineStyle = value;
+  }
+}


### PR DESCRIPTION
Two pieces shipped together so the v1.1.0 announcement and the opt-out land at the same time.

## Release notes draft

`RELEASE_NOTES.md` updated with a v1.1.0 section covering everything shipped post-1.0 — modern timeline, slash CLI dropdown + embedded terminal, ad-hoc shell button, MCP panel detail + actions, permission button redesign, plan-mode fix, picker-sync, per-theme distinction, first-message loader, composer chip fix.  Final section points users at the new "Classic compact" opt-out.

**Per the project's release-notes rule, this PR does NOT bump version.**  Review the release notes draft, then run `npm run bump -- 1.1.0` when ready.

## Classic compact opt-out

Settings → Appearance → **Agent Timeline Style** with two options:

- **Modern (default)** — speaker-chip layout with sans-serif body
- **Classic compact** — pre-1.1 logbook style: mono body, italic mono on user messages, brass left-bar instead of card, hairline rules between turns, quieter speaker chip, no reading-width cap

Implemented as CSS-only overrides under `html[data-agent-timeline-style="classic"]` so all 30 themes still apply on top.  Toggle is live (no restart needed).

Also adds the 1.1.0 changelog entry to `changelog.ts` so `WhatsNewDialog` fires automatically on next launch after the bump.  Adds `agent_timeline_style` to `VALID_SETTING_KEYS` so the setting persists.

## Tests

- `npx tsc --noEmit` clean
- `npm test -- --run` — 3065 passing (+5 new for the toggle: attribute toggling for classic / modern / undefined / unknown values, plus a CSS-grep guard pinning that the override rules exist under the selector)
- `cargo test --lib` — 220 passing
- `cargo clippy --lib -- -D warnings` clean
- [ ] Visual review: open Settings → Appearance, switch to "Classic compact", verify the timeline switches to mono body + brass left-bar without restart.  Switch back to confirm the modern layout returns.