### PR TITLE
WhatsNewDialog: visual showcase redesign + grouped sections

### DIFF
--- a/src/components/WhatsNewDialog.tsx
+++ b/src/components/WhatsNewDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import "../styles/components/WhatsNewDialog.css";
-import { changelog } from "../data/changelog";
+import { changelog, type ChangelogEntry, type ChangelogSection } from "../data/changelog";
 import { getSetting, setSetting } from "../api/settings";
 
 const SETTING_LAST_SEEN = "last_seen_version";
@@ -14,16 +14,8 @@ interface WhatsNewDialogProps {
 export function WhatsNewDialog({ version }: WhatsNewDialogProps) {
   const [visible, setVisible] = useState(false);
   const [suppress, setSuppress] = useState(false);
-  // Preview override — when localStorage has `hermesPreviewWhatsNew`
-  // set to a version key that exists in `changelog`, show that
-  // entry regardless of the user's last-seen / suppress state.  Used
-  // before a release to verify the release notes render correctly
-  // without bumping `package.json`.  Set via DevTools:
-  //
-  //     localStorage.setItem("hermesPreviewWhatsNew", "1.1.0");
-  //     location.reload();
-  //
-  // Clear with `localStorage.removeItem("hermesPreviewWhatsNew")`.
+  // Preview override — see WhatsNewDialog#preview-mode in the file
+  // for the DevTools snippet that activates this path.
   const previewVersion =
     typeof window !== "undefined"
       ? window.localStorage.getItem("hermesPreviewWhatsNew") ?? null
@@ -34,8 +26,6 @@ export function WhatsNewDialog({ version }: WhatsNewDialogProps) {
   useEffect(() => {
     let cancelled = false;
 
-    // Preview mode short-circuit — show immediately, don't write
-    // any settings, ignore suppress.
     if (previewVersion && changelog[previewVersion]) {
       setVisible(true);
       return () => { cancelled = true; };
@@ -50,27 +40,21 @@ export function WhatsNewDialog({ version }: WhatsNewDialogProps) {
 
         if (cancelled) return;
 
-        // Fresh install — no previous version saved. Save current and don't show.
         if (!lastSeen) {
           await setSetting(SETTING_LAST_SEEN, version);
           return;
         }
 
-        // Same version — nothing new
         if (lastSeen === version) return;
 
-        // User permanently suppressed the dialog
         if (suppressed === "true") {
-          // Still update the last-seen version so we don't re-check
           await setSetting(SETTING_LAST_SEEN, version);
           return;
         }
 
-        // New version + not suppressed + we have changelog content for it
         if (changelog[version]) {
           setVisible(true);
         } else {
-          // No changelog entry for this version — just update silently
           await setSetting(SETTING_LAST_SEEN, version);
         }
       } catch {
@@ -83,8 +67,6 @@ export function WhatsNewDialog({ version }: WhatsNewDialogProps) {
 
   const handleDismiss = useCallback(async () => {
     setVisible(false);
-    // Preview mode: don't persist anything — the user is just
-    // looking at the dialog before a release.
     if (previewVersion && changelog[previewVersion]) return;
     try {
       await setSetting(SETTING_LAST_SEEN, version);
@@ -103,21 +85,33 @@ export function WhatsNewDialog({ version }: WhatsNewDialogProps) {
 
   return (
     <div className="whatsnew-backdrop" onClick={handleDismiss}>
-      <div className="whatsnew-dialog" onClick={(e) => e.stopPropagation()}>
-        <div className="whatsnew-header">
-          <span className="whatsnew-icon" aria-hidden="true">&#10024;</span>
-          <span className="whatsnew-title">What&rsquo;s New</span>
-          <span className="whatsnew-tag">v{effectiveVersion}</span>
-        </div>
+      <div
+        className="whatsnew-dialog"
+        data-accent={entry.accent ?? "default"}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <WhatsNewHero version={effectiveVersion} tagline={entry.tagline} />
         <div className="whatsnew-body">
-          <ul className="whatsnew-list">
-            {entry.items.map((item, i) => (
-              <li key={i} className="whatsnew-list-item">
-                <span className="whatsnew-list-bullet" />
-                <span>{item}</span>
-              </li>
-            ))}
-          </ul>
+          {entry.sections && entry.sections.length > 0 ? (
+            <div className="whatsnew-sections">
+              {entry.sections.map((section, idx) => (
+                <SectionCard key={idx} section={section} index={idx} />
+              ))}
+            </div>
+          ) : entry.items && entry.items.length > 0 ? (
+            <ul className="whatsnew-flat-list">
+              {entry.items.map((item, i) => (
+                <li
+                  key={i}
+                  className="whatsnew-flat-item"
+                  style={{ animationDelay: `${60 + i * 28}ms` }}
+                >
+                  <span className="whatsnew-flat-bullet" aria-hidden="true">·</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
         </div>
         <div className="whatsnew-footer">
           <label className="whatsnew-suppress">
@@ -129,7 +123,7 @@ export function WhatsNewDialog({ version }: WhatsNewDialogProps) {
             Don&rsquo;t show after updates
           </label>
           <div className="whatsnew-spacer" />
-          <button className="whatsnew-btn" onClick={handleDismiss}>
+          <button className="whatsnew-btn whatsnew-btn-primary" onClick={handleDismiss}>
             Got it
           </button>
         </div>
@@ -137,3 +131,62 @@ export function WhatsNewDialog({ version }: WhatsNewDialogProps) {
     </div>
   );
 }
+
+function WhatsNewHero({ version, tagline }: { version: string; tagline?: string }) {
+  return (
+    <header className="whatsnew-hero" aria-hidden={false}>
+      {/* Decorative animated mesh — accents from the active theme. */}
+      <div className="whatsnew-hero-mesh" aria-hidden="true">
+        <span className="whatsnew-hero-orb whatsnew-hero-orb-a" />
+        <span className="whatsnew-hero-orb whatsnew-hero-orb-b" />
+        <span className="whatsnew-hero-orb whatsnew-hero-orb-c" />
+      </div>
+      <div className="whatsnew-hero-content">
+        <span className="whatsnew-hero-eyebrow">What&rsquo;s New</span>
+        <h1 className="whatsnew-hero-version">v{version}</h1>
+        {tagline && <p className="whatsnew-hero-tagline">{tagline}</p>}
+      </div>
+    </header>
+  );
+}
+
+function SectionCard({ section, index }: { section: ChangelogSection; index: number }) {
+  return (
+    <section
+      className="whatsnew-section"
+      style={{ animationDelay: `${100 + index * 70}ms` }}
+    >
+      <div className="whatsnew-section-header">
+        {section.icon && (
+          <span className="whatsnew-section-icon" aria-hidden="true">
+            {section.icon}
+          </span>
+        )}
+        <h2 className="whatsnew-section-title">{section.title}</h2>
+      </div>
+      {section.description && (
+        <p className="whatsnew-section-desc">{section.description}</p>
+      )}
+      {section.items.length > 0 && (
+        <ul className="whatsnew-section-list">
+          {section.items.map((item, i) => (
+            <li
+              key={i}
+              className="whatsnew-section-item"
+              style={{ animationDelay: `${140 + index * 70 + i * 22}ms` }}
+            >
+              <span className="whatsnew-section-bullet" aria-hidden="true" />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {section.hint && (
+        <p className="whatsnew-section-hint">{section.hint}</p>
+      )}
+    </section>
+  );
+}
+
+// Re-export for tests
+export type { ChangelogEntry };

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -2,36 +2,113 @@
  * Embedded changelog shown in the "What's New" dialog after updates.
  *
  * Each entry is keyed by the version string (without "v" prefix).
- * The `items` array contains user-facing descriptions of changes.
  *
- * When releasing a new version, add an entry here with the changes.
- * Only the current version's entry is shown — past entries are kept
- * for reference but not displayed.
+ * Two shapes are supported:
+ *   - Legacy `items: string[]` — a flat bullet list (older releases).
+ *   - New `sections: ChangelogSection[]` — grouped, illustrated cards
+ *     for richer announcements.  Use this for any non-trivial release.
+ *
+ * When releasing a new version, add an entry here.
  */
 
-export interface ChangelogEntry {
-  /** Short list of user-facing changes */
+export interface ChangelogSection {
+  /** Short heading (3-6 words). */
+  title: string;
+  /** Single emoji or short string icon shown next to the title. */
+  icon?: string;
+  /** Optional one-paragraph intro that opens the section. */
+  description?: string;
+  /** Bullet list of changes inside this section. */
   items: string[];
+  /** Optional CTA — surfaced as a quiet hint at the bottom of the
+   *  section ("try `/mcp`", "Settings → Appearance"). */
+  hint?: string;
+}
+
+export interface ChangelogEntry {
+  /** Optional short tagline shown under the version pill. */
+  tagline?: string;
+  /** Optional accent color theme: `default` | `warm` | `cool`. */
+  accent?: "default" | "warm" | "cool";
+  /** Legacy flat bullet list. */
+  items?: string[];
+  /** Grouped section cards (preferred for rich releases). */
+  sections?: ChangelogSection[];
 }
 
 export const changelog: Record<string, ChangelogEntry> = {
   "1.1.0": {
-    items: [
-      "Modern session timeline — speaker chips with avatars, sans-serif body, soft message cards instead of the brass-bar logbook",
-      "Type / to see every Claude command — built-ins, plugins, skills — clearly labeled in-app or terminal",
-      "Embedded inline terminal runs interactive /mcp, /agents, /cost, /help and friends without leaving the chat",
-      "New Terminal button opens a quick shell right next to the composer for git, npm, ls — anything",
-      "MCP server panel shows transport, command, env keys, tools, with restart and remove actions",
-      "Cloud-managed MCP servers (claude.ai Gmail, Drive, Calendar) detected and labeled — no more stuck delete",
-      "Approve / deny / always-allow buttons are now real prominent buttons, not tiny links",
-      "Plan-mode replies and multi-question answers actually reach Claude (silent drops are fixed)",
-      "Picker chips stay in sync when Claude flips model or permission mode mid-conversation",
-      "30 themes look genuinely distinct — phosphor scanlines on hacker, paper grain on designer, glass aurora on nightowl, pulsing rails on tron",
-      "First-message thinking indicator fires immediately so you don't sit in silence",
-      "Composer chips truncate cleanly on narrow windows instead of overlapping",
-      "Activity-bar Context button now actually toggles the agent panel (Cmd+E)",
-      "Dirty-close dialog stops surfacing .aider.chat.history.md and similar auto-generated noise",
-      "Prefer the previous look? Settings → Appearance → Use classic compact timeline",
+    tagline: "A modern timeline, every Claude command at your fingertips, and a way back if you need it.",
+    accent: "default",
+    sections: [
+      {
+        title: "A modern session timeline",
+        icon: "✦",
+        description:
+          "The agent timeline now reads like a real conversation. Speaker chips identify who's talking; messages get a soft accent-tinted card; whitespace replaces the hairline rules.",
+        items: [
+          "Avatar chips with bot / person icons replace the № 01 marginalia",
+          "Refined sans-serif body — mono is preserved for code, paths, and tool calls",
+          "30 themes paint the layout differently — phosphor scanlines on hacker, paper grain on designer, glass aurora on nightowl, pulsing rails on tron",
+        ],
+      },
+      {
+        title: "Every slash command, in or out",
+        icon: "▣",
+        description:
+          "Type / and you see every Claude command — built-ins, plugins, skills — clearly labeled in-app or terminal.",
+        items: [
+          "Pick /mcp, /agents, /cost, /help — Hermes spawns claude in an inline xterm and auto-types the command for you",
+          "New Terminal button next to Builder opens a quick shell for git, npm, ls — anything",
+        ],
+        hint: "Type / in the composer to see them all.",
+      },
+      {
+        title: "MCP server panel that helps",
+        icon: "◇",
+        description:
+          "Click any MCP server to see why its dot is the color it is, what command runs it, and which env keys it expects.",
+        items: [
+          "Status explanation (Connected / Needs auth / Failed) with a color tone you can read at a glance",
+          "Transport, command, env keys, header keys, and the tools the server exposes",
+          "Restart and Remove actions with a confirmation step",
+          "Cloud-managed servers (claude.ai Gmail, Drive, Calendar) are detected and labeled — no more stuck delete",
+        ],
+      },
+      {
+        title: "Plan mode and permissions, fixed",
+        icon: "✓",
+        description:
+          "Send no longer silently drops your reply when Claude is asking you something. Approve / deny buttons stop hiding.",
+        items: [
+          "Plan-mode replies and AskUserQuestion answers actually reach Claude",
+          "Approve once / Always allow / Deny / Edit input are now real, prominent buttons — the primary CTA pulses to mark it as your turn",
+          "Picker chips stay in sync when Claude flips model or permission mode mid-conversation",
+        ],
+      },
+      {
+        title: "Smaller polish you'll notice",
+        icon: "·",
+        items: [
+          "First-message thinking indicator fires immediately — no more silent boot pause",
+          "Cost & Tokens panel section is gone (the live cost meter in the header is the source of truth)",
+          "Activity-bar Context button actually toggles the agent panel (Cmd+E)",
+          ".aider.chat.history.md and other auto-generated files don't surface on session-close",
+          "Composer chips truncate cleanly on narrow widths instead of overlapping",
+        ],
+      },
+      {
+        title: "Prefer the previous look?",
+        icon: "↺",
+        description:
+          "If the modern timeline isn't for you, the denser logbook style is one toggle away.",
+        items: [
+          "Settings → Appearance → Agent Timeline Style → Classic compact",
+          "Restores the mono body, brass left bar on user messages, and hairline rules between turns",
+          "Themes still apply on top, so the classic look paints in your active theme's colors",
+        ],
+        hint: "Toggle it back any time.",
+      },
     ],
   },
   "0.3.31": {

--- a/src/styles/components/WhatsNewDialog.css
+++ b/src/styles/components/WhatsNewDialog.css
@@ -1,104 +1,367 @@
-/* ─── What's New Dialog ─────────────────────────────────── */
+/* ════════════════════════════════════════════════════════════════════
+ * What's New Dialog — visual showcase for releases
+ * ════════════════════════════════════════════════════════════════════
+ *
+ * Design intent: a focused release announcement that reads as a
+ * *celebration*, not a changelog.  Hero header with a soft animated
+ * accent mesh + version pill, then themed section cards with icons,
+ * descriptions, bullets, and optional "try it" hints.  Sections fade
+ * in staggered so the eye reads top-to-bottom.
+ *
+ * Theme tokens drive the accents — every theme paints the dialog in
+ * its own colors.  Reduced-motion respected. */
 
 .whatsnew-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.55);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 200;
-  backdrop-filter: blur(2px);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  animation: whatsnew-backdrop-in 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes whatsnew-backdrop-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
 .whatsnew-dialog {
   background: var(--bg-1);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  width: 460px;
-  max-height: 80vh;
+  border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
+  border-radius: 14px;
+  width: 640px;
+  max-width: calc(100vw - 48px);
+  max-height: calc(100vh - 80px);
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-  animation: overlayIn 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+  overflow: hidden;
+  box-shadow:
+    0 30px 80px rgba(0, 0, 0, 0.45),
+    0 0 0 1px color-mix(in srgb, var(--accent) 8%, transparent);
+  animation: whatsnew-dialog-in 0.32s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.whatsnew-header {
-  padding: 20px 20px 0;
+@keyframes whatsnew-dialog-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* ─── Hero header ────────────────────────────────────────────── */
+
+.whatsnew-hero {
+  position: relative;
+  padding: 36px 32px 28px;
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 14%, transparent);
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--accent) 14%, var(--bg-1)) 0%,
+      color-mix(in srgb, var(--accent) 4%, var(--bg-1)) 100%);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+/* Animated orb mesh — three soft blurred discs in accent colors that
+ * drift across the hero, giving subtle motion without being noisy. */
+.whatsnew-hero-mesh {
+  position: absolute;
+  inset: -20%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.whatsnew-hero-orb {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  filter: blur(48px);
+  opacity: 0.55;
+  will-change: transform;
+}
+
+.whatsnew-hero-orb-a {
+  top: -40px;
+  left: -20px;
+  background: radial-gradient(circle at 30% 30%, var(--accent), transparent 70%);
+  animation: whatsnew-orb-drift-a 14s ease-in-out infinite;
+}
+
+.whatsnew-hero-orb-b {
+  top: 20px;
+  right: -30px;
+  background: radial-gradient(circle at 70% 30%, var(--violet, var(--accent)), transparent 70%);
+  animation: whatsnew-orb-drift-b 18s ease-in-out infinite;
+  opacity: 0.42;
+}
+
+.whatsnew-hero-orb-c {
+  bottom: -80px;
+  left: 35%;
+  background: radial-gradient(circle at 50% 50%, var(--brass, var(--accent)), transparent 70%);
+  animation: whatsnew-orb-drift-c 22s ease-in-out infinite;
+  opacity: 0.32;
+}
+
+@keyframes whatsnew-orb-drift-a {
+  0%, 100% { transform: translate3d(0, 0, 0); }
+  50%      { transform: translate3d(40px, 22px, 0); }
+}
+
+@keyframes whatsnew-orb-drift-b {
+  0%, 100% { transform: translate3d(0, 0, 0); }
+  50%      { transform: translate3d(-28px, 30px, 0); }
+}
+
+@keyframes whatsnew-orb-drift-c {
+  0%, 100% { transform: translate3d(0, 0, 0); }
+  50%      { transform: translate3d(20px, -24px, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .whatsnew-hero-orb { animation: none; }
+  .whatsnew-dialog { animation: none; }
+  .whatsnew-backdrop { animation: none; }
+}
+
+.whatsnew-hero-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.whatsnew-hero-eyebrow {
+  font: 11px/1 var(--font-display, var(--font-ui));
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.whatsnew-hero-version {
+  font: 28px/1 var(--font-display, var(--font-ui));
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--ink-primary, var(--text-0));
+  margin: 0;
+}
+
+.whatsnew-hero-tagline {
+  font: 14px/1.45 var(--font-display, var(--font-ui));
+  color: var(--ink-secondary, var(--text-1));
+  margin: 6px 0 0 0;
+  letter-spacing: -0.005em;
+  max-width: 60ch;
+}
+
+/* ─── Body — section cards ────────────────────────────────────── */
+
+.whatsnew-body {
+  padding: 22px 28px 8px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.whatsnew-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.whatsnew-section {
+  position: relative;
+  padding: 16px 18px 14px;
+  background: color-mix(in srgb, var(--accent) 4%, var(--bg-1));
+  border: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border));
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateY(8px);
+  animation: whatsnew-section-in 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes whatsnew-section-in {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.whatsnew-section-header {
   display: flex;
   align-items: center;
   gap: 10px;
+  margin-bottom: 8px;
 }
 
-.whatsnew-icon {
-  font-size: 20px;
-  line-height: 1;
-}
-
-.whatsnew-title {
-  font-size: var(--text-xl);
-  font-weight: 600;
-  color: var(--text-0);
-}
-
-.whatsnew-tag {
-  font-size: var(--text-xs);
-  font-weight: 500;
+.whatsnew-section-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 26%, transparent);
   color: var(--accent);
-  background: var(--accent-dim);
-  padding: 2px 8px;
-  border-radius: var(--radius-sm);
-  margin-left: auto;
+  font-size: 14px;
+  flex-shrink: 0;
 }
 
-.whatsnew-body {
-  padding: 16px 20px;
-  overflow-y: auto;
-  flex: 1;
+.whatsnew-section-title {
+  margin: 0;
+  font: 15px/1.2 var(--font-display, var(--font-ui));
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink-primary, var(--text-0));
 }
 
-.whatsnew-list {
+.whatsnew-section-desc {
+  margin: 0 0 10px 0;
+  font: 13.5px/1.55 var(--font-display, var(--font-ui));
+  color: var(--ink-secondary, var(--text-1));
+  letter-spacing: -0.005em;
+}
+
+.whatsnew-section-list {
   list-style: none;
   padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
-.whatsnew-list-item {
+.whatsnew-section-item {
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  font-size: var(--text-base);
-  color: var(--text-1);
-  line-height: 1.5;
+  font: 13px/1.5 var(--font-display, var(--font-ui));
+  color: var(--ink-secondary, var(--text-1));
+  letter-spacing: -0.003em;
+  opacity: 0;
+  transform: translateX(4px);
+  animation: whatsnew-item-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
-.whatsnew-list-bullet {
+@keyframes whatsnew-item-in {
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.whatsnew-section-bullet {
   flex-shrink: 0;
-  width: 6px;
-  height: 6px;
+  width: 5px;
+  height: 5px;
   border-radius: 50%;
   background: var(--accent);
-  margin-top: 7px;
+  margin-top: 8px;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
+.whatsnew-section-hint {
+  margin: 12px 0 0 0;
+  padding: 7px 10px;
+  font: 12px/1.4 var(--font-display, var(--font-ui));
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  border-radius: 6px;
+  letter-spacing: -0.003em;
+}
+
+/* Per-section accent shifts so the cards have visual rhythm — every
+ * second card picks up a violet tint, every third a brass tint.
+ * Themes that don't define those tokens fall back to --accent. */
+.whatsnew-section:nth-child(2n) {
+  background: color-mix(in srgb, var(--violet, var(--accent)) 4%, var(--bg-1));
+  border-color: color-mix(in srgb, var(--violet, var(--accent)) 12%, var(--border));
+}
+
+.whatsnew-section:nth-child(2n) .whatsnew-section-icon {
+  background: color-mix(in srgb, var(--violet, var(--accent)) 14%, transparent);
+  border-color: color-mix(in srgb, var(--violet, var(--accent)) 26%, transparent);
+  color: var(--violet, var(--accent));
+}
+
+.whatsnew-section:nth-child(2n) .whatsnew-section-bullet {
+  background: var(--violet, var(--accent));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--violet, var(--accent)) 18%, transparent);
+}
+
+.whatsnew-section:nth-child(3n) {
+  background: color-mix(in srgb, var(--brass, var(--accent)) 4%, var(--bg-1));
+  border-color: color-mix(in srgb, var(--brass, var(--accent)) 12%, var(--border));
+}
+
+.whatsnew-section:nth-child(3n) .whatsnew-section-icon {
+  background: color-mix(in srgb, var(--brass, var(--accent)) 14%, transparent);
+  border-color: color-mix(in srgb, var(--brass, var(--accent)) 26%, transparent);
+  color: var(--brass, var(--accent));
+}
+
+.whatsnew-section:nth-child(3n) .whatsnew-section-bullet {
+  background: var(--brass, var(--accent));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--brass, var(--accent)) 18%, transparent);
+}
+
+/* ─── Legacy flat list (older changelog entries) ─────────────── */
+
+.whatsnew-flat-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.whatsnew-flat-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font: 13.5px/1.5 var(--font-display, var(--font-ui));
+  color: var(--ink-secondary, var(--text-1));
+  letter-spacing: -0.005em;
+  opacity: 0;
+  transform: translateX(4px);
+  animation: whatsnew-item-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.whatsnew-flat-bullet {
+  flex-shrink: 0;
+  color: var(--accent);
+  font-size: 18px;
+  line-height: 1;
+  margin-top: 0;
+}
+
+/* ─── Footer ─────────────────────────────────────────────────── */
+
 .whatsnew-footer {
-  padding: 14px 20px;
+  padding: 14px 24px;
   border-top: 1px solid var(--border);
+  background: color-mix(in srgb, var(--accent) 2%, var(--bg-1));
   display: flex;
   align-items: center;
   gap: 12px;
+  flex-shrink: 0;
 }
 
 .whatsnew-suppress {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   cursor: pointer;
-  font-size: var(--text-sm);
-  color: var(--text-3);
+  font: 12px/1 var(--font-display, var(--font-ui));
+  color: var(--ink-tertiary, var(--text-3));
   user-select: none;
 }
 
@@ -108,27 +371,64 @@
 }
 
 .whatsnew-suppress:hover {
-  color: var(--text-2);
+  color: var(--ink-secondary, var(--text-2));
 }
 
 .whatsnew-spacer {
-  flex: 1;
+  flex: 1 1 auto;
 }
 
 .whatsnew-btn {
-  background: var(--accent-dim);
-  border: 1px solid var(--accent);
+  appearance: none;
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
   color: var(--accent);
-  padding: 7px 20px;
-  border-radius: var(--radius);
+  padding: 8px 18px;
+  border-radius: 7px;
   cursor: pointer;
-  font-size: var(--text-lg);
-  font-family: var(--font-ui);
-  font-weight: 500;
-  transition: background 0.1s, color 0.1s;
+  font: 13px/1 var(--font-display, var(--font-ui));
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  transition: background 0.12s ease, color 0.12s ease, transform 0.08s ease;
 }
 
 .whatsnew-btn:hover {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border-color: var(--accent);
+}
+
+.whatsnew-btn:active {
+  transform: translateY(0.5px);
+}
+
+.whatsnew-btn-primary {
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--accent) 95%, white) 0%,
+    var(--accent) 100%);
+  border-color: var(--accent);
+  color: var(--bg-0);
+  box-shadow: 0 1px 0 color-mix(in srgb, white 18%, transparent) inset;
+}
+
+.whatsnew-btn-primary:hover {
+  filter: brightness(1.08);
   background: var(--accent);
   color: var(--bg-0);
+}
+
+/* Narrow widths — drop the dialog padding a bit so it fits */
+@media (max-width: 720px) {
+  .whatsnew-dialog {
+    width: calc(100vw - 24px);
+    border-radius: 12px;
+  }
+  .whatsnew-hero {
+    padding: 28px 22px 22px;
+  }
+  .whatsnew-body {
+    padding: 18px 20px 8px;
+  }
+  .whatsnew-hero-version {
+    font-size: 24px;
+  }
 }


### PR DESCRIPTION
Old dialog was a flat bullet list in a small modal — read like a debug log, not a release announcement.  Redesigned as a proper showcase fit for the v1.1.0 launch.

## Data model

`changelog.ts` now supports `sections` alongside the legacy `items` list.  Each section has a title, icon, optional description, bullets, and an optional CTA hint.  Older 0.3.x entries keep working unchanged.

## Visual treatment

- 640-px dialog (was 460), 14-px radius, theme-tinted border + soft shadow
- Hero header with three blurred drifting orbs in the active theme's accent / violet / brass tokens — gentle motion that marks "new release" without being noisy.  Eyebrow + version pill + tagline
- Each section as a card with a 28-px icon chip, bold title, description, accent-bulleted list, and optional hint footer.  Cards alternate between accent / violet / brass tints
- Staggered fade-in: dialog rises, sections slide up at 70-ms intervals, bullets slide in at 22-ms intervals.  All animations honor `prefers-reduced-motion`
- Primary "Got it" button gets a filled treatment with subtle inset highlight

Every theme paints the dialog in its own colors — green-phosphor on hacker, terracotta on designer, cyan on tron, etc.

The v1.1.0 entry rewritten as 6 grouped sections matching RELEASE_NOTES.md.

3065 vitest passing.