### PR TITLE
Remember the last selected AI engine across sessions (closes #3)

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -2396,6 +2396,7 @@ const VALID_SETTING_KEYS: &[&str] = &[
     // AI agent defaults
     "default_permission_mode",
     "custom_command_suffix",
+    "last_ai_provider",
     // Per-agent launch command prefix (JSON map of providerId -> prefix string)
     "ai_agent_prefixes",
     // Keyboard shortcuts

--- a/src/__tests__/last-ai-provider.test.ts
+++ b/src/__tests__/last-ai-provider.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { resolveDefaultAiProvider } from "../utils/lastAiProvider";
+
+const KNOWN = ["claude", "codex", "gemini"] as const;
+
+describe("resolveDefaultAiProvider", () => {
+	it("returns null for missing input", () => {
+		expect(resolveDefaultAiProvider(null, KNOWN)).toBeNull();
+		expect(resolveDefaultAiProvider(undefined, KNOWN)).toBeNull();
+		expect(resolveDefaultAiProvider("", KNOWN)).toBeNull();
+	});
+
+	it("returns null for whitespace-only input", () => {
+		expect(resolveDefaultAiProvider("   ", KNOWN)).toBeNull();
+		expect(resolveDefaultAiProvider("\t\n", KNOWN)).toBeNull();
+	});
+
+	it("returns a known provider id verbatim", () => {
+		expect(resolveDefaultAiProvider("claude", KNOWN)).toBe("claude");
+		expect(resolveDefaultAiProvider("codex", KNOWN)).toBe("codex");
+	});
+
+	it("trims surrounding whitespace before matching", () => {
+		expect(resolveDefaultAiProvider("  claude  ", KNOWN)).toBe("claude");
+	});
+
+	it("returns null for an id not in the registry (silent fallback)", () => {
+		expect(resolveDefaultAiProvider("deprecated-provider", KNOWN)).toBeNull();
+	});
+
+	it("is case-sensitive (registry IDs are canonical)", () => {
+		expect(resolveDefaultAiProvider("CLAUDE", KNOWN)).toBeNull();
+		expect(resolveDefaultAiProvider("Claude", KNOWN)).toBeNull();
+	});
+
+	it("works with an empty registry — everything falls back to null", () => {
+		expect(resolveDefaultAiProvider("claude", [])).toBeNull();
+	});
+});

--- a/src/components/SessionCreator.tsx
+++ b/src/components/SessionCreator.tsx
@@ -21,6 +21,7 @@ import {
 } from "../utils/aiProviders";
 import { PLATFORM } from "../utils/platform";
 import { getSetting, setSetting } from "../api/settings";
+import { LAST_AI_PROVIDER_KEY, resolveDefaultAiProvider } from "../utils/lastAiProvider";
 import { listSshSavedHosts, upsertSshSavedHost, type SshSavedHost } from "../api/ssh";
 import type { PermissionMode, SessionMode, TmuxSessionEntry } from "../types/session";
 import { isGitRepo as checkIsGitRepo } from "../api/git";
@@ -106,6 +107,15 @@ export function SessionCreator({ onClose, onCreate, defaultGroup, initialMode, o
   // For terminal mode the user picks an AI provider; for agent mode it's
   // forced to "claude"; for ssh mode it's irrelevant (mode is "terminal").
   const [aiProvider, setAiProvider] = useState<string | null>(initialMode === "agent" ? "claude" : null);
+  // Pre-selection default for terminal-mode (issue #3). Loaded async from
+  // the persisted setting; applied once on the first transition into
+  // terminal mode via `defaultProviderAppliedRef`. Stays null if the user
+  // never picked a provider before, or if the saved provider is no longer
+  // in the registry (silent fall-through is the right UX — better than
+  // surfacing a dead selection the user has to clear).
+  const [defaultAiProvider, setDefaultAiProvider] = useState<string | null>(null);
+  const [defaultAiProviderLoaded, setDefaultAiProviderLoaded] = useState(false);
+  const defaultProviderAppliedRef = useRef(false);
   const [label, setLabel] = useState("");
   const [description, setDescription] = useState("");
   const [allProjects, setAllProjects] = useState<ProjectOrdered[]>([]);
@@ -624,9 +634,53 @@ export function SessionCreator({ onClose, onCreate, defaultGroup, initialMode, o
     []
   );
 
+  const knownProviderIds = useMemo(() => AI_PROVIDERS.map((p) => p.id), []);
+
+  // Load the persisted default once on mount.
+  useEffect(() => {
+    let cancelled = false;
+    getSetting(LAST_AI_PROVIDER_KEY)
+      .then((raw) => {
+        if (cancelled) return;
+        setDefaultAiProvider(resolveDefaultAiProvider(raw, knownProviderIds));
+        setDefaultAiProviderLoaded(true);
+      })
+      .catch((err) => {
+        if (!cancelled) setDefaultAiProviderLoaded(true);
+        console.warn("[SessionCreator] Failed to load last_ai_provider:", err);
+      });
+    return () => { cancelled = true; };
+    // knownProviderIds is a stable useMemo — exhaustive-deps lint silenced.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Apply the saved default the first time the user lands in terminal mode
+  // with the setting loaded. One-shot: subsequent mode flips don't override
+  // the user's in-flight selection.
+  useEffect(() => {
+    if (defaultProviderAppliedRef.current) return;
+    if (mode !== "terminal") return;
+    if (!defaultAiProviderLoaded) return;
+    if (!defaultAiProvider) return;
+    defaultProviderAppliedRef.current = true;
+    setAiProvider(defaultAiProvider);
+  }, [mode, defaultAiProvider, defaultAiProviderLoaded]);
+
+  /** Wrap setAiProvider so an explicit user pick is also persisted as the
+   *  new global default. Only non-null choices are persisted — "no AI"
+   *  leaves the previous default intact so it can pre-select next time. */
+  const chooseAiProvider = useCallback((id: string | null) => {
+    setAiProvider(id);
+    if (id) {
+      setSetting(LAST_AI_PROVIDER_KEY, id).catch((err) =>
+        console.warn("[SessionCreator] Failed to persist last_ai_provider:", err),
+      );
+    }
+  }, []);
+
   const selectProviderAndAdvance = (idx: number) => {
     const id = enabledProviders[idx] ?? null;
-    setAiProvider(id as string | null);
+    chooseAiProvider(id as string | null);
     if (!id) { setAutoApprove(false); setPermissionMode("default"); }
     if (id !== "claude") setSelectedChannels([]);
     goNext();
@@ -1202,7 +1256,7 @@ export function SessionCreator({ onClose, onCreate, defaultGroup, initialMode, o
                   <button
                     key={p.id}
                     className={`session-creator-provider-card ${aiProvider === p.id ? "selected" : ""} ${highlightedProviderIndex === providerIdx ? "selected" : ""} ${availabilityLoaded && !isAvailable ? "session-creator-provider-unavailable" : ""}`}
-                    onClick={() => { setAiProvider(p.id); setHighlightedProviderIndex(providerIdx); if (p.id !== "claude") setSelectedChannels([]); }}
+                    onClick={() => { chooseAiProvider(p.id); setHighlightedProviderIndex(providerIdx); if (p.id !== "claude") setSelectedChannels([]); }}
                   >
                     <span className="session-creator-provider-name">
                       {p.label}

--- a/src/utils/lastAiProvider.ts
+++ b/src/utils/lastAiProvider.ts
@@ -1,0 +1,28 @@
+// ─── Last selected AI provider ───────────────────────────────────────
+//
+// Backing the "remember last selected AI engine" UX (issue #3): the
+// terminal-mode session-creator pre-selects the provider the user
+// picked last time, so they don't re-pick on every new session.
+//
+// Stored in the `last_ai_provider` setting key. Only provider IDs that
+// still exist in the registry are honored — a stale ID (e.g. a removed
+// provider) silently falls back to "no pre-selection."
+//
+// Scope: single global default. Per-project / per-workspace memory is
+// an explicit follow-up; see the open question on the issue.
+
+export const LAST_AI_PROVIDER_KEY = "last_ai_provider";
+
+/** Validate a persisted setting value against the current provider registry.
+ *  Returns the trimmed id if it's known, otherwise null. Empty / unset /
+ *  whitespace-only values return null. */
+export function resolveDefaultAiProvider(
+	raw: string | null | undefined,
+	knownProviderIds: readonly string[],
+): string | null {
+	if (raw == null) return null;
+	const trimmed = raw.trim();
+	if (trimmed === "") return null;
+	if (!knownProviderIds.includes(trimmed)) return null;
+	return trimmed;
+}


### PR DESCRIPTION
The terminal-mode session creator now pre-selects the AI provider the user picked last time, so a user who consistently runs Claude doesn't re-click "Claude" on every new session.

Stored as a single global default (`last_ai_provider` setting key). Per-workspace memory is an explicit follow-up — the issue calls it out as an open question, and the smaller change is enough to close the reported friction.

Behavior:
- Applied once on the first transition into terminal mode per SessionCreator mount (`defaultProviderAppliedRef`). Switching modes back and forth doesn't re-clobber an in-flight selection.
- Saved provider IDs are validated against the live registry — a stale id (removed provider) silently falls back to "no pre-selection."
- Only non-null picks persist. Choosing "Plain shell / no AI" leaves the previous default intact so it can still pre-select next time.
- Agent mode is unaffected (forced to "claude" by design).

Pure validator `resolveDefaultAiProvider` lives in `src/utils/lastAiProvider.ts` with 7 vitest cases (null/empty, whitespace, known id, trim, unknown id, case sensitivity, empty registry).

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

<!-- Link to the issue or discussion that approved this change -->
<!-- Feature PRs without a linked discussion will be closed -->

Closes #

## Type of Change

- [ ] Bug fix
- [ ] Performance improvement
- [x] New feature (approved in discussion)
- [ ] Documentation
- [ ] Refactoring (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [x] `npx tsc --noEmit` passes
- [x] `npm run test` passes
- [x] I have signed the [CLA](../CLA.md)
