### PR TITLE
Auto-name unnamed agent sessions from the first user message (closes #1)

### DIFF
--- a/src/__tests__/auto-session-label.test.ts
+++ b/src/__tests__/auto-session-label.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+	MAX_AUTO_LABEL_CHARS,
+	deriveSessionLabelFromMessage,
+	isDefaultSessionLabel,
+} from "../utils/autoSessionLabel";
+
+describe("isDefaultSessionLabel", () => {
+	it("treats null and empty as default (unnamed)", () => {
+		expect(isDefaultSessionLabel(null)).toBe(true);
+		expect(isDefaultSessionLabel(undefined)).toBe(true);
+		expect(isDefaultSessionLabel("")).toBe(true);
+	});
+
+	it("matches the backend 'Session N' placeholder", () => {
+		expect(isDefaultSessionLabel("Session 1")).toBe(true);
+		expect(isDefaultSessionLabel("Session 42")).toBe(true);
+		expect(isDefaultSessionLabel("Session 9999")).toBe(true);
+	});
+
+	it("treats user-chosen names as non-default — does not match", () => {
+		expect(isDefaultSessionLabel("My Project")).toBe(false);
+		expect(isDefaultSessionLabel("Session A")).toBe(false);
+		expect(isDefaultSessionLabel("session 1")).toBe(false); // case-sensitive
+		expect(isDefaultSessionLabel("Session")).toBe(false);
+		expect(isDefaultSessionLabel("Session 1 extra")).toBe(false);
+	});
+});
+
+describe("deriveSessionLabelFromMessage", () => {
+	it("returns null for empty / whitespace-only drafts", () => {
+		expect(deriveSessionLabelFromMessage("")).toBeNull();
+		expect(deriveSessionLabelFromMessage("   ")).toBeNull();
+		expect(deriveSessionLabelFromMessage("\n\n\n")).toBeNull();
+	});
+
+	it("uses a short single-line message verbatim", () => {
+		expect(deriveSessionLabelFromMessage("fix the login bug")).toBe("fix the login bug");
+	});
+
+	it("trims surrounding whitespace from the line it picks", () => {
+		expect(deriveSessionLabelFromMessage("   refactor the parser   ")).toBe(
+			"refactor the parser",
+		);
+	});
+
+	it("takes the first non-empty line of a multi-line message", () => {
+		const draft = "\n\ndesign the auth flow\n\nbackground: we need OAuth";
+		expect(deriveSessionLabelFromMessage(draft)).toBe("design the auth flow");
+	});
+
+	it("collapses internal whitespace runs", () => {
+		expect(deriveSessionLabelFromMessage("look\tat   the\t\tlogs")).toBe(
+			"look at the logs",
+		);
+	});
+
+	it("truncates at the max-char limit with an ellipsis", () => {
+		const long = "A".repeat(MAX_AUTO_LABEL_CHARS + 10);
+		const label = deriveSessionLabelFromMessage(long);
+		expect(label).not.toBeNull();
+		expect(label!.length).toBeLessThanOrEqual(MAX_AUTO_LABEL_CHARS + 1); // +1 for "…"
+		expect(label!.endsWith("…")).toBe(true);
+	});
+
+	it("prefers a nearby word boundary when truncating", () => {
+		// Cut should land on the space before "failures" (char 33), not mid-word.
+		const draft = "investigate the intermittent test failures in the CI pipeline";
+		expect(deriveSessionLabelFromMessage(draft)).toBe(
+			"investigate the intermittent test…",
+		);
+	});
+
+	it("falls back to a hard cut when no word boundary is near the limit", () => {
+		// A single 60-char run with no spaces — must still produce a truncated label.
+		const draft = "X".repeat(60);
+		const label = deriveSessionLabelFromMessage(draft);
+		expect(label).not.toBeNull();
+		expect(label!.endsWith("…")).toBe(true);
+		expect(label!.slice(0, -1).length).toBeLessThanOrEqual(MAX_AUTO_LABEL_CHARS);
+	});
+
+	it("keeps slash commands as labels (a `/clear` session is at least identifiable)", () => {
+		expect(deriveSessionLabelFromMessage("/help")).toBe("/help");
+	});
+});

--- a/src/__tests__/session-ref-cleanup.test.ts
+++ b/src/__tests__/session-ref-cleanup.test.ts
@@ -30,6 +30,7 @@ function emptyBundle(): SessionRefBundle {
     claudeAddDirs: new Map(),
     pendingFlags: new Map(),
     lastIdeStateHash: new Map(),
+    autoNamedSessions: new Set(),
   };
 }
 
