### PR TITLE
Don't record keystrokes typed inside a TUI as shell commands (closes …

### DIFF
--- a/src-tauri/src/pty/analyzer.rs
+++ b/src-tauri/src/pty/analyzer.rs
@@ -122,6 +122,12 @@ pub struct OutputAnalyzer {
     pub ai_launch_failed: Option<String>,
     /// Provider being launched (set before launch, cleared after check window).
     pub ai_launching_provider: Option<String>,
+    /// True when the terminal is currently inside an "alternate screen buffer"
+    /// (DEC private modes 1049 / 1047 / 47), i.e. running a full-screen TUI
+    /// like vim, less, htop, nano, ssh, or the Claude/Codex CLIs. While this
+    /// is true the input path skips the line-buffer machinery so random
+    /// keystrokes typed at the TUI don't get recorded as shell commands.
+    pub in_alternate_screen: bool,
 }
 
 impl Default for OutputAnalyzer {
@@ -168,6 +174,7 @@ impl OutputAnalyzer {
             ai_launch_check_remaining: 0,
             ai_launch_failed: None,
             ai_launching_provider: None,
+            in_alternate_screen: false,
         }
     }
 
@@ -215,6 +222,11 @@ impl OutputAnalyzer {
                 }
             }
         }
+
+        // Track alternate-screen-buffer state on the raw byte stream before
+        // ANSI escapes are stripped. Used by the input path to suppress
+        // line-buffer recording while a TUI owns the screen.
+        Self::update_alt_screen_state(&mut self.in_alternate_screen, raw);
 
         // Strip ANSI escapes once — reused for busy detection, cost/token scanning,
         // and line-by-line analysis below.
