### PR TITLE
Release v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hermes-ide",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1945,7 +1945,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-ide"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-ide"
-version = "1.0.0"
+version = "1.1.0"
 description = "AI-native terminal"
 authors = ["Gabriel Anhaia"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "HERMES-IDE",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "com.hermes-ide.terminal",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to v1.1.0 + release notes (already merged separately in #264).

Changes:
- \`package.json\`, \`src-tauri/tauri.conf.json\`, \`src-tauri/Cargo.toml\`, \`src-tauri/Cargo.lock\` all bumped 1.0.0 → 1.1.0
- Existing \`RELEASE_NOTES.md\` already covers the v1.1.0 changes (modern timeline, slash CLI dropdown + embedded terminal, MCP panel detail + actions, plan-mode + permissions fixes, classic compact opt-out)
- The in-app \`WhatsNewDialog\` will fire automatically on the next launch for users on 1.0.0 — its v1.1.0 changelog entry is already merged via #264 / #266 / #267 and now has a real version to anchor to

## What ships in 1.1.0

See \`RELEASE_NOTES.md\` for the user-facing announcement.  PR-by-PR summary for the record:

| PR | Highlight |
|---|---|
| #254 | Interactive tools fix (Send button silently dropped in plan mode + AskUserQuestion answers); per-theme archetype paint system; Esc kbd chip |
| #255 | Speaker-chip timeline + sans-serif body |
| #256 | MCP panel: status detail, restart/remove, real-name validator |
| #257 / #259 / #260 | MCP remove/add UX fixes (cloud-managed detection, optimistic hide, prewarm union) |
| #261 | Composer chip overlap fix; Cost section removed; activity-bar Context toggle wired; .aider noise filter; first-message loader; permission modal redesign |
| #262 | Slash CLI dropdown with in-app/terminal badges + embedded inline PTY |
| #263 | Context panel default-closed |
| #264 | v1.1.0 release notes draft + Settings → Appearance classic-compact toggle |
| #265–267 | What's New dialog visual redesign + per-feature CSS mockups |
| #268 | EmptyState workshop-atelier hero |

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test -- --run\` — 3068 passing
- [x] \`cargo test --lib\` — 220 passing
- [x] \`cargo clippy --lib -- -D warnings\` clean
- [ ] Visual smoke in dev: empty hero, slash dropdown, /mcp embedded terminal, MCP panel, classic-compact toggle, What's New (via \`localStorage.hermesPreviewWhatsNew = "1.1.0"\` then reload)

## After merge

I'll re-tag the squashed merge commit on main as \`v1.1.0\` and push the tag, since the local v1.1.0 tag from the bump script points at the unsquashed branch HEAD.