### PR TITLE
Fix Windows-only test failures in claude_config (unblocks v1.1.0 release)

### DIFF
--- a/src-tauri/src/claude_config/mod.rs
+++ b/src-tauri/src/claude_config/mod.rs
@@ -945,8 +945,7 @@ mod prewarm_tests {
         assert_eq!(got.len(), 2);
         // Normalize Windows backslashes to forward slashes so the
         // suffix checks are platform-agnostic.
-        let normalized: Vec<String> =
-            got.iter().map(|p| p.replace('\\', "/")).collect();
+        let normalized: Vec<String> = got.iter().map(|p| p.replace('\\', "/")).collect();
         assert!(normalized.iter().any(|p| p.ends_with("/.claude/CLAUDE.md")));
         assert!(normalized
             .iter()

--- a/src-tauri/src/claude_config/mod.rs
+++ b/src-tauri/src/claude_config/mod.rs
@@ -518,8 +518,13 @@ mod tests {
 
     #[test]
     fn canonicalise_memory_path_requires_md_extension() {
-        assert!(canonicalise_memory_path("/tmp/x.txt").is_err());
-        assert!(canonicalise_memory_path("/tmp/CLAUDE.md").is_ok());
+        // Use the platform's temp dir so the absolute-path check
+        // succeeds on Windows (where `/tmp/...` is not absolute).
+        let tmp = std::env::temp_dir();
+        let bad = tmp.join("x.txt");
+        let good = tmp.join("CLAUDE.md");
+        assert!(canonicalise_memory_path(bad.to_str().unwrap()).is_err());
+        assert!(canonicalise_memory_path(good.to_str().unwrap()).is_ok());
     }
 }
 
@@ -938,8 +943,12 @@ mod prewarm_tests {
 
         let got = read_static_memory_paths(Some(proj.path().to_string_lossy().into_owned()));
         assert_eq!(got.len(), 2);
-        assert!(got.iter().any(|p| p.ends_with("/.claude/CLAUDE.md")));
-        assert!(got
+        // Normalize Windows backslashes to forward slashes so the
+        // suffix checks are platform-agnostic.
+        let normalized: Vec<String> =
+            got.iter().map(|p| p.replace('\\', "/")).collect();
+        assert!(normalized.iter().any(|p| p.ends_with("/.claude/CLAUDE.md")));
+        assert!(normalized
             .iter()
             .any(|p| p.ends_with("/CLAUDE.md") && !p.contains(".claude")));
     }


### PR DESCRIPTION
## Summary
- Two unit tests in `src-tauri/src/claude_config/mod.rs` failed on `windows-2022` during the v1.1.0 release run, blocking installer builds for all three platforms.
- Both failures are Unix-path assumptions in the tests; production code is unchanged.

### Fixes
1. `canonicalise_memory_path_requires_md_extension` hard-coded `/tmp/CLAUDE.md`. On Windows that path is not absolute (no drive letter), so the function returns `Err(\"memory path must be absolute\")` before reaching the `.md` extension check. Use `std::env::temp_dir()` instead.
2. `pw_6_static_memory_paths_lists_existing_claude_md_files` asserted on `\"/.claude/CLAUDE.md\"` suffix, but `PathBuf` returns backslash-separated strings on Windows. Normalize `\\` → `/` before the suffix check.

## Test plan
- [x] Both tests pass locally on macOS (`cargo test --lib -- claude_config::tests::canonicalise_memory_path_requires_md_extension claude_config::prewarm_tests::pw_6_static_memory_paths_lists_existing_claude_md_files`).
- [ ] CI passes on `windows-2022` and `ubuntu-latest`.