@@ -690,4 +702,133 @@ fn percentile(samples: &VecDeque<f64>, pct: f64) -> Option<f64> {
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let idx = ((pct / 100.0) * (sorted.len() as f64 - 1.0)).round() as usize;
     sorted.get(idx).copied()
+}
+
+impl OutputAnalyzer {
+    /// Scan `raw` for DEC private-mode set/reset sequences that toggle the
+    /// alternate screen buffer and update `state` to reflect the most-recent
+    /// transition observed. Handles all three variants in common use:
+    ///   - `\x1b[?1049h` / `\x1b[?1049l` (xterm-style, modern default)
+    ///   - `\x1b[?1047h` / `\x1b[?1047l`
+    ///   - `\x1b[?47h`   / `\x1b[?47l`   (older terminals)
+    /// Only the latest transition in a chunk matters — if a TUI exits and a
+    /// new one starts inside the same PTY read, we should land on "in TUI".
+    fn update_alt_screen_state(state: &mut bool, raw: &[u8]) {
+        const PATTERNS: &[(&[u8], bool)] = &[
+            (b"\x1b[?1049h", true),
+            (b"\x1b[?1049l", false),
+            (b"\x1b[?1047h", true),
+            (b"\x1b[?1047l", false),
+            (b"\x1b[?47h", true),
+            (b"\x1b[?47l", false),
+        ];
+        let mut latest: Option<(usize, bool)> = None;
+        for (needle, enter) in PATTERNS {
+            if needle.is_empty() || raw.len() < needle.len() {
+                continue;
+            }
+            let mut start = 0usize;
+            while let Some(rel) = raw[start..]
+                .windows(needle.len())
+                .position(|w| w == *needle)
+            {
+                let abs = start + rel;
+                match latest {
+                    Some((cur, _)) if cur >= abs => {}
+                    _ => latest = Some((abs, *enter)),
+                }
+                start = abs + needle.len();
+            }
+        }
+        if let Some((_, enter)) = latest {
+            *state = enter;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alt_screen_enter_sets_state() {
+        let mut s = false;
+        OutputAnalyzer::update_alt_screen_state(&mut s, b"\x1b[?1049h");
+        assert!(s, "1049h should enter alt screen");
+    }
+
+    #[test]
+    fn alt_screen_exit_clears_state() {
+        let mut s = true;
+        OutputAnalyzer::update_alt_screen_state(&mut s, b"some output\x1b[?1049l\r\n");
+        assert!(!s, "1049l should leave alt screen");
+    }
+
+    #[test]
+    fn alt_screen_older_1047_variants_supported() {
+        let mut s = false;
+        OutputAnalyzer::update_alt_screen_state(&mut s, b"\x1b[?1047h");
+        assert!(s);
+        OutputAnalyzer::update_alt_screen_state(&mut s, b"\x1b[?1047l");
+        assert!(!s);
+    }
+
+    #[test]
+    fn alt_screen_oldest_47_variants_supported() {
+        let mut s = false;
+        OutputAnalyzer::update_alt_screen_state(&mut s, b"\x1b[?47h");
+        assert!(s);
+        OutputAnalyzer::update_alt_screen_state(&mut s, b"\x1b[?47l");
+        assert!(!s);
+    }
+
+    #[test]
+    fn alt_screen_latest_transition_in_chunk_wins() {
+        // Enter, exit, re-enter — final state should be "in alt screen".
+        let mut s = false;
+        let chunk = b"\x1b[?1049h...content...\x1b[?1049l...gap...\x1b[?1049h";
+        OutputAnalyzer::update_alt_screen_state(&mut s, chunk);
+        assert!(s, "last transition (re-enter) should win");
+    }
+
+    #[test]
+    fn alt_screen_state_persists_when_chunk_has_no_transitions() {
+        let mut s = true;
+        OutputAnalyzer::update_alt_screen_state(&mut s, b"plain output, no escapes");
+        assert!(s, "unchanged when no toggle present");
+
+        let mut s2 = false;
+        OutputAnalyzer::update_alt_screen_state(&mut s2, b"plain output, no escapes");
+        assert!(!s2, "unchanged when no toggle present");
+    }
+
+    #[test]
+    fn alt_screen_process_integration() {
+        // End-to-end through process(): receive TUI enter, then receive
+        // some content, then receive exit. The flag tracks each transition.
+        let mut a = OutputAnalyzer::new();
+        assert!(!a.in_alternate_screen);
+
+        a.process(b"\x1b[?1049h\x1b[2J");
+        assert!(a.in_alternate_screen, "should be in alt screen after enter");
+
+        a.process(b"some TUI content with cursor moves \x1b[5;10H more text");
+        assert!(a.in_alternate_screen, "still in alt screen during TUI");
+
+        a.process(b"\x1b[?1049l");
+        assert!(!a.in_alternate_screen, "should have left alt screen");
+    }
+
+    #[test]
+    fn alt_screen_unrelated_dec_modes_do_not_toggle() {
+        // 1049/1047/47 are the alt-screen modes; other DEC private modes
+        // (e.g. ?25h hide-cursor, ?2004h bracketed-paste) must NOT affect us.
+        let mut s = false;
+        OutputAnalyzer::update_alt_screen_state(&mut s, b"\x1b[?25h\x1b[?2004h");
+        assert!(!s, "unrelated DEC modes should not enter alt screen");
+
+        let mut s2 = true;
+        OutputAnalyzer::update_alt_screen_state(&mut s2, b"\x1b[?25l\x1b[?2004l");
+        assert!(s2, "unrelated DEC modes should not leave alt screen");
+    }
 }

--- a/src-tauri/src/pty/commands.rs
+++ b/src-tauri/src/pty/commands.rs
@@ -1735,33 +1735,47 @@ pub fn write_to_session(
     if let Ok(mut a) = session.analyzer.lock() {
         a.mark_input_sent();
 
-        let text = String::from_utf8_lossy(&bytes);
-        let is_enter = text.contains('\r') || text.contains('\n');
+        // While a TUI owns the screen (vim, less, htop, claude, etc.) the
+        // line buffer must stay quiescent. Keystrokes typed at a TUI are
+        // application input, not shell commands, and recording them would
+        // pollute the execution-node stream and feed garbage into the
+        // command-prediction system (issue #172).
+        if !a.in_alternate_screen {
+            let text = String::from_utf8_lossy(&bytes);
+            let is_enter = text.contains('\r') || text.contains('\n');
 
-        // Accumulate printable chars into the line buffer
-        for ch in text.chars() {
-            if ch == '\r' || ch == '\n' {
-                // Enter pressed — commit the accumulated line
-                continue;
-            } else if ch == '\x7f' || ch == '\x08' {
-                // Backspace — pop last char
-                a.input_line_buffer.pop();
-            } else if ch == '\x03' {
-                // Ctrl+C — clear buffer
-                a.input_line_buffer.clear();
-            } else if !ch.is_control() {
-                a.input_line_buffer.push(ch);
+            // Accumulate printable chars into the line buffer
+            for ch in text.chars() {
+                if ch == '\r' || ch == '\n' {
+                    // Enter pressed — commit the accumulated line
+                    continue;
+                } else if ch == '\x7f' || ch == '\x08' {
+                    // Backspace — pop last char
+                    a.input_line_buffer.pop();
+                } else if ch == '\x03' {
+                    // Ctrl+C — clear buffer
+                    a.input_line_buffer.clear();
+                } else if !ch.is_control() {
+                    a.input_line_buffer.push(ch);
+                }
             }
-        }
 
-        if is_enter && !a.input_line_buffer.is_empty() {
-            let line = a.input_line_buffer.drain(..).collect::<String>();
-            a.mark_input_line(&line);
-            let cwd = a.current_cwd.clone().unwrap_or_default();
-            a.start_node(&cwd);
-        } else if is_enter {
-            // Enter with empty buffer — still mark activity
-            a.input_line_buffer.clear();
+            if is_enter && !a.input_line_buffer.is_empty() {
+                let line = a.input_line_buffer.drain(..).collect::<String>();
+                a.mark_input_line(&line);
+                let cwd = a.current_cwd.clone().unwrap_or_default();
+                a.start_node(&cwd);
+            } else if is_enter {
+                // Enter with empty buffer — still mark activity
+                a.input_line_buffer.clear();
+            }
+        } else {
+            // Defensive: a TUI may launch mid-line. Any half-typed shell
+            // command in the buffer at that point isn't a real command —
+            // drop it so we don't commit it on the next post-TUI Enter.
+            if !a.input_line_buffer.is_empty() {
+                a.input_line_buffer.clear();
+            }
         }
     }
 


### PR DESCRIPTION
…#172)

When the terminal hands control to a full-screen TUI — vim, less, htop, nano, ssh, or the Claude/Codex CLIs — every printable keystroke was still being accumulated in the input line buffer and committed on Enter as if it were a shell command. That polluted the execution-node stream and fed garbage sequences into the command-prediction system, surfacing as "AI suggestions with random text" after the user exited the TUI.

Agent detection alone wasn't enough to gate this: it has detection lag on Claude/Codex (keystrokes typed during the first second land before detection completes) and doesn't cover non-AI TUIs at all.

Fix: the analyzer now tracks DEC private-mode set/reset sequences on the PTY output stream — 1049/1047/47 set or reset — to know when a TUI owns the screen. While the alt-screen flag is true, write_to_session skips the line-buffer machinery entirely. Keystrokes still reach the PTY (the TUI receives input normally); they just stop being recorded.

Also clears any half-typed shell command from the buffer when a TUI launches mid-line, so it doesn't get committed on the next post-TUI Enter.

8 new Rust unit tests cover the three escape variants, latest-transition- wins semantics, persistence across chunks with no transitions, and a process()-level end-to-end. All 244 lib tests pass.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

<!-- Link to the issue or discussion that approved this change -->
<!-- Feature PRs without a linked discussion will be closed -->

Closes #

## Type of Change

- [x] Bug fix
- [ ] Performance improvement
- [ ] New feature (approved in discussion)
- [ ] Documentation
- [ ] Refactoring (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [x] `npx tsc --noEmit` passes
- [x] `npm run test` passes
- [x] I have signed the [CLA](../CLA.md)
