### PR TITLE
EmptyState: workshop-atelier hero for the 0→1 moment

### DIFF
--- a/src/__tests__/empty-state.test.tsx
+++ b/src/__tests__/empty-state.test.tsx
@@ -1,9 +1,13 @@
 /**
- * Phase 8 (v1.0.0 redesign) — EmptyState wording.
+ * EmptyState — workshop-atelier hero.  Pins the v1.1 redesign:
  *
- * Asserts that the empty state subtitle uses agent-leaning copy
- * ("AI-native development environment") instead of the legacy terminal-leaning
- * tagline ("AI-native terminal & IDE").
+ *   - The legacy `terminal & IDE` framing stays banished.
+ *   - The new tagline ("instrument panel for working with code &
+ *     agents") is rendered.
+ *   - The masthead, contents-page index ("I.", "II."), and the
+ *     three primary tiles (New session / Command palette / Context
+ *     panel) all show up — these are the contract this surface
+ *     delivers.
  */
 import { describe, expect, it, vi } from "vitest";
 import { renderToString } from "react-dom/server";
@@ -14,12 +18,13 @@ vi.mock("../utils/platform", () => ({
   fmt: (s: string) => s.replace("{mod}", "Cmd+"),
 }));
 
-describe("EmptyState subtitle (Phase 8)", () => {
-  it("renders 'AI-native development environment' as the subtitle", () => {
+describe("EmptyState — workshop-atelier hero (v1.1 redesign)", () => {
+  it("renders the new tagline (instrument panel for working with code & agents)", () => {
     const html = renderToString(
       <EmptyState recentSessions={[]} onNew={() => {}} onRestore={() => {}} />,
     );
-    expect(html).toContain("AI-native development environment");
+    expect(html).toContain("instrument panel");
+    expect(html).toMatch(/code\s*(&amp;|&)\s*agents/);
   });
 
   it("does not render the legacy 'AI-native terminal & IDE' tagline", () => {
@@ -27,6 +32,58 @@ describe("EmptyState subtitle (Phase 8)", () => {
       <EmptyState recentSessions={[]} onNew={() => {}} onRestore={() => {}} />,
     );
     expect(html).not.toContain("AI-native terminal");
-    expect(html).not.toContain("AI-native terminal & IDE");
+    expect(html).not.toContain("AI-native development environment");
+  });
+
+  it("renders the contents-page index labels (I., II.)", () => {
+    const html = renderToString(
+      <EmptyState
+        recentSessions={[
+          {
+            id: "s1",
+            label: "old session",
+            color: "#000",
+            working_directory: "/Users/me/project",
+            closed_at: "2026-01-01T00:00:00Z",
+          } as never,
+        ]}
+        onNew={() => {}}
+        onRestore={() => {}}
+      />,
+    );
+    // Index numerals — "I." for the actions, "II." for the logbook.
+    expect(html).toContain(">I.<");
+    expect(html).toContain(">II.<");
+  });
+
+  it("renders the three primary tiles", () => {
+    const html = renderToString(
+      <EmptyState recentSessions={[]} onNew={() => {}} onRestore={() => {}} />,
+    );
+    expect(html).toContain("New session");
+    expect(html).toContain("Command palette");
+    expect(html).toContain("Context panel");
+  });
+
+  it("renders the marginalia logbook numbers when recent sessions exist", () => {
+    const html = renderToString(
+      <EmptyState
+        recentSessions={[
+          {
+            id: "s1",
+            label: "ira-site",
+            color: "#a78bfa",
+            working_directory: "/Users/me/projects/ira-site",
+            closed_at: "2026-01-01T00:00:00Z",
+          } as never,
+        ]}
+        onNew={() => {}}
+        onRestore={() => {}}
+      />,
+    );
+    // Marginalia numeral (№ 01 with the SERIF italic styling).
+    expect(html).toMatch(/№\s*01/);
+    // Session label is rendered.
+    expect(html).toContain("ira-site");
   });
 });

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,3 +1,25 @@
+/**
+ * Empty-state hero — what the user sees when there are no sessions
+ * open.  This is the 0→1 moment of the entire app, so it's designed
+ * as a piece of typography, not a button row:
+ *
+ *   - Newsreader serif sets a "hand-bound logbook" tone — Hermes
+ *     already loads it for the agent surface; here it gets the lead
+ *     role on the title cut.
+ *   - JetBrains Mono carries the operator voice (subtitle, shortcut
+ *     keys, command palette).
+ *   - Inter Tight handles connective tissue (paragraph copy, hints).
+ *
+ * Composition is deliberately asymmetric: a serif title cut by a
+ * brass rule + ornament glyph, action tiles laid out like a printed
+ * contents page, recent sessions treated as a margin-numbered
+ * logbook list.
+ *
+ * Motion: a one-shot orchestrated reveal on mount — title characters
+ * stagger in, the brass rule grows from the left, tiles fade up,
+ * recent sessions slide in last.  Reduced-motion drops it all to
+ * static.  No looping animations except the cursor block.
+ */
 import "../styles/components/EmptyState.css";
 import { SessionHistoryEntry } from "../state/SessionContext";
 import { fmt } from "../utils/platform";
@@ -32,40 +54,147 @@ function projectName(path: string): string {
   return parts[parts.length - 1] || path;
 }
 
+const TITLE_CHARS = "Hermes".split("");
+
 export function EmptyState({ recentSessions, onNew, onRestore }: EmptyStateProps) {
   return (
-    <div className="empty-state">
-      <div className="empty-state-logo">HERMES-IDE</div>
-      <p className="empty-state-subtitle">AI-native development environment</p>
-      <p className="empty-state-hint">Drop a session here or press <kbd>{fmt("{mod}N")}</kbd> to start</p>
-
-      <div className="empty-state-actions">
-        <button className="btn-primary" onClick={onNew}>New Session</button>
+    <div className="es-stage">
+      {/* Atmospheric layer — soft brass + cool orbs and a faint paper
+       * grain.  Sits behind everything; pointer-events: none. */}
+      <div className="es-atmosphere" aria-hidden="true">
+        <span className="es-orb es-orb-warm" />
+        <span className="es-orb es-orb-cool" />
+        <span className="es-grain" />
       </div>
 
-      <div className="empty-state-shortcuts">
-        <span><kbd>{fmt("{mod}N")}</kbd> New session</span>
-        <span><kbd>{fmt("{mod}K")}</kbd> Command palette</span>
-        <span><kbd>{fmt("{mod}E")}</kbd> Toggle context</span>
-      </div>
+      <div className="es-frame">
+        {/* ── Masthead ─────────────────────────────────────── */}
+        <header className="es-masthead">
+          <div className="es-eyebrow">
+            <span className="es-eyebrow-dot" aria-hidden="true" />
+            HERMES <span className="es-eyebrow-sep" aria-hidden="true">·</span> WORKSHOP
+            <span className="es-eyebrow-sep" aria-hidden="true">·</span> v1.1
+          </div>
 
-      {recentSessions.length > 0 && (
-        <div className="empty-state-recent">
-          <div className="empty-state-recent-title">Recent Sessions</div>
-          {recentSessions.slice(0, 5).map((entry) => (
+          <h1 className="es-title" aria-label="Hermes">
+            {TITLE_CHARS.map((c, i) => (
+              <span
+                key={i}
+                className="es-title-char"
+                style={{ animationDelay: `${120 + i * 60}ms` }}
+              >
+                {c}
+              </span>
+            ))}
+            <span className="es-title-period" aria-hidden="true">.</span>
+          </h1>
+
+          <div className="es-rule" aria-hidden="true">
+            <span className="es-rule-line" />
+            <span className="es-rule-glyph">❦</span>
+            <span className="es-rule-line es-rule-line-short" />
+          </div>
+
+          <p className="es-tagline">
+            <span className="es-tagline-mono">an instrument panel for working with code &amp; agents.</span>
+            <span className="es-cursor" aria-hidden="true" />
+          </p>
+        </header>
+
+        {/* ── Contents page — primary actions + shortcuts ──── */}
+        <section className="es-contents" aria-label="Start a session">
+          <div className="es-contents-label">
+            <span className="es-contents-num">I.</span>
+            <span className="es-contents-text">Begin a session</span>
+          </div>
+
+          <div className="es-tiles">
             <button
-              key={entry.id}
-              className="empty-state-recent-item"
-              onClick={() => onRestore(entry, true)}
+              className="es-tile es-tile-primary"
+              onClick={onNew}
+              type="button"
             >
-              <span className="recent-dot" style={{ background: entry.color }} />
-              <span className="recent-label">{entry.label}</span>
-              <span className="recent-path">{projectName(entry.working_directory)}</span>
-              {entry.closed_at && <span className="recent-time">{timeAgo(entry.closed_at)}</span>}
+              <span className="es-tile-marker" aria-hidden="true">▸</span>
+              <div className="es-tile-text">
+                <span className="es-tile-title">New session</span>
+                <span className="es-tile-desc">
+                  Open Claude in agent mode, attach folders, start typing.
+                </span>
+              </div>
+              <kbd className="es-tile-kbd">{fmt("{mod}N")}</kbd>
             </button>
-          ))}
-        </div>
-      )}
+
+            <div className="es-tile es-tile-secondary">
+              <span className="es-tile-marker" aria-hidden="true">▢</span>
+              <div className="es-tile-text">
+                <span className="es-tile-title">Command palette</span>
+                <span className="es-tile-desc">
+                  Jump to settings, themes, recent sessions, anywhere.
+                </span>
+              </div>
+              <kbd className="es-tile-kbd">{fmt("{mod}K")}</kbd>
+            </div>
+
+            <div className="es-tile es-tile-secondary">
+              <span className="es-tile-marker" aria-hidden="true">◇</span>
+              <div className="es-tile-text">
+                <span className="es-tile-title">Context panel</span>
+                <span className="es-tile-desc">
+                  MCP servers, memory, permissions — show or hide.
+                </span>
+              </div>
+              <kbd className="es-tile-kbd">{fmt("{mod}E")}</kbd>
+            </div>
+          </div>
+
+          <p className="es-hint">
+            or drop a folder onto the window to bind it as a workspace.
+          </p>
+        </section>
+
+        {/* ── Logbook — recent sessions, numbered like marginalia ── */}
+        {recentSessions.length > 0 && (
+          <section className="es-logbook" aria-label="Recent sessions">
+            <div className="es-contents-label">
+              <span className="es-contents-num">II.</span>
+              <span className="es-contents-text">Logbook</span>
+              <span className="es-contents-hint">most-recent first</span>
+            </div>
+
+            <ol className="es-recent-list">
+              {recentSessions.slice(0, 5).map((entry, i) => (
+                <li key={entry.id} className="es-recent-item-wrap">
+                  <button
+                    className="es-recent-item"
+                    onClick={() => onRestore(entry, true)}
+                    type="button"
+                  >
+                    <span className="es-recent-num">{`№ ${String(i + 1).padStart(2, "0")}`}</span>
+                    <span
+                      className="es-recent-dot"
+                      style={{ background: entry.color }}
+                      aria-hidden="true"
+                    />
+                    <span className="es-recent-label">{entry.label}</span>
+                    <span className="es-recent-path">{projectName(entry.working_directory)}</span>
+                    {entry.closed_at && (
+                      <span className="es-recent-time">{timeAgo(entry.closed_at)}</span>
+                    )}
+                    <span className="es-recent-arrow" aria-hidden="true">⤍</span>
+                  </button>
+                </li>
+              ))}
+            </ol>
+          </section>
+        )}
+
+        {/* ── Footer ──────────────────────────────────────── */}
+        <footer className="es-foot" aria-hidden="true">
+          <span className="es-foot-line" />
+          <span className="es-foot-text">made for the workshop</span>
+          <span className="es-foot-line" />
+        </footer>
+      </div>
     </div>
   );
 }

--- a/src/styles/components/EmptyState.css
+++ b/src/styles/components/EmptyState.css
@@ -1,96 +1,615 @@
-/* ─── Empty State ──────────────────────────────────────────── */
+/* ════════════════════════════════════════════════════════════════════
+ * Empty-state hero — workshop atelier composition
+ * ════════════════════════════════════════════════════════════════════
+ *
+ * The 0→1 moment.  Designed as a piece of typography first: serif
+ * Newsreader title cut by a brass rule with an ornament, asymmetric
+ * grid with a marginalia "I." / "II." index, motion staggered as a
+ * one-shot reveal so the whole composition resolves in ~1.5s on
+ * mount.  Theme tokens drive every color so the workshop palette
+ * paints whatever theme is active.
+ *
+ * Type:
+ *   - Newsreader (serif, already loaded)  → title + ornaments
+ *   - Inter Tight (display sans, loaded)   → headers, copy
+ *   - JetBrains Mono (loaded)              → kbd, paths, eyebrow
+ */
 
-.empty-state {
+.es-stage {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100%;
-  gap: var(--space-2);
-  flex: 1;
+  padding: 48px 40px;
+  background:
+    radial-gradient(
+      ellipse 100% 70% at 30% -10%,
+      color-mix(in srgb, var(--brass, var(--accent)) 6%, transparent),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 80% 60% at 80% 110%,
+      color-mix(in srgb, var(--accent) 4%, transparent),
+      transparent 70%
+    ),
+    var(--bg-0);
+  overflow: hidden;
 }
 
-.empty-state-logo {
-  font-size: 36px;
-  font-weight: 200;
-  color: var(--text-1);
-  letter-spacing: 8px;
+/* ─── Atmospheric layer — drifting orbs + paper grain ────────── */
+
+.es-atmosphere {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
 }
 
-.empty-state-subtitle {
-  font-size: var(--text-lg);
-  color: var(--text-3);
-  margin-bottom: var(--space-4);
+.es-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.55;
 }
 
-.empty-state-hint {
-  font-size: var(--text-md);
-  color: var(--text-3);
-  margin-bottom: var(--space-4);
+.es-orb-warm {
+  width: 520px;
+  height: 520px;
+  top: -160px;
+  left: -120px;
+  background: radial-gradient(circle at 30% 30%, var(--brass, var(--accent)), transparent 70%);
+  animation: es-orb-drift-warm 22s ease-in-out infinite;
 }
 
-.empty-state-actions { margin-bottom: 20px; }
-
-.btn-primary {
-  background: var(--accent);
-  border: none;
-  color: var(--bg-0);
-  padding: 10px 24px;
-  border-radius: var(--radius);
-  font-size: var(--text-lg);
-  font-weight: 500;
-  cursor: pointer;
-  transition: filter 0.15s;
-}
-.btn-primary:hover { filter: brightness(1.1); }
-
-.empty-state-shortcuts {
-  display: flex;
-  gap: 20px;
-  font-size: var(--text-md);
-  color: var(--text-3);
-  margin-bottom: 32px;
-}
-.empty-state-shortcuts span {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+.es-orb-cool {
+  width: 460px;
+  height: 460px;
+  bottom: -180px;
+  right: -100px;
+  background: radial-gradient(circle at 70% 70%, var(--accent), transparent 70%);
+  animation: es-orb-drift-cool 28s ease-in-out infinite;
+  opacity: 0.42;
 }
 
-.empty-state-recent { width: 360px; }
-
-.empty-state-recent-title {
-  font-size: var(--text-base);
-  font-weight: 600;
-  color: var(--text-3);
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-  margin-bottom: var(--space-2);
-  padding: 0 8px;
+@keyframes es-orb-drift-warm {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(1); }
+  50%      { transform: translate3d(40px, 30px, 0) scale(1.06); }
 }
 
-.empty-state-recent-item {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+@keyframes es-orb-drift-cool {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(1); }
+  50%      { transform: translate3d(-50px, -25px, 0) scale(1.04); }
+}
+
+/* Inline SVG noise — gives the surface a hand-bound paper feel
+ * without an HTTP fetch.  Set very low opacity. */
+.es-grain {
+  position: absolute;
+  inset: 0;
+  opacity: 0.06;
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.6'/></svg>");
+  mix-blend-mode: overlay;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .es-orb { animation: none; }
+}
+
+/* ─── Frame — content column with asymmetric max-widths ──────── */
+
+.es-frame {
+  position: relative;
+  z-index: 1;
   width: 100%;
-  padding: 8px 12px;
-  background: none;
-  border: 1px solid transparent;
-  border-radius: var(--radius);
-  cursor: pointer;
-  color: var(--text-1);
-  font-family: var(--font-ui);
-  font-size: var(--text-lg);
-  text-align: left;
-  transition: background 0.1s, border-color 0.1s;
-}
-.empty-state-recent-item:hover {
-  background: var(--bg-2);
-  border-color: var(--border);
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+  /* Slight left bias so the composition reads off-center, like a
+   * page in a printed book rather than centered web layout. */
+  padding-left: clamp(0px, 4vw, 48px);
 }
 
-.recent-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
-.recent-label { font-weight: 500; color: var(--text-0); }
-.recent-path { flex: 1; font-size: var(--text-base); color: var(--text-3); font-family: var(--font-mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.recent-time { font-size: var(--text-sm); color: var(--text-3); flex-shrink: 0; }
+/* ─── Masthead ───────────────────────────────────────────────── */
+
+.es-masthead {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.es-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font: 10px/1 var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-tertiary, var(--text-3));
+  opacity: 0;
+  transform: translateY(-2px);
+  animation: es-fade-in 0.5s ease-out 80ms forwards;
+}
+
+.es-eyebrow-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--brass, var(--accent));
+  box-shadow: 0 0 6px color-mix(in srgb, var(--brass, var(--accent)) 60%, transparent);
+}
+
+.es-eyebrow-sep {
+  color: color-mix(in srgb, var(--ink-tertiary, var(--text-3)) 50%, transparent);
+}
+
+.es-title {
+  margin: 0;
+  font-family: "Newsreader", "Lyon Text", "Charter", Georgia, serif;
+  font-weight: 500;
+  font-size: clamp(72px, 10vw, 124px);
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  color: var(--ink-primary, var(--text-0));
+  display: flex;
+  align-items: baseline;
+  gap: 0;
+}
+
+.es-title-char {
+  display: inline-block;
+  opacity: 0;
+  transform: translateY(40px) rotate(-3deg);
+  filter: blur(8px);
+  animation: es-title-char-in 0.9s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.es-title-period {
+  display: inline-block;
+  color: var(--brass, var(--accent));
+  font-style: italic;
+  margin-left: 4px;
+  opacity: 0;
+  animation: es-fade-in 0.5s ease-out 700ms forwards;
+}
+
+@keyframes es-title-char-in {
+  to {
+    opacity: 1;
+    transform: translateY(0) rotate(0);
+    filter: blur(0);
+  }
+}
+
+@keyframes es-fade-in {
+  to { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .es-title-char,
+  .es-title-period,
+  .es-eyebrow,
+  .es-rule-line,
+  .es-rule-glyph,
+  .es-tagline,
+  .es-tile,
+  .es-recent-item-wrap,
+  .es-foot,
+  .es-contents-label {
+    opacity: 1 !important;
+    transform: none !important;
+    filter: none !important;
+    animation: none !important;
+  }
+}
+
+/* ─── Brass rule + ornament ─────────────────────────────────── */
+
+.es-rule {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 6px 0 10px;
+}
+
+.es-rule-line {
+  height: 1.5px;
+  background:
+    linear-gradient(90deg,
+      transparent 0%,
+      var(--brass, var(--accent)) 30%,
+      var(--brass, var(--accent)) 70%,
+      transparent 100%);
+  flex: 1 1 auto;
+  max-width: 280px;
+  transform-origin: left center;
+  transform: scaleX(0);
+  animation: es-rule-grow 0.7s cubic-bezier(0.16, 1, 0.3, 1) 600ms forwards;
+}
+
+.es-rule-line-short {
+  max-width: 60px;
+}
+
+.es-rule-glyph {
+  font-family: "Newsreader", serif;
+  font-size: 18px;
+  color: var(--brass, var(--accent));
+  font-style: italic;
+  opacity: 0;
+  animation: es-fade-in 0.5s ease-out 950ms forwards;
+}
+
+@keyframes es-rule-grow {
+  to { transform: scaleX(1); }
+}
+
+/* ─── Tagline + cursor ─────────────────────────────────────── */
+
+.es-tagline {
+  margin: 0;
+  font-family: var(--font-display, var(--font-ui));
+  font-size: 17px;
+  line-height: 1.5;
+  color: var(--ink-secondary, var(--text-1));
+  letter-spacing: -0.005em;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  flex-wrap: wrap;
+  opacity: 0;
+  transform: translateY(6px);
+  animation: es-fade-in 0.6s ease-out 850ms forwards;
+}
+
+.es-tagline-mono {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-style: normal;
+  color: var(--ink-secondary, var(--text-1));
+  letter-spacing: 0.005em;
+}
+
+.es-cursor {
+  display: inline-block;
+  width: 8px;
+  height: 16px;
+  background: var(--brass, var(--accent));
+  margin-left: 4px;
+  vertical-align: -2px;
+  animation: es-cursor-blink 1.05s step-end infinite;
+}
+
+@keyframes es-cursor-blink {
+  50% { opacity: 0; }
+}
+
+/* ─── Contents-page label ──────────────────────────────────── */
+
+.es-contents-label {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin-bottom: 18px;
+  opacity: 0;
+  transform: translateY(4px);
+  animation: es-fade-in 0.5s ease-out 1000ms forwards;
+}
+
+.es-contents-num {
+  font-family: "Newsreader", serif;
+  font-style: italic;
+  font-size: 26px;
+  color: var(--brass, var(--accent));
+  line-height: 1;
+}
+
+.es-contents-text {
+  font: 12px/1 var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-secondary, var(--text-1));
+}
+
+.es-contents-hint {
+  font: 11px/1 var(--font-display, var(--font-ui));
+  font-style: italic;
+  color: var(--ink-tertiary, var(--text-3));
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+/* ─── Tile grid ────────────────────────────────────────────── */
+
+.es-tiles {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr 1fr;
+  gap: 14px;
+}
+
+@media (max-width: 720px) {
+  .es-tiles { grid-template-columns: 1fr; }
+}
+
+.es-tile {
+  appearance: none;
+  text-align: left;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: start;
+  gap: 14px;
+  padding: 18px 18px 16px;
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--bg-1) 70%, transparent) 0%,
+      color-mix(in srgb, var(--bg-1) 95%, transparent) 100%);
+  border: 1px solid var(--rule-strong, var(--rule));
+  border-radius: 10px;
+  cursor: pointer;
+  font-family: var(--font-display, var(--font-ui));
+  color: var(--ink-primary, var(--text-0));
+  position: relative;
+  overflow: hidden;
+  transition: transform 200ms cubic-bezier(0.16, 1, 0.3, 1),
+              border-color 200ms ease,
+              background 200ms ease;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: es-tile-in 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.es-tile:nth-of-type(1) { animation-delay: 1100ms; }
+.es-tile:nth-of-type(2) { animation-delay: 1180ms; }
+.es-tile:nth-of-type(3) { animation-delay: 1260ms; }
+
+@keyframes es-tile-in {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* The primary tile gets a subtle brass tint + a wider grid column
+ * so it visually leads.  Hover makes the whole tile lift and the
+ * tinted edge intensify. */
+.es-tile-primary {
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--brass, var(--accent)) 8%, var(--bg-1)) 0%,
+      color-mix(in srgb, var(--brass, var(--accent)) 4%, var(--bg-1)) 100%);
+  border-color: color-mix(in srgb, var(--brass, var(--accent)) 32%, var(--rule));
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--brass, var(--accent)) 18%, transparent) inset;
+}
+
+.es-tile:hover {
+  transform: translateY(-1px);
+  border-color: var(--brass, var(--accent));
+}
+
+.es-tile-primary:hover {
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--brass, var(--accent)) 14%, var(--bg-1)) 0%,
+      color-mix(in srgb, var(--brass, var(--accent)) 8%, var(--bg-1)) 100%);
+}
+
+.es-tile:active { transform: translateY(0); }
+
+.es-tile::after {
+  /* Subtle diagonal sheen that drifts across on hover. */
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    115deg,
+    transparent 30%,
+    color-mix(in srgb, var(--brass, var(--accent)) 8%, transparent) 50%,
+    transparent 70%
+  );
+  background-size: 200% 100%;
+  background-position: 200% 0;
+  pointer-events: none;
+  transition: background-position 600ms ease;
+}
+
+.es-tile:hover::after {
+  background-position: -100% 0;
+}
+
+.es-tile-marker {
+  font: 18px/1 "Newsreader", serif;
+  font-style: italic;
+  color: var(--brass, var(--accent));
+  margin-top: 1px;
+}
+
+.es-tile-secondary .es-tile-marker {
+  color: var(--ink-tertiary, var(--text-3));
+}
+
+.es-tile-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.es-tile-title {
+  font-family: "Newsreader", serif;
+  font-size: 22px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--ink-primary, var(--text-0));
+  line-height: 1.1;
+}
+
+.es-tile-secondary .es-tile-title {
+  font-size: 18px;
+}
+
+.es-tile-desc {
+  font: 12.5px/1.45 var(--font-display, var(--font-ui));
+  color: var(--ink-secondary, var(--text-1));
+  letter-spacing: -0.005em;
+}
+
+.es-tile-kbd {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  font: 10.5px/1 var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--ink-tertiary, var(--text-3));
+  padding: 4px 7px;
+  background: var(--bg-0);
+  border: 1px solid var(--rule, var(--border));
+  border-radius: 4px;
+  white-space: nowrap;
+  margin-top: 2px;
+  align-self: start;
+}
+
+.es-hint {
+  margin: 14px 0 0;
+  font: italic 13px/1.5 "Newsreader", serif;
+  color: var(--ink-tertiary, var(--text-3));
+  opacity: 0;
+  animation: es-fade-in 0.5s ease-out 1400ms forwards;
+}
+
+/* ─── Logbook — recent sessions ─────────────────────────────── */
+
+.es-recent-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.es-recent-item-wrap {
+  border-top: 1px solid color-mix(in srgb, var(--rule) 70%, transparent);
+  opacity: 0;
+  transform: translateX(-6px);
+  animation: es-recent-in 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.es-recent-item-wrap:last-child {
+  border-bottom: 1px solid color-mix(in srgb, var(--rule) 70%, transparent);
+}
+
+.es-recent-item-wrap:nth-child(1) { animation-delay: 1300ms; }
+.es-recent-item-wrap:nth-child(2) { animation-delay: 1360ms; }
+.es-recent-item-wrap:nth-child(3) { animation-delay: 1420ms; }
+.es-recent-item-wrap:nth-child(4) { animation-delay: 1480ms; }
+.es-recent-item-wrap:nth-child(5) { animation-delay: 1540ms; }
+
+@keyframes es-recent-in {
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.es-recent-item {
+  appearance: none;
+  background: none;
+  border: 0;
+  width: 100%;
+  display: grid;
+  grid-template-columns: max-content 8px 1fr max-content max-content max-content;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 4px;
+  text-align: left;
+  font-family: var(--font-display, var(--font-ui));
+  color: var(--ink-primary, var(--text-0));
+  cursor: pointer;
+  transition: background 160ms ease, padding 160ms ease;
+  border-radius: 4px;
+}
+
+.es-recent-item:hover {
+  background: color-mix(in srgb, var(--brass, var(--accent)) 4%, transparent);
+  padding-left: 10px;
+}
+
+.es-recent-num {
+  font: italic 11px/1 "Newsreader", serif;
+  color: var(--brass, var(--accent));
+  letter-spacing: 0.04em;
+  min-width: 36px;
+}
+
+.es-recent-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--bg-0) 40%, transparent);
+}
+
+.es-recent-label {
+  font-family: "Newsreader", serif;
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--ink-primary, var(--text-0));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.es-recent-path {
+  font: 11.5px/1.2 var(--font-mono);
+  color: var(--ink-tertiary, var(--text-3));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 240px;
+}
+
+.es-recent-time {
+  font: italic 11px/1 "Newsreader", serif;
+  color: var(--ink-tertiary, var(--text-3));
+}
+
+.es-recent-arrow {
+  font: 14px/1 var(--font-mono);
+  color: color-mix(in srgb, var(--brass, var(--accent)) 70%, transparent);
+  opacity: 0;
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.es-recent-item:hover .es-recent-arrow {
+  opacity: 1;
+  transform: translateX(2px);
+}
+
+/* ─── Footer ─────────────────────────────────────────────────── */
+
+.es-foot {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+  opacity: 0;
+  animation: es-fade-in 0.6s ease-out 1700ms forwards;
+}
+
+.es-foot-line {
+  height: 1px;
+  flex: 1 1 auto;
+  background: linear-gradient(90deg,
+    transparent,
+    color-mix(in srgb, var(--ink-tertiary, var(--text-3)) 30%, transparent),
+    transparent);
+}
+
+.es-foot-text {
+  font: italic 11px/1 "Newsreader", serif;
+  color: var(--ink-tertiary, var(--text-3));
+  letter-spacing: 0.02em;
+}


### PR DESCRIPTION
Old empty state was a centered logo + button + shortcut row.  Redesigned as a piece of typography worth landing on:

- Newsreader serif title with character-by-character staggered reveal
- Brass rule + ❦ ornament cutting under the title
- Eyebrow + tagline in JetBrains Mono, blinking cursor
- Asymmetric grid with marginalia I. / II. numerals
- Three tiles (1.6/1/1): primary New session in brass-tinted treatment, secondary Command palette + Context panel
- Recent sessions as a hairline-divided 'Logbook' with marginalia № 01 / № 02 numerals + hover ⤍ arrow
- Atmospheric drifting orbs + paper-grain overlay
- Reduced-motion guard kills every animation cleanly

Theme tokens drive every accent so each of the 30 themes paints the hero in its own colors.

3068 vitest passing.