### PR TITLE
WhatsNew: embed CSS micro-mockups of each new feature

### DIFF
--- a/src/components/WhatsNewDialog.tsx
+++ b/src/components/WhatsNewDialog.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect, useCallback } from "react";
 import "../styles/components/WhatsNewDialog.css";
-import { changelog, type ChangelogEntry, type ChangelogSection } from "../data/changelog";
+import {
+  changelog,
+  type ChangelogEntry,
+  type ChangelogPreviewKind,
+  type ChangelogSection,
+} from "../data/changelog";
 import { getSetting, setSetting } from "../api/settings";
 
 const SETTING_LAST_SEEN = "last_seen_version";
@@ -164,6 +169,7 @@ function SectionCard({ section, index }: { section: ChangelogSection; index: num
         )}
         <h2 className="whatsnew-section-title">{section.title}</h2>
       </div>
+      {section.preview && <SectionPreview kind={section.preview} />}
       {section.description && (
         <p className="whatsnew-section-desc">{section.description}</p>
       )}
@@ -185,6 +191,166 @@ function SectionCard({ section, index }: { section: ChangelogSection; index: num
         <p className="whatsnew-section-hint">{section.hint}</p>
       )}
     </section>
+  );
+}
+
+/**
+ * Pure CSS micro-mockups of the new features, embedded inside section
+ * cards so the user can see the change at a glance.  Each branch is
+ * a small, theme-aware illustration — no dependency on the actual
+ * components (rendering them in the dialog context would cascade
+ * SessionContext / xterm / etc., and the look wouldn't compress
+ * cleanly anyway).  Pure HTML + the styles in WhatsNewDialog.css.
+ */
+function SectionPreview({ kind }: { kind: ChangelogPreviewKind }) {
+  return (
+    <div className={`whatsnew-preview whatsnew-preview-${kind}`} aria-hidden="true">
+      {kind === "timeline" && (
+        <>
+          {/* Mock user turn: avatar chip + accent-tinted message card. */}
+          <div className="wn-tl-row" data-role="user">
+            <div className="wn-tl-chip">
+              <span className="wn-tl-avatar wn-tl-avatar-user" />
+              <span className="wn-tl-name">You</span>
+              <span className="wn-tl-time">14:27</span>
+            </div>
+            <div className="wn-tl-body wn-tl-body-user">
+              let&rsquo;s redesign the navbar
+            </div>
+          </div>
+          {/* Mock assistant turn: bot avatar + sans-serif prose. */}
+          <div className="wn-tl-row" data-role="assistant">
+            <div className="wn-tl-chip">
+              <span className="wn-tl-avatar wn-tl-avatar-bot" />
+              <span className="wn-tl-name">Hermes</span>
+            </div>
+            <div className="wn-tl-body wn-tl-body-bot">
+              I&rsquo;ll start by reading the existing nav component
+              and your design tokens.
+            </div>
+          </div>
+        </>
+      )}
+
+      {kind === "slash-popover" && (
+        <>
+          <div className="wn-sp-input">
+            <span className="wn-sp-caret">/</span>
+            <span className="wn-sp-input-cursor" />
+          </div>
+          <div className="wn-sp-list">
+            <div className="wn-sp-row">
+              <code className="wn-sp-cmd">/mcp</code>
+              <span className="wn-sp-desc">Manage MCP servers</span>
+              <span className="wn-sp-badge wn-sp-badge-cli">▣ terminal</span>
+            </div>
+            <div className="wn-sp-row wn-sp-row-active">
+              <code className="wn-sp-cmd">/telegram:configure</code>
+              <span className="wn-sp-desc">Set up Telegram</span>
+              <span className="wn-sp-badge wn-sp-badge-native">✦ in-app</span>
+            </div>
+            <div className="wn-sp-row">
+              <code className="wn-sp-cmd">/agents</code>
+              <span className="wn-sp-desc">Manage subagents</span>
+              <span className="wn-sp-badge wn-sp-badge-cli">▣ terminal</span>
+            </div>
+            <div className="wn-sp-row">
+              <code className="wn-sp-cmd">/recap</code>
+              <span className="wn-sp-desc">Summarize this session</span>
+              <span className="wn-sp-badge wn-sp-badge-native">✦ in-app</span>
+            </div>
+          </div>
+        </>
+      )}
+
+      {kind === "mcp-row" && (
+        <>
+          <div className="wn-mcp-row">
+            <span className="wn-mcp-dot wn-mcp-dot-ok" />
+            <span className="wn-mcp-name">context7</span>
+            <span className="wn-mcp-status wn-mcp-status-ok">connected</span>
+          </div>
+          <div className="wn-mcp-explain">
+            Connected — server is responding to tool calls.
+          </div>
+          <div className="wn-mcp-spec">
+            <span className="wn-mcp-label">Transport</span>
+            <span className="wn-mcp-transport">stdio</span>
+            <span className="wn-mcp-label">Command</span>
+            <code className="wn-mcp-code">npx -y @upstash/context7-mcp</code>
+            <span className="wn-mcp-label">Env</span>
+            <span className="wn-mcp-chips">
+              <span className="wn-mcp-chip">CONTEXT7_API_KEY</span>
+              <span className="wn-mcp-chip">DEBUG</span>
+            </span>
+          </div>
+          <div className="wn-mcp-actions">
+            <span className="wn-mcp-action">restart</span>
+            <span className="wn-mcp-action wn-mcp-action-deny">remove</span>
+          </div>
+        </>
+      )}
+
+      {kind === "perm-buttons" && (
+        <>
+          <div className="wn-perm-prompt">
+            <span className="wn-perm-icon">⚠</span>
+            <span className="wn-perm-text">Run <code>git status -s</code>?</span>
+          </div>
+          <div className="wn-perm-actions">
+            <span className="wn-perm-btn">Deny</span>
+            <span className="wn-perm-btn">Edit input</span>
+            <span className="wn-perm-spacer" />
+            <span className="wn-perm-btn wn-perm-btn-secondary">Always allow (Bash)</span>
+            <span className="wn-perm-btn wn-perm-btn-primary">Approve once</span>
+          </div>
+        </>
+      )}
+
+      {kind === "embedded-terminal" && (
+        <>
+          <div className="wn-term-header">
+            <span className="wn-term-dot" />
+            <code className="wn-term-cmd">claude → /mcp</code>
+            <span className="wn-term-status">running</span>
+          </div>
+          <div className="wn-term-body">
+            <div className="wn-term-line">claude.ai Gmail · ✓ connected</div>
+            <div className="wn-term-line">claude.ai Drive · ✓ connected</div>
+            <div className="wn-term-line wn-term-line-prompt">
+              <span className="wn-term-chevron">❯</span> /mcp
+            </div>
+          </div>
+        </>
+      )}
+
+      {kind === "classic-toggle" && (
+        <>
+          {/* Side-by-side: modern (left) vs classic (right). */}
+          <div className="wn-ct-pair">
+            <div className="wn-ct-side wn-ct-side-modern">
+              <div className="wn-ct-label">Modern</div>
+              <div className="wn-ct-row">
+                <span className="wn-tl-avatar wn-tl-avatar-user" />
+                <span className="wn-ct-name">You</span>
+              </div>
+              <div className="wn-ct-body wn-ct-body-modern">
+                let&rsquo;s redesign the navbar
+              </div>
+            </div>
+            <div className="wn-ct-side wn-ct-side-classic">
+              <div className="wn-ct-label">Classic</div>
+              <div className="wn-ct-row wn-ct-row-classic">
+                <span className="wn-ct-name-classic">YOU · 14:27</span>
+              </div>
+              <div className="wn-ct-body wn-ct-body-classic">
+                <em>let&rsquo;s redesign the navbar</em>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
   );
 }
 

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -11,6 +11,19 @@
  * When releasing a new version, add an entry here.
  */
 
+/** Preview-mockup keys.  Each key maps to a small CSS-only
+ *  illustration rendered inside the section card so the user
+ *  can see what the feature actually looks like.  The mockups
+ *  live in `<SectionPreview>` (WhatsNewDialog.tsx) — adding a
+ *  new key requires a matching render branch there. */
+export type ChangelogPreviewKind =
+  | "timeline"
+  | "slash-popover"
+  | "mcp-row"
+  | "perm-buttons"
+  | "embedded-terminal"
+  | "classic-toggle";
+
 export interface ChangelogSection {
   /** Short heading (3-6 words). */
   title: string;
@@ -23,6 +36,9 @@ export interface ChangelogSection {
   /** Optional CTA — surfaced as a quiet hint at the bottom of the
    *  section ("try `/mcp`", "Settings → Appearance"). */
   hint?: string;
+  /** Optional CSS micro-mockup of the feature, shown above the
+   *  bullet list.  Brings the announcement to life. */
+  preview?: ChangelogPreviewKind;
 }
 
 export interface ChangelogEntry {
@@ -44,6 +60,7 @@ export const changelog: Record<string, ChangelogEntry> = {
       {
         title: "A modern session timeline",
         icon: "✦",
+        preview: "timeline",
         description:
           "The agent timeline now reads like a real conversation. Speaker chips identify who's talking; messages get a soft accent-tinted card; whitespace replaces the hairline rules.",
         items: [
@@ -55,6 +72,7 @@ export const changelog: Record<string, ChangelogEntry> = {
       {
         title: "Every slash command, in or out",
         icon: "▣",
+        preview: "slash-popover",
         description:
           "Type / and you see every Claude command — built-ins, plugins, skills — clearly labeled in-app or terminal.",
         items: [
@@ -66,6 +84,7 @@ export const changelog: Record<string, ChangelogEntry> = {
       {
         title: "MCP server panel that helps",
         icon: "◇",
+        preview: "mcp-row",
         description:
           "Click any MCP server to see why its dot is the color it is, what command runs it, and which env keys it expects.",
         items: [
@@ -78,6 +97,7 @@ export const changelog: Record<string, ChangelogEntry> = {
       {
         title: "Plan mode and permissions, fixed",
         icon: "✓",
+        preview: "perm-buttons",
         description:
           "Send no longer silently drops your reply when Claude is asking you something. Approve / deny buttons stop hiding.",
         items: [
@@ -100,6 +120,7 @@ export const changelog: Record<string, ChangelogEntry> = {
       {
         title: "Prefer the previous look?",
         icon: "↺",
+        preview: "classic-toggle",
         description:
           "If the modern timeline isn't for you, the denser logbook style is one toggle away.",
         items: [

--- a/src/styles/components/WhatsNewDialog.css
+++ b/src/styles/components/WhatsNewDialog.css
@@ -432,3 +432,542 @@
     font-size: 24px;
   }
 }
+
+/* ════════════════════════════════════════════════════════════════════
+ * Section preview mockups — pure CSS feature illustrations
+ * ════════════════════════════════════════════════════════════════════ */
+
+.whatsnew-preview {
+  margin: 0 0 12px 0;
+  padding: 12px 14px;
+  background: color-mix(in srgb, var(--bg-0, #000) 35%, var(--bg-1));
+  border: 1px solid color-mix(in srgb, var(--accent) 14%, var(--border));
+  border-radius: 8px;
+  font-family: var(--font-display, var(--font-ui));
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  position: relative;
+  overflow: hidden;
+}
+
+/* Subtle scan-shimmer over every preview tile so they read as "live". */
+.whatsnew-preview::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    115deg,
+    transparent 30%,
+    color-mix(in srgb, var(--accent) 6%, transparent) 50%,
+    transparent 70%
+  );
+  background-size: 200% 100%;
+  animation: whatsnew-preview-shimmer 6s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes whatsnew-preview-shimmer {
+  0%, 100% { background-position: 200% 0; }
+  50%      { background-position: -100% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .whatsnew-preview::before { animation: none; }
+}
+
+/* ─── Timeline preview ─────────────────────────────────────── */
+
+.wn-tl-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.wn-tl-row + .wn-tl-row { margin-top: 6px; }
+
+.wn-tl-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+  color: var(--ink-secondary, var(--text-1));
+}
+
+.wn-tl-avatar {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.wn-tl-avatar-user {
+  background: color-mix(in srgb, var(--brass, var(--accent)) 22%, transparent);
+  border: 1px solid color-mix(in srgb, var(--brass, var(--accent)) 36%, transparent);
+}
+
+.wn-tl-avatar-user::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--brass, var(--accent));
+  box-shadow: 0 5px 0 -1px var(--brass, var(--accent));
+}
+
+.wn-tl-avatar-bot {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 36%, transparent);
+}
+
+.wn-tl-avatar-bot::before {
+  content: "";
+  width: 9px;
+  height: 7px;
+  border-radius: 1.5px;
+  background: var(--accent);
+  position: relative;
+}
+
+.wn-tl-avatar-bot::after {
+  content: "";
+  width: 1.5px;
+  height: 3px;
+  background: var(--accent);
+  position: absolute;
+  margin-top: -10px;
+}
+
+.wn-tl-name {
+  font-weight: 600;
+  color: var(--ink-primary, var(--text-0));
+  font-size: 11.5px;
+  letter-spacing: -0.005em;
+}
+
+.wn-tl-time {
+  font: 10px/1 var(--font-mono);
+  color: var(--ink-tertiary, var(--text-3));
+  margin-left: 2px;
+}
+
+.wn-tl-body {
+  margin-left: 24px;
+  padding: 8px 12px;
+  font: 12.5px/1.5 var(--font-display, var(--font-ui));
+  color: var(--ink-primary, var(--text-0));
+  letter-spacing: -0.005em;
+}
+
+.wn-tl-body-user {
+  background: color-mix(in srgb, var(--brass, var(--accent)) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--brass, var(--accent)) 14%, transparent);
+  border-radius: 8px;
+}
+
+.wn-tl-body-bot {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+/* ─── Slash popover preview ────────────────────────────────── */
+
+.wn-sp-input {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  background: var(--bg-0);
+  border: 1px solid var(--rule, var(--border));
+  border-radius: 6px;
+  font: 12px/1 var(--font-mono);
+  color: var(--ink-primary, var(--text-0));
+  align-self: flex-start;
+}
+
+.wn-sp-caret { color: var(--accent); font-weight: 600; }
+
+.wn-sp-input-cursor {
+  display: inline-block;
+  width: 7px;
+  height: 12px;
+  background: var(--accent);
+  animation: whatsnew-cursor-blink 1.05s step-end infinite;
+}
+
+@keyframes whatsnew-cursor-blink {
+  50% { opacity: 0; }
+}
+
+.wn-sp-list {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-1);
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
+  border-radius: 8px;
+  padding: 4px;
+  box-shadow: 0 8px 16px color-mix(in srgb, #000 18%, transparent);
+}
+
+.wn-sp-row {
+  display: grid;
+  grid-template-columns: max-content 1fr max-content;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 5px;
+  font-size: 12px;
+}
+
+.wn-sp-row-active {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.wn-sp-cmd {
+  font: 11.5px/1 var(--font-mono);
+  color: var(--accent);
+}
+
+.wn-sp-row-active .wn-sp-cmd { color: var(--ink-primary, var(--text-0)); }
+
+.wn-sp-desc {
+  color: var(--ink-secondary, var(--text-1));
+  font-size: 11.5px;
+  letter-spacing: -0.005em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wn-sp-badge {
+  font: 9px/1 var(--font-display, var(--font-ui));
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 3px 6px;
+  border-radius: 3px;
+  font-weight: 600;
+}
+
+.wn-sp-badge-cli {
+  color: var(--yellow, #ffb000);
+  background: color-mix(in srgb, var(--yellow, #ffb000) 18%, transparent);
+}
+
+.wn-sp-badge-native {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+/* ─── MCP row preview ──────────────────────────────────────── */
+
+.wn-mcp-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font: 12px/1 var(--font-display, var(--font-ui));
+}
+
+.wn-mcp-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--ink-tertiary);
+}
+
+.wn-mcp-dot-ok {
+  background: var(--green, #34d399);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--green, #34d399) 40%, transparent);
+}
+
+.wn-mcp-name {
+  flex: 1 1 auto;
+  font-weight: 600;
+  color: var(--ink-primary, var(--text-0));
+}
+
+.wn-mcp-status {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+}
+
+.wn-mcp-status-ok { color: var(--green, #34d399); }
+
+.wn-mcp-explain {
+  padding: 6px 10px;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--green, #34d399) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--green, #34d399) 24%, transparent);
+  color: var(--ink-secondary, var(--text-1));
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
+.wn-mcp-spec {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 10px;
+  row-gap: 5px;
+  font-size: 11.5px;
+}
+
+.wn-mcp-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ink-tertiary, var(--text-3));
+  padding-top: 1px;
+}
+
+.wn-mcp-transport {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 26%, transparent);
+  color: var(--accent);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  align-self: start;
+  width: max-content;
+}
+
+.wn-mcp-code {
+  font: 11px/1.4 var(--font-mono);
+  color: var(--ink-primary, var(--text-0));
+  background: color-mix(in srgb, var(--ink-tertiary) 10%, transparent);
+  padding: 3px 6px;
+  border-radius: 3px;
+  align-self: start;
+}
+
+.wn-mcp-chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.wn-mcp-chip {
+  font: 10px/1.4 var(--font-mono);
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--brass, var(--accent)) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--brass, var(--accent)) 24%, transparent);
+  color: var(--brass, var(--accent));
+}
+
+.wn-mcp-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.wn-mcp-action {
+  font: 11px/1 var(--font-display, var(--font-ui));
+  font-weight: 500;
+  padding: 5px 10px;
+  border-radius: 5px;
+  border: 1px solid var(--rule, var(--border));
+  background: var(--bg-1);
+  color: var(--ink-secondary, var(--text-1));
+}
+
+.wn-mcp-action-deny {
+  border-color: color-mix(in srgb, var(--red, #ff4444) 30%, var(--border));
+  color: var(--red, #ff4444);
+}
+
+/* ─── Permission buttons preview ──────────────────────────── */
+
+.wn-perm-prompt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: color-mix(in srgb, var(--yellow, #ffb000) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--yellow, #ffb000) 24%, transparent);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--ink-secondary, var(--text-1));
+}
+
+.wn-perm-icon { color: var(--yellow, #ffb000); }
+
+.wn-perm-text code {
+  font: 11px/1 var(--font-mono);
+  background: color-mix(in srgb, var(--yellow, #ffb000) 14%, transparent);
+  color: var(--yellow, #ffb000);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.wn-perm-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  background: color-mix(in srgb, var(--brass, var(--accent)) 4%, transparent);
+  border-radius: 6px;
+}
+
+.wn-perm-spacer { flex: 1 1 auto; }
+
+.wn-perm-btn {
+  font: 11px/1 var(--font-display, var(--font-ui));
+  font-weight: 500;
+  padding: 5px 10px;
+  border-radius: 5px;
+  border: 1px solid var(--rule, var(--border));
+  background: var(--bg-1);
+  color: var(--ink-secondary, var(--text-1));
+  white-space: nowrap;
+}
+
+.wn-perm-btn-secondary {
+  border-color: color-mix(in srgb, var(--brass, var(--accent)) 30%, transparent);
+  color: var(--brass, var(--accent));
+}
+
+.wn-perm-btn-primary {
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--brass, var(--accent)) 95%, white),
+    var(--brass, var(--accent)));
+  border-color: var(--brass, var(--accent));
+  color: var(--bg-0);
+  font-weight: 600;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--brass, var(--accent)) 14%, transparent);
+}
+
+/* ─── Embedded terminal preview ───────────────────────────── */
+
+.wn-term-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--yellow, #ffb000) 8%, var(--bg-1));
+  border: 1px solid color-mix(in srgb, var(--yellow, #ffb000) 24%, transparent);
+  border-radius: 6px 6px 0 0;
+}
+
+.wn-term-dot {
+  width: 6px;
+  height: 6px;
+  background: var(--yellow, #ffb000);
+}
+
+.wn-term-cmd {
+  flex: 1 1 auto;
+  font: 10.5px/1 var(--font-mono);
+  color: var(--yellow, #ffb000);
+  padding: 2px 6px;
+  background: color-mix(in srgb, var(--yellow, #ffb000) 14%, transparent);
+  border-radius: 3px;
+}
+
+.wn-term-status {
+  font: 10px/1 var(--font-mono);
+  color: var(--ink-tertiary, var(--text-3));
+}
+
+.wn-term-body {
+  padding: 8px 10px;
+  background: #0d1218;
+  border: 1px solid color-mix(in srgb, var(--yellow, #ffb000) 24%, transparent);
+  border-top: 0;
+  border-radius: 0 0 6px 6px;
+  font: 11px/1.5 var(--font-mono);
+  color: #c8d6e5;
+}
+
+.wn-term-line { color: #c8d6e5; }
+
+.wn-term-line-prompt {
+  margin-top: 4px;
+  color: #e2e8f0;
+}
+
+.wn-term-chevron {
+  color: var(--accent);
+  font-weight: 700;
+  margin-right: 6px;
+}
+
+/* ─── Classic toggle preview ──────────────────────────────── */
+
+.wn-ct-pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.wn-ct-side {
+  padding: 10px;
+  background: var(--bg-1);
+  border: 1px solid var(--rule, var(--border));
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.wn-ct-side-modern {
+  border-color: color-mix(in srgb, var(--accent) 22%, var(--border));
+}
+
+.wn-ct-label {
+  font: 9px/1 var(--font-display, var(--font-ui));
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-tertiary, var(--text-3));
+  font-weight: 600;
+}
+
+.wn-ct-row { display: flex; align-items: center; gap: 6px; }
+
+.wn-ct-row-classic { padding-bottom: 2px; }
+
+.wn-ct-name {
+  font: 11px/1 var(--font-display, var(--font-ui));
+  font-weight: 600;
+  color: var(--ink-primary, var(--text-0));
+}
+
+.wn-ct-name-classic {
+  font: 10px/1 var(--font-mono);
+  color: var(--brass, var(--accent));
+  letter-spacing: 0.04em;
+}
+
+.wn-ct-body {
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--ink-secondary, var(--text-1));
+}
+
+.wn-ct-body-modern {
+  padding: 6px 8px;
+  background: color-mix(in srgb, var(--brass, var(--accent)) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--brass, var(--accent)) 14%, transparent);
+  border-radius: 5px;
+  font-family: var(--font-display, var(--font-ui));
+}
+
+.wn-ct-body-classic {
+  padding: 0 0 0 8px;
+  border-left: 2px solid var(--brass, var(--accent));
+  font-family: var(--font-mono);
+  font-style: italic;
+}
+
+@media (max-width: 720px) {
+  .wn-ct-pair {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Bullets describe the changes; mockups SHOW them.  Six pure-CSS illustrations rendered inside the section cards, no real-component dependencies.

- timeline → mock user/assistant turns with avatar chips
- slash-popover → fake / autocomplete with in-app / terminal badges
- mcp-row → status explainer + transport + env chips + actions
- perm-buttons → prominent brass Approve once CTA
- embedded-terminal → claude → /mcp header + fake xterm panel
- classic-toggle → side-by-side modern vs classic

Each tile has a slow scan-shimmer (reduced-motion respected) so they read as 'live'.  Theme tokens drive every accent.

3065 vitest passing.