### PR TITLE
Editor font size: Mod+= / Mod+- / Mod+0 shortcuts (closes #193)

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -2362,6 +2362,7 @@ const VALID_SETTING_KEYS: &[&str] = &[
     "ui_scale",
     "font_size",
     "font_family",
+    "editor_font_size",
     "agent_timeline_style",
     // Terminal
     "default_shell",

--- a/src/__tests__/editor-font-size.test.ts
+++ b/src/__tests__/editor-font-size.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+	DEFAULT_EDITOR_FONT_PX,
+	MIN_EDITOR_FONT_PX,
+	MAX_EDITOR_FONT_PX,
+	nextEditorFontSize,
+	parseEditorFontSize,
+} from "../editor/editorFontSize";
+
+describe("parseEditorFontSize", () => {
+	it("returns the default for missing input", () => {
+		expect(parseEditorFontSize(undefined)).toBe(DEFAULT_EDITOR_FONT_PX);
+		expect(parseEditorFontSize(null)).toBe(DEFAULT_EDITOR_FONT_PX);
+		expect(parseEditorFontSize("")).toBe(DEFAULT_EDITOR_FONT_PX);
+	});
+
+	it("returns the default for unparseable input", () => {
+		expect(parseEditorFontSize("not a number")).toBe(DEFAULT_EDITOR_FONT_PX);
+		expect(parseEditorFontSize("NaN")).toBe(DEFAULT_EDITOR_FONT_PX);
+	});
+
+	it("accepts in-range integers", () => {
+		expect(parseEditorFontSize("14")).toBe(14);
+		expect(parseEditorFontSize("18")).toBe(18);
+	});
+
+	it("clamps below the minimum", () => {
+		expect(parseEditorFontSize("1")).toBe(MIN_EDITOR_FONT_PX);
+		expect(parseEditorFontSize("-100")).toBe(MIN_EDITOR_FONT_PX);
+	});
+
+	it("clamps above the maximum", () => {
+		expect(parseEditorFontSize("999")).toBe(MAX_EDITOR_FONT_PX);
+	});
+
+	it("parses integer prefixes (parseInt semantics)", () => {
+		expect(parseEditorFontSize("14px")).toBe(14);
+	});
+});
+
+describe("nextEditorFontSize", () => {
+	it("increments by 1 on increase", () => {
+		expect(nextEditorFontSize(13, "increase")).toBe(14);
+	});
+
+	it("decrements by 1 on decrease", () => {
+		expect(nextEditorFontSize(13, "decrease")).toBe(12);
+	});
+
+	it("snaps back to the default on reset", () => {
+		expect(nextEditorFontSize(20, "reset")).toBe(DEFAULT_EDITOR_FONT_PX);
+		expect(nextEditorFontSize(8, "reset")).toBe(DEFAULT_EDITOR_FONT_PX);
+	});
+
+	it("clamps at the upper bound on increase", () => {
+		expect(nextEditorFontSize(MAX_EDITOR_FONT_PX, "increase")).toBe(MAX_EDITOR_FONT_PX);
+	});
+
+	it("clamps at the lower bound on decrease", () => {
+		expect(nextEditorFontSize(MIN_EDITOR_FONT_PX, "decrease")).toBe(MIN_EDITOR_FONT_PX);
+	});
+});

--- a/src/editor/EditorPane.tsx
+++ b/src/editor/EditorPane.tsx
@@ -17,6 +17,12 @@ import { search, searchKeymap, openSearchPanel, gotoLine, selectNextOccurrence }
 import { getLanguageSupport } from "./languageRegistry";
 import { createSyntaxHighlighting } from "./editorTheme";
 import { Minimap } from "./Minimap";
+import {
+  DEFAULT_EDITOR_FONT_PX,
+  nextEditorFontSize,
+  parseEditorFontSize,
+} from "./editorFontSize";
+import { getSetting, setSetting } from "../api/settings";
 
 export interface CursorInfo {
   line: number;
@@ -50,7 +56,8 @@ const baseTheme = EditorView.theme({
   ".cm-scroller": {
     overflow: "auto",
     fontFamily: "var(--font-mono)",
-    fontSize: "var(--text-sm)",
+    // fontSize is owned by the fontSizeCompartment so Mod+= / Mod+- /
+    // Mod+0 can update it live without rebuilding the EditorState.
     scrollbarWidth: "thin",
     scrollbarColor: "var(--bg-active) transparent",
   },
@@ -172,6 +179,12 @@ const baseTheme = EditorView.theme({
   },
 });
 
+function buildFontSizeExtension(px: number) {
+  return EditorView.theme({
+    ".cm-scroller": { fontSize: `${px}px` },
+  });
+}
+
 function buildIndentExtensions(config: IndentConfig) {
   const unit = config.useTabs ? "\t" : " ".repeat(config.size);
   const insertStr = unit;
@@ -212,6 +225,12 @@ export function EditorPane({ content, language, onContentChange, onSave, onCurso
   const themeCompartment = useRef(new Compartment());
   const wrapCompartment = useRef(new Compartment());
   const indentCompartment = useRef(new Compartment());
+  const fontSizeCompartment = useRef(new Compartment());
+  // Live font size, mutated by Mod+= / Mod+- / Mod+0 inside the keymap.
+  // Held in a ref (not React state) so shortcut handlers can update it
+  // without triggering a re-creation of the EditorView in the useEffect
+  // below that depends on `language`.
+  const fontSizePxRef = useRef<number>(DEFAULT_EDITOR_FONT_PX);
 
   // Keep callback refs up to date
   onContentChangeRef.current = onContentChange;
@@ -219,6 +238,22 @@ export function EditorPane({ content, language, onContentChange, onSave, onCurso
   onCursorChangeRef.current = onCursorChange;
 
   const effectiveIndent: IndentConfig = indentConfig ?? { useTabs: false, size: 2 };
+
+  /** Apply a font-size change to the live EditorView and persist it. */
+  const applyFontSizeAction = (action: "increase" | "decrease" | "reset"): boolean => {
+    const view = viewRef.current;
+    if (!view) return false;
+    const next = nextEditorFontSize(fontSizePxRef.current, action);
+    if (next === fontSizePxRef.current) return true; // already clamped at bound
+    fontSizePxRef.current = next;
+    view.dispatch({
+      effects: fontSizeCompartment.current.reconfigure(buildFontSizeExtension(next)),
+    });
+    setSetting("editor_font_size", String(next)).catch((err) =>
+      console.warn("[EditorPane] Failed to persist editor_font_size:", err),
+    );
+    return true;
+  };
 
   // Create and destroy EditorView
   useEffect(() => {
@@ -243,6 +278,7 @@ export function EditorPane({ content, language, onContentChange, onSave, onCurso
         search({ top: true }),
         wrapCompartment.current.of(wordWrap ? EditorView.lineWrapping : []),
         indentCompartment.current.of(buildIndentExtensions(effectiveIndent)),
+        fontSizeCompartment.current.of(buildFontSizeExtension(fontSizePxRef.current)),
         keymap.of([
           ...closeBracketsKeymap,
           ...defaultKeymap,
@@ -251,6 +287,12 @@ export function EditorPane({ content, language, onContentChange, onSave, onCurso
           ...foldKeymap,
           // ── Save ──
           { key: "Mod-s", run: () => { onSaveRef.current(); return true; } },
+          // ── Font size (issue #193). Bind both `=` and `+` so users with
+          //    a US layout don't have to press Shift to grow the font. ──
+          { key: "Mod-=", run: () => applyFontSizeAction("increase") },
+          { key: "Mod-+", run: () => applyFontSizeAction("increase") },
+          { key: "Mod--", run: () => applyFontSizeAction("decrease") },
+          { key: "Mod-0", run: () => applyFontSizeAction("reset") },
           // ── Search / Replace / Go-to-line ──
           {
             key: "Mod-r",
@@ -398,6 +440,30 @@ export function EditorPane({ content, language, onContentChange, onSave, onCurso
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [effectiveIndent.useTabs, effectiveIndent.size]);
+
+  // Load the persisted editor_font_size on mount and apply it to the
+  // live view. Default is already set via the compartment's initial
+  // value, so a missing setting falls through cleanly.
+  useEffect(() => {
+    let cancelled = false;
+    getSetting("editor_font_size")
+      .then((raw) => {
+        if (cancelled) return;
+        const px = parseEditorFontSize(raw);
+        if (px === fontSizePxRef.current) return;
+        fontSizePxRef.current = px;
+        const view = viewRef.current;
+        if (view) {
+          view.dispatch({
+            effects: fontSizeCompartment.current.reconfigure(buildFontSizeExtension(px)),
+          });
+        }
+      })
+      .catch((err) => console.warn("[EditorPane] Failed to load editor_font_size:", err));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Hot-swap syntax colours when the app theme changes
   useEffect(() => {

--- a/src/editor/editorFontSize.ts
+++ b/src/editor/editorFontSize.ts
@@ -1,0 +1,36 @@
+// ─── Editor font size ────────────────────────────────────────────────
+//
+// The editor pane has its own font-size dimension, separate from the
+// terminal `font_size` setting and from the global `ui_scale`. Bound
+// to the persisted `editor_font_size` setting; mutated by Mod+= /
+// Mod+- / Mod+0 shortcuts inside the editor.
+
+export const DEFAULT_EDITOR_FONT_PX = 13;
+export const MIN_EDITOR_FONT_PX = 8;
+export const MAX_EDITOR_FONT_PX = 32;
+export const EDITOR_FONT_STEP_PX = 1;
+
+const clamp = (n: number): number =>
+	Math.min(MAX_EDITOR_FONT_PX, Math.max(MIN_EDITOR_FONT_PX, n));
+
+/** Parse a persisted setting value into an integer pixel size, falling back
+ *  to the default on missing/invalid input. The persisted value is clamped
+ *  to the allowed range so that a hand-edited DB row can't push the editor
+ *  to 2pt or 200pt. */
+export function parseEditorFontSize(raw: string | undefined | null): number {
+	if (raw == null || raw === "") return DEFAULT_EDITOR_FONT_PX;
+	const n = Number.parseInt(raw, 10);
+	if (!Number.isFinite(n)) return DEFAULT_EDITOR_FONT_PX;
+	return clamp(n);
+}
+
+/** Apply an increase / decrease / reset action to the current font size,
+ *  always returning a clamped value. */
+export function nextEditorFontSize(
+	current: number,
+	action: "increase" | "decrease" | "reset",
+): number {
+	if (action === "reset") return DEFAULT_EDITOR_FONT_PX;
+	const step = action === "increase" ? EDITOR_FONT_STEP_PX : -EDITOR_FONT_STEP_PX;
+	return clamp(current + step);
+}


### PR DESCRIPTION
Wires three CodeMirror keymap entries into EditorPane:

  Mod-= / Mod-+   increase by 1 pt (both keys bound so a US layout
                  doesn't have to press Shift to grow the font)
  Mod--           decrease by 1 pt
  Mod-0           reset to the default (13 px)

The active font size lives in a new `fontSizeCompartment` so updates reconfigure the theme live rather than rebuilding the EditorState. A new `editor_font_size` setting key persists the choice across sessions; it's loaded on mount and re-applied via the same compartment. The Mod-0 reset is exactly that — restore the default, not the previous value.

Out of scope: a settings UI surface (the toolbar/Settings panel exposure is mentioned in the issue as a "consider," easy follow-up once the shortcuts are in).

Pure helper (parse + clamp + next-value) lives in
`src/editor/editorFontSize.ts` with 11 vitest cases covering defaults, garbage input, in-range, and both clamp bounds.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

<!-- Link to the issue or discussion that approved this change -->
<!-- Feature PRs without a linked discussion will be closed -->

Closes #

## Type of Change

- [ ] Bug fix
- [x] Performance improvement
- [ ] New feature (approved in discussion)
- [ ] Documentation
- [ ] Refactoring (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [x] `npx tsc --noEmit` passes
- [x] `npm run test` passes
- [x] I have signed the [CLA](../CLA.md)
