### PR TITLE
Stop silently dropping imported prompts that share a name (closes #224)

### DIFF
--- a/src/__tests__/prompt-bundle.test.ts
+++ b/src/__tests__/prompt-bundle.test.ts
@@ -682,6 +682,180 @@ describe("importBundle", () => {
 		expect(templates).toHaveLength(1);
 	});
 
+	// ── Content-aware dedupe (issue #224) ────────────────────────────────
+
+	it("renames an imported template that shares a name but has different content", () => {
+		const existing = makeTemplate({
+			id: "ex-1",
+			name: "Shared Name",
+			fields: {
+				roleIds: [],
+				task: "EXISTING task body",
+				scope: "",
+				constraints: "",
+				styleSelections: [],
+				style: "",
+			},
+			recommendedRoles: [],
+			recommendedStyles: [],
+		});
+		const bundle: PromptBundle = {
+			_hermes_bundle_version: 1,
+			_hermes_app_version: "0.6.4",
+			_hermes_exported_at: "",
+			templates: [
+				makeTemplate({
+					id: "in-1",
+					name: "Shared Name",
+					fields: {
+						roleIds: [],
+						task: "INCOMING task body — clearly different",
+						scope: "",
+						constraints: "",
+						styleSelections: [],
+						style: "",
+					},
+					recommendedRoles: [],
+					recommendedStyles: [],
+				}),
+			],
+			roles: [],
+			styles: [],
+		};
+
+		const { templates, result } = importBundle(
+			bundle, [existing], [], [], BUILT_IN_ROLE_IDS, BUILT_IN_STYLE_IDS,
+		);
+
+		expect(result.templatesAdded).toBe(1);
+		expect(result.templatesRenamed).toBe(1);
+		expect(result.templatesSkipped).toBe(0);
+		expect(templates).toHaveLength(2);
+		// Original existing template kept as-is
+		expect(templates[0].name).toBe("Shared Name");
+		expect(templates[0].fields?.task).toBe("EXISTING task body");
+		// Incoming template renamed and added; its body is preserved
+		expect(templates[1].name).toBe("Shared Name (2)");
+		expect(templates[1].fields?.task).toBe("INCOMING task body — clearly different");
+	});
+
+	it("skips silently when name AND content match identically", () => {
+		// makeTemplate() returns the same default body, so this is a true duplicate.
+		const existing = makeTemplate({ id: "ex-1", name: "Same Everything" });
+		const bundle: PromptBundle = {
+			_hermes_bundle_version: 1,
+			_hermes_app_version: "0.6.4",
+			_hermes_exported_at: "",
+			templates: [makeTemplate({ id: "in-1", name: "Same Everything" })],
+			roles: [makeRole()],
+			styles: [makeStyle()],
+		};
+
+		const { templates, result } = importBundle(
+			bundle, [existing], [makeRole()], [makeStyle()], BUILT_IN_ROLE_IDS, BUILT_IN_STYLE_IDS,
+		);
+
+		expect(result.templatesAdded).toBe(0);
+		expect(result.templatesRenamed).toBe(0);
+		expect(result.templatesSkipped).toBe(1);
+		expect(templates).toHaveLength(1); // only the existing one remains
+	});
+
+	it("picks the next free suffix when (2) is also taken", () => {
+		const existingA = makeTemplate({
+			id: "ex-a", name: "Notes",
+			fields: { roleIds: [], task: "A", scope: "", constraints: "", styleSelections: [], style: "" },
+			recommendedRoles: [], recommendedStyles: [],
+		});
+		const existingB = makeTemplate({
+			id: "ex-b", name: "Notes (2)",
+			fields: { roleIds: [], task: "B", scope: "", constraints: "", styleSelections: [], style: "" },
+			recommendedRoles: [], recommendedStyles: [],
+		});
+		const bundle: PromptBundle = {
+			_hermes_bundle_version: 1,
+			_hermes_app_version: "0.6.4",
+			_hermes_exported_at: "",
+			templates: [makeTemplate({
+				id: "in-1", name: "Notes",
+				fields: { roleIds: [], task: "C — yet another body", scope: "", constraints: "", styleSelections: [], style: "" },
+				recommendedRoles: [], recommendedStyles: [],
+			})],
+			roles: [],
+			styles: [],
+		};
+
+		const { templates, result } = importBundle(
+			bundle, [existingA, existingB], [], [], BUILT_IN_ROLE_IDS, BUILT_IN_STYLE_IDS,
+		);
+
+		expect(result.templatesRenamed).toBe(1);
+		expect(templates).toHaveLength(3);
+		expect(templates[2].name).toBe("Notes (3)");
+		expect(templates[2].fields?.task).toBe("C — yet another body");
+	});
+
+	it("renames against built-in template names with differing content", () => {
+		const builtInTemplates = [
+			makeTemplate({
+				id: "builtin-1", name: "Code Review", builtIn: true,
+				fields: { roleIds: [], task: "official body", scope: "", constraints: "", styleSelections: [], style: "" },
+				recommendedRoles: [], recommendedStyles: [],
+			}),
+		];
+		const bundle: PromptBundle = {
+			_hermes_bundle_version: 1,
+			_hermes_app_version: "0.6.4",
+			_hermes_exported_at: "",
+			templates: [makeTemplate({
+				id: "in-1", name: "Code Review",
+				fields: { roleIds: [], task: "my custom variant", scope: "", constraints: "", styleSelections: [], style: "" },
+				recommendedRoles: [], recommendedStyles: [],
+			})],
+			roles: [],
+			styles: [],
+		};
+
+		const { templates, result } = importBundle(
+			bundle, [], [], [], BUILT_IN_ROLE_IDS, BUILT_IN_STYLE_IDS, builtInTemplates,
+		);
+
+		expect(result.templatesAdded).toBe(1);
+		expect(result.templatesRenamed).toBe(1);
+		expect(result.templatesSkipped).toBe(0);
+		expect(templates).toHaveLength(1);
+		expect(templates[0].name).toBe("Code Review (2)");
+		expect(templates[0].fields?.task).toBe("my custom variant");
+	});
+
+	it("treats whitespace and case differences in name as the same for collision purposes", () => {
+		const existing = makeTemplate({
+			id: "ex-1", name: "  My Template  ",
+			fields: { roleIds: [], task: "v1", scope: "", constraints: "", styleSelections: [], style: "" },
+			recommendedRoles: [], recommendedStyles: [],
+		});
+		const bundle: PromptBundle = {
+			_hermes_bundle_version: 1,
+			_hermes_app_version: "0.6.4",
+			_hermes_exported_at: "",
+			templates: [makeTemplate({
+				id: "in-1", name: "MY TEMPLATE",
+				fields: { roleIds: [], task: "v2", scope: "", constraints: "", styleSelections: [], style: "" },
+				recommendedRoles: [], recommendedStyles: [],
+			})],
+			roles: [],
+			styles: [],
+		};
+
+		const { result } = importBundle(
+			bundle, [existing], [], [], BUILT_IN_ROLE_IDS, BUILT_IN_STYLE_IDS,
+		);
+
+		// Different content, so the name collision triggers a rename, not a skip.
+		expect(result.templatesRenamed).toBe(1);
+		expect(result.templatesSkipped).toBe(0);
+	});
+
 	it("handles template with missing fields gracefully", () => {
 		const bundle: PromptBundle = {
 			_hermes_bundle_version: 1,

--- a/src/components/PromptComposer.tsx
+++ b/src/components/PromptComposer.tsx
@@ -436,10 +436,13 @@ export function PromptComposer({ sessionId, onClose, addToast }: PromptComposerP
       if (result.templatesAdded > 0) parts.push(`${result.templatesAdded} template${result.templatesAdded === 1 ? "" : "s"}`);
       if (result.rolesAdded > 0) parts.push(`${result.rolesAdded} role${result.rolesAdded === 1 ? "" : "s"}`);
       if (result.stylesAdded > 0) parts.push(`${result.stylesAdded} style${result.stylesAdded === 1 ? "" : "s"}`);
-      const skipped = result.templatesSkipped > 0 ? ` (${result.templatesSkipped} skipped)` : "";
+      const notes: string[] = [];
+      if (result.templatesRenamed > 0) notes.push(`${result.templatesRenamed} renamed to avoid name conflict`);
+      if (result.templatesSkipped > 0) notes.push(`${result.templatesSkipped} skipped as duplicate${result.templatesSkipped === 1 ? "" : "s"}`);
+      const suffix = notes.length > 0 ? ` (${notes.join(", ")})` : "";
       const msg = parts.length > 0
-        ? `Imported ${parts.join(", ")}${skipped}`
-        : `Nothing new to import${skipped}`;
+        ? `Imported ${parts.join(", ")}${suffix}`
+        : `Nothing new to import${suffix}`;
       addToast?.({ message: msg, type: parts.length > 0 ? "success" : "info", duration: 4000 });
     } catch (err) {
       console.error("[PromptComposer] Import failed:", err);

--- a/src/lib/promptBundle.ts
+++ b/src/lib/promptBundle.ts
@@ -23,6 +23,7 @@ export interface PromptBundle {
 export interface BundleImportResult {
 	templatesAdded: number;
 	templatesSkipped: number;
+	templatesRenamed: number;
 	rolesAdded: number;
 	stylesAdded: number;
 }
@@ -162,8 +163,13 @@ export function validateBundle(
  * Strategy:
  * - Roles/styles: deduplicate by label (case-insensitive). If match found,
  *   reuse existing ID. Otherwise add with a regenerated ID.
- * - Templates: deduplicate by name (case-insensitive). If match found,
- *   skip. Otherwise add with a regenerated ID. All role/style refs remapped.
+ * - Templates: compare by name (case-insensitive) AND content fingerprint.
+ *   - Name match + fingerprint match: silently skip (true duplicate).
+ *   - Name match + fingerprint differs: auto-rename to "Name (2)" (or the
+ *     next free integer suffix) and import — preserves the incoming content
+ *     instead of silently dropping it.
+ *   - No name match: add with a regenerated ID.
+ *   All role/style refs are remapped in either case.
  */
 export function importBundle(
 	bundle: PromptBundle,
@@ -184,6 +190,7 @@ export function importBundle(
 	const result: BundleImportResult = {
 		templatesAdded: 0,
 		templatesSkipped: 0,
+		templatesRenamed: 0,
 		rolesAdded: 0,
 		stylesAdded: 0,
 	};
@@ -229,17 +236,21 @@ export function importBundle(
 	}
 
 	// ── Step 3: Import templates ──────────────────────────────────────
-	const existingNameSet = new Set(
-		[...existingTemplates, ...builtInTemplates].map((t) => t.name.toLowerCase()),
-	);
+	// Index existing templates (user + built-in) by normalized name so we
+	// can detect collisions and, when needed, compare content fingerprints
+	// to decide skip-vs-rename.
+	const nameKey = (n: string) => n.trim().toLowerCase();
+	const existingByName = new Map<string, PromptTemplate[]>();
+	for (const t of [...existingTemplates, ...builtInTemplates]) {
+		const key = nameKey(t.name);
+		const list = existingByName.get(key);
+		if (list) list.push(t);
+		else existingByName.set(key, [t]);
+	}
 	const newTemplates = [...existingTemplates];
 
 	for (let i = 0; i < bundle.templates.length; i++) {
 		const tpl = bundle.templates[i];
-		if (existingNameSet.has(tpl.name.toLowerCase())) {
-			result.templatesSkipped++;
-			continue;
-		}
 
 		const newId = `user-${now}-${i}`;
 		const remapped: PromptTemplate = {
@@ -262,8 +273,26 @@ export function importBundle(
 			})),
 		};
 
+		const collisions = existingByName.get(nameKey(tpl.name));
+		if (collisions && collisions.length > 0) {
+			const incomingFp = templateFingerprint(remapped);
+			const isTrueDuplicate = collisions.some(
+				(existing) => templateFingerprint(existing) === incomingFp,
+			);
+			if (isTrueDuplicate) {
+				result.templatesSkipped++;
+				continue;
+			}
+			// Same name, different body: keep the user's content by renaming.
+			remapped.name = nextAvailableName(tpl.name.trim(), existingByName);
+			result.templatesRenamed++;
+		}
+
 		newTemplates.push(remapped);
-		existingNameSet.add(tpl.name.toLowerCase());
+		const finalKey = nameKey(remapped.name);
+		const list = existingByName.get(finalKey);
+		if (list) list.push(remapped);
+		else existingByName.set(finalKey, [remapped]);
 		result.templatesAdded++;
 	}
 
@@ -286,4 +315,44 @@ function remapId(
 ): string {
 	if (builtInIds.has(id)) return id;
 	return idMap.get(id) ?? id;
+}
+
+/** Deterministic fingerprint of a template's substantive prose content, used
+ *  to decide whether a name collision is a true duplicate (skip) or a real
+ *  content change that should be preserved by renaming.
+ *
+ *  Only user-authored prose is fingerprinted (name, category, description,
+ *  task, scope, constraints, style). Identity-only fields (id, builtIn,
+ *  group) are excluded, and role/style ID arrays are deliberately excluded
+ *  too: those IDs get regenerated on every import, so two semantically-
+ *  equivalent templates would otherwise fingerprint differently after one
+ *  round trip. The trade-off is that two templates that differ ONLY in
+ *  which roles/styles they reference will be treated as duplicates — that
+ *  is acceptable because it matches the user's intuition of "same template"
+ *  and the import path already remaps those references on each pass. */
+function templateFingerprint(tpl: PromptTemplate): string {
+	const stable = {
+		name: tpl.name.trim().toLowerCase(),
+		category: tpl.category ?? "",
+		description: (tpl as { description?: string }).description ?? "",
+		task: tpl.fields?.task ?? "",
+		scope: tpl.fields?.scope ?? "",
+		constraints: tpl.fields?.constraints ?? "",
+		style: tpl.fields?.style ?? "",
+	};
+	return JSON.stringify(stable);
+}
+
+/** Pick the first unused "Name (N)" suffix for a template whose base name
+ *  is already taken by a different-content template. Starts at (2). */
+function nextAvailableName(
+	baseName: string,
+	existingByName: Map<string, PromptTemplate[]>,
+): string {
+	for (let n = 2; n < 1000; n++) {
+		const candidate = `${baseName} (${n})`;
+		if (!existingByName.has(candidate.trim().toLowerCase())) return candidate;
+	}
+	// Pathological fallback: use timestamp to guarantee uniqueness.
+	return `${baseName} (${Date.now()})`;
 }


### PR DESCRIPTION
When importing a prompt bundle, templates whose name matched an existing one were skipped without notice, even if the body differed entirely — quiet data loss. Now compare by name AND a content fingerprint of the substantive prose (task, scope, constraints, style, category, description):

- Name matches + fingerprint matches: silent skip (true duplicate).
- Name matches + fingerprint differs: auto-rename to "Name (2)" (or the next free integer suffix) and import — preserves the user's content.
- No name match: add as before.

The fingerprint deliberately ignores role/style ID arrays because those IDs get regenerated on every import, so equivalent templates would otherwise stop matching after one round trip. The toast now reports the renamed count alongside the skipped count.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

<!-- Link to the issue or discussion that approved this change -->
<!-- Feature PRs without a linked discussion will be closed -->

Closes #

## Type of Change

- [x] Bug fix
- [ ] Performance improvement
- [ ] New feature (approved in discussion)
- [ ] Documentation
- [ ] Refactoring (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [x] `npx tsc --noEmit` passes
- [x] `npm run test` passes
- [x] I have signed the [CLA](../CLA.md)