@@ -48,10 +49,11 @@ describe("cleanupSessionRefs (v1.1.2 H2 + H3 leak fixes)", () => {
     b.claudeAddDirs.set(sid, ["/a", "/b"]);
     b.pendingFlags.set(sid, { model: "opus" });
     b.lastIdeStateHash.set(sid, "hash-1");
+    b.autoNamedSessions.add(sid);
 
     const { removed } = cleanupSessionRefs(b, sid);
 
-    expect(removed).toBe(10);
+    expect(removed).toBe(11);
     expect(b.busyTimestamps.has(sid)).toBe(false);
     expect(b.closingSessionIds.has(sid)).toBe(false);
     expect(b.lastAutoAttachCwd.has(sid)).toBe(false);
@@ -62,6 +64,7 @@ describe("cleanupSessionRefs (v1.1.2 H2 + H3 leak fixes)", () => {
     expect(b.claudeAddDirs.has(sid)).toBe(false);
     expect(b.pendingFlags.has(sid)).toBe(false);
     expect(b.lastIdeStateHash.has(sid)).toBe(false);
+    expect(b.autoNamedSessions.has(sid)).toBe(false);
   });
 
   it("H3: leaves OTHER sessions' entries untouched", () => {

--- a/src/state/SessionContext.tsx
+++ b/src/state/SessionContext.tsx
@@ -13,10 +13,11 @@ let workspaceDirty = false;
 import {
   createSession as apiCreateSession, closeSession as apiCloseSession,
   getSessions, getRecentSessions, getSessionSnapshot,
-  updateSessionDescription, updateSessionGroup,
+  updateSessionDescription, updateSessionGroup, updateSessionLabel,
   saveAllSnapshots,
   addWorkspacePath,
 } from "../api/sessions";
+import { deriveSessionLabelFromMessage, isDefaultSessionLabel } from "../utils/autoSessionLabel";
 import { getProjects, getSessionProjects, attachSessionProject } from "../api/projects";
 import { autoAttachInsideProject } from "../utils/autoAttach";
 import { hasAddDirDrift } from "../utils/agentDrift";
@@ -976,6 +977,10 @@ export function SessionProvider({ children }: { children: ReactNode }) {
    *  detects the diff and triggers a respawn so Read/Edit tools can
    *  actually access files in newly-attached paths. */
   const claudeAddDirs = useRef<Map<string, string[]>>(new Map());
+  /** sessionId → "already auto-named, don't try again". Prevents racing
+   *  duplicate label writes if the user submits two messages in quick
+   *  succession before the first persist round-trip completes. */
+  const autoNamedSessions = useRef<Set<string>>(new Set());
   /** sessionId → flag changes the user has *requested* but not yet applied,
    *  because applying them requires a fresh fork-respawn AND a user message
    *  for the new subprocess to actually persist its session.
@@ -1251,6 +1256,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
             claudeAddDirs: claudeAddDirs.current,
             pendingFlags: pendingFlags.current,
             lastIdeStateHash: lastIdeStateHash.current,
+            autoNamedSessions: autoNamedSessions.current,
           },
           event.payload,
         );
@@ -2163,6 +2169,23 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     // Echo first so the user sees their own message immediately even if
     // we're about to respawn the subprocess.
     await echoUserEnvelope(sessionId, envelope);
+
+    // Auto-name unnamed agent sessions from the first user message
+    // (issue #1). Cheap heuristic — no model round-trip; the first
+    // message is already a great summary. Fire-and-forget so the
+    // persist doesn't block the send.
+    if (!autoNamedSessions.current.has(sessionId)) {
+      const sess = stateRef.current.sessions[sessionId];
+      if (sess?.mode === "agent" && isDefaultSessionLabel(sess.label)) {
+        const derived = deriveSessionLabelFromMessage(draft);
+        if (derived) {
+          autoNamedSessions.current.add(sessionId);
+          updateSessionLabel(sessionId, derived).catch((err) =>
+            console.warn(`[SessionContext] auto-name failed for ${sessionId}:`, err),
+          );
+        }
+      }
+    }
 
     // Apply any queued flag changes (model / permission mode / effort)
     // BEFORE the send.  This is the production-bug fix: forking with no

--- a/src/utils/autoSessionLabel.ts
+++ b/src/utils/autoSessionLabel.ts
@@ -1,0 +1,48 @@
+// ─── Auto-generated session labels ───────────────────────────────────
+//
+// When a user opens an agent-mode session without giving it a name,
+// the backend assigns a placeholder like "Session 7". Once the user
+// sends their first message we can do better: derive a label from the
+// message text and rename the session in place (issue #1).
+//
+// This is intentionally not a model round-trip — the first message is
+// already a great summary of "what this session is for," it costs no
+// tokens, and it works in airgapped / no-API-key environments. If a
+// future PR wants AI-generated names that's an additive layer; this
+// module just owns the heuristic.
+
+/** Pattern the backend uses for unnamed sessions ("Session 1",
+ *  "Session 2", ...). Anything else means the user named it manually
+ *  or a previous auto-name already ran. */
+export const DEFAULT_LABEL_PATTERN = /^Session \d+$/;
+
+export const MAX_AUTO_LABEL_CHARS = 40;
+
+/** True if `label` looks like the backend's auto-assigned placeholder. */
+export function isDefaultSessionLabel(label: string | null | undefined): boolean {
+	if (!label) return true;
+	return DEFAULT_LABEL_PATTERN.test(label.trim());
+}
+
+/** Derive a session label from the user's first message. Returns null
+ *  when the message has no usable text content (e.g. only attachments). */
+export function deriveSessionLabelFromMessage(draft: string): string | null {
+	if (!draft) return null;
+	// Take the first non-empty line — multi-line drafts are common when the
+	// user pastes context, but the first line is almost always the prompt.
+	let first = "";
+	for (const line of draft.split(/\r?\n/)) {
+		const t = line.trim();
+		if (t) { first = t; break; }
+	}
+	if (!first) return null;
+	// Collapse runs of internal whitespace so a tab-indented or
+	// double-spaced fragment still reads cleanly in the sidebar.
+	first = first.replace(/\s+/g, " ");
+	if (first.length <= MAX_AUTO_LABEL_CHARS) return first;
+	// Truncate, preferring to break on a word boundary if one's nearby.
+	const slice = first.slice(0, MAX_AUTO_LABEL_CHARS);
+	const lastSpace = slice.lastIndexOf(" ");
+	const cutoff = lastSpace >= MAX_AUTO_LABEL_CHARS - 12 ? lastSpace : MAX_AUTO_LABEL_CHARS;
+	return slice.slice(0, cutoff).trimEnd() + "…";
+}

--- a/src/utils/sessionRefCleanup.ts
+++ b/src/utils/sessionRefCleanup.ts
@@ -29,6 +29,7 @@ export interface SessionRefBundle {
   claudeAddDirs: Map<string, string[]>;
   pendingFlags: Map<string, unknown>;
   lastIdeStateHash: Map<string, string>;
+  autoNamedSessions: Set<string>;
 }
 
 /**
@@ -60,6 +61,7 @@ export function cleanupSessionRefs(
   tryDelete(bundle.claudeAddDirs as Map<string, unknown>);
   tryDelete(bundle.pendingFlags as Map<string, unknown>);
   tryDelete(bundle.lastIdeStateHash as Map<string, unknown>);
+  tryDelete(bundle.autoNamedSessions);
 
   // Cancel + delete any pending close-fallback timer (H2 fix).
   let cancelledTimer = false;


### PR DESCRIPTION
When the user opens an agent-mode session without giving it a name, the backend assigns a placeholder like "Session 7". Once the user sends their first message we can do better: derive a label from the message text and rename the session in place.

Scope choice (the issue lists several open questions):

  - Mode: agent only. Terminal mode has no clean "first user message" moment — shell commands are different in shape and frequency, and naming from a `cd` or `ls` is worse than the "Session N" default.

  - Trigger: first call to submitAgentMessage that has usable text. Once-per-session via a tracking Set (autoNamedSessions) so two rapid submits don't race two different label writes.

  - No model round-trip. The first message is already a great summary of "what this session is for," costs zero tokens, and works in air-gapped / no-API-key environments. A future PR can add an AI-naming layer if maintainers want it — this just owns the heuristic.

  - Failure mode: persist is fire-and-forget; a network/DB error logs a warning but doesn't break the send.

  - User override: unchanged. Inline rename still works exactly as before. The auto-name only fires when the label matches the backend's "Session N" pattern, so any manual rename suppresses future auto-naming on that session.

Derivation: first non-empty line, internal whitespace collapsed, truncated to 40 chars at a nearby word boundary (or hard-cut if no boundary is near), with a trailing "…" when truncated.

Tests: 10 cases on the pure helper (`deriveSessionLabelFromMessage`
+ `isDefaultSessionLabel`); the cleanup-refs regression suite is extended to cover the new per-session Set.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

<!-- Link to the issue or discussion that approved this change -->
<!-- Feature PRs without a linked discussion will be closed -->

Closes #

## Type of Change

- [ ] Bug fix
- [ ] Performance improvement
- [x] New feature (approved in discussion)
- [ ] Documentation
- [ ] Refactoring (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [x] `npx tsc --noEmit` passes
- [x] `npm run test` passes
- [x] I have signed the [CLA](../CLA.md)
