### PR TITLE
Branch picker single-click + agent masthead ticker polish

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,29 +1,58 @@
-# Hermes IDE 1.2.5
+# Hermes IDE 1.3.0
 
-The model picker, the permission chip, the effort selector — they
-stay where you put them. Even when you switch sessions and come back.
+A keyboard convention overhaul, a quieter branch picker, and several
+header and popover polish fixes.
 
-## Your chips stay put
+## Press Enter to send
 
-If you opened two Agent sessions, clicked between them a few times,
-and watched the model picker / permission chip / effort selector
-quietly disappear from your composer — leaving only the `Builder`,
-`Terminal`, and `Attach` buttons — that's fixed.
+The agent composer now sends on **Enter**, with **Shift+Enter** for a
+new line — matching Claude.ai, ChatGPT, Cursor, Slack, and the
+muscle memory you bring to Hermes from those tools.
 
-The chips now reflect the actual state of each agent the moment you
-look at them, regardless of how long ago the session was spawned or
-how many times you've switched away. Plan-mode flips, manual model
-swaps, and effort changes all show up immediately on whichever
-session you're viewing.
+If you've already learned the older binding, **Cmd+Enter** (Ctrl+Enter
+on Windows and Linux) still sends. Nothing lost, just an extra route in.
 
-## Why this kept happening
+The send button's tooltip now reads `Send · Shift+Enter for newline` so
+the convention is discoverable at a glance.
 
-The chips read from a per-session snapshot that was reset every time
-you switched, and the underlying signal that populates it only fires
-once when the agent boots — so any session you didn't have visible
-at boot time silently lost its chip data and never got it back until
-the next respawn. The fix caches that snapshot per session and
-restores it whenever the composer mounts.
+## One click picks a branch
 
-That's all in 1.2.5. Same Agent mode, same branch isolation
-guarantees from 1.2.3 — just no more vanishing chips.
+When you create a session and pick a branch — especially across
+multiple projects at once — clicking a branch row now commits your
+choice immediately. No more silent trap where the row looked
+"selected" but never actually registered, and you ended up with no
+branch isolation when you continued.
+
+A small `→` chevron fades in on hover to telegraph that the click is
+the action. Remote-only branches get a small `remote` tag so the
+single click doesn't feel surprising.
+
+The per-project **Use current branch** escape stays — pick one project
+to share, another to isolate.
+
+## Cmd+Enter sends Claude's option lists
+
+When Claude asks you a multiple-choice question in the chat,
+**Cmd+Enter** (Ctrl+Enter on Windows and Linux) now sends your
+selection without reaching for the mouse. The send button shows the
+shortcut as a small chip next to the word, mirroring the **Esc**
+cancel chip.
+
+## Quieter agent header
+
+- **"Thinking" is no longer clipped** along its baseline. The brass
+  glow had been getting cut off at the bottom edge of the header on
+  some themes.
+- **No more row jitter** when the status switches between one-word and
+  two-word labels. Previously, "Running Bash" or "Awaiting Claude"
+  could wrap to a second line in narrow panes, making the whole header
+  height jump on every state change.
+
+## Readable subagents popover
+
+The popover that shows your running subagents now has a fully opaque
+background. The previous build still let a faint blurred copy of the
+chat bleed through on some setups, hurting legibility — that's gone.
+
+The chat behind the popover stays where it is; the popover just stops
+being half-see-through.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-ide",
-  "version": "1.2.2",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-ide",
-      "version": "1.2.2",
+      "version": "1.2.5",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.132",

--- a/src/__tests__/agent-masthead-ticker-stability.test.ts
+++ b/src/__tests__/agent-masthead-ticker-stability.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Two presentational regressions in the agent session masthead.
+ *
+ * 1. **Glow not clipped.**  `.agent-session-ticker` has a brass `text-shadow`
+ *    that glows symmetrically around the text.  Its parent
+ *    `.agent-session-header-title` used to have `overflow: hidden`, which
+ *    clipped the bottom 8px of the glow — visible as "Thinking" looking
+ *    cut off along the baseline.  The parent overflow rule is now gone;
+ *    the leaves (ticker, cwd, model) handle their own truncation.
+ *
+ * 2. **Single-line ticker.**  When the activity status switched from a
+ *    one-word label ("Thinking") to a two-word label ("Running Bash",
+ *    "Awaiting Claude"), the ticker could wrap to a second line in narrow
+ *    panes — the header would grow vertically and surrounding chips would
+ *    visibly jump.  The ticker is now `white-space: nowrap` with ellipsis
+ *    so the row height stays constant across state changes.
+ *
+ * We assert against the stylesheet text itself — there is no behavioural
+ * surface to render-test here, and a string match catches accidental
+ * reverts cleanly.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const CSS_PATH = path.resolve(
+  __dirname,
+  "../styles/components/agent/AgentSessionView.css",
+);
+
+function readCss(): string {
+  // Strip block comments so our string-level assertions don't trip on
+  // explanatory prose that happens to mention the same property names
+  // (e.g. "No overflow: hidden here — it clips the brass glow").
+  return fs
+    .readFileSync(CSS_PATH, "utf-8")
+    .replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/** Extract a rule body for a given selector heading.  Anchors on
+ *  `selector {` (with the brace) so we don't accidentally match a
+ *  prefix of a longer selector. */
+function ruleBody(css: string, selector: string): string {
+  const re = new RegExp(
+    selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "\\s*\\{",
+  );
+  const m = css.match(re);
+  if (!m || m.index === undefined) return "";
+  const open = css.indexOf("{", m.index);
+  let depth = 1;
+  for (let i = open + 1; i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) return css.slice(open + 1, i);
+    }
+  }
+  return "";
+}
+
+describe("Agent masthead — ticker stability (presentational)", () => {
+  it(".agent-session-header-title does NOT clip overflow (would chop the brass glow)", () => {
+    const body = ruleBody(readCss(), ".agent-session-header-title");
+    expect(body).not.toMatch(/overflow:\s*hidden/);
+  });
+
+  it(".agent-session-ticker pins single-line layout with ellipsis", () => {
+    const body = ruleBody(readCss(), ".agent-session-ticker");
+    expect(body).toMatch(/white-space:\s*nowrap/);
+    expect(body).toMatch(/overflow:\s*hidden/);
+    expect(body).toMatch(/text-overflow:\s*ellipsis/);
+  });
+
+  it(".agent-session-ticker keeps the brass glow", () => {
+    const body = ruleBody(readCss(), ".agent-session-ticker");
+    // Regression guard — we don't want the fix above to accidentally drop
+    // the glow that's the whole point of the brass treatment.
+    expect(body).toMatch(/text-shadow:/);
+    expect(body).toMatch(/var\(--brass-dim\)/);
+  });
+});

--- a/src/__tests__/agent-subagent-popover-opacity.test.ts
+++ b/src/__tests__/agent-subagent-popover-opacity.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Subagent masthead popover — fully opaque, no backdrop bleed-through.
+ *
+ * The v1.2.2 release notes already claimed "opaque on every theme", but
+ * users still saw the chat behind bleeding through the popover.  The
+ * cause was a layered `linear-gradient(--bg-elevated) over --bg-0` plus
+ * `backdrop-filter: blur(10px)`.  On some GPU compositors the blur
+ * leaked through even when both color tokens were fully opaque hex.
+ *
+ * All shipped themes define `--bg-elevated` as an opaque hex value, so
+ * a single solid fill is both correct and simpler.  These assertions
+ * pin the simpler invariant:
+ *   1. The popover background is a solid `--bg-elevated` (no gradient).
+ *   2. There is NO `backdrop-filter` on the popover.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const CSS_PATH = path.resolve(
+  __dirname,
+  "../styles/components/agent/AgentSessionView.css",
+);
+
+function ruleBody(css: string, selector: string): string {
+  // Strip block comments so descriptive prose can't trip our assertions.
+  const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const re = new RegExp(
+    selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "\\s*\\{",
+  );
+  const m = stripped.match(re);
+  if (!m || m.index === undefined) return "";
+  const open = stripped.indexOf("{", m.index);
+  let depth = 1;
+  for (let i = open + 1; i < stripped.length; i++) {
+    if (stripped[i] === "{") depth++;
+    else if (stripped[i] === "}") {
+      depth--;
+      if (depth === 0) return stripped.slice(open + 1, i);
+    }
+  }
+  return "";
+}
+
+describe("Subagent popover — background opacity", () => {
+  const css = fs.readFileSync(CSS_PATH, "utf-8");
+  const body = ruleBody(css, ".agent-subagent-popover");
+
+  it("popover rule exists", () => {
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  it("background is a single solid fill, not a layered gradient", () => {
+    // Drop linear-gradient(...) entirely so a stray reference in a
+    // comment in another rule can't false-positive — but the comment
+    // strip above already handles that; this is belt + braces.
+    expect(body).not.toMatch(/linear-gradient/);
+  });
+
+  it("background uses --bg-elevated (with --bg-1 fallback)", () => {
+    expect(body).toMatch(/background:\s*var\(--bg-elevated[^)]*\)/);
+  });
+
+  it("does NOT set backdrop-filter — it leaks through on some compositors", () => {
+    expect(body).not.toMatch(/backdrop-filter:/);
+    expect(body).not.toMatch(/-webkit-backdrop-filter:/);
+  });
+});

--- a/src/__tests__/ask-user-question-shortcut.test.tsx
+++ b/src/__tests__/ask-user-question-shortcut.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+/**
+ * AskUserQuestion card — Cmd+Enter (mac) / Ctrl+Enter (win/linux) submits.
+ *
+ * Esc already cancels.  The send button is reachable by mouse and TAB, but
+ * users in a flow state expect a keyboard send — and "naked" Enter is taken
+ * by the "Other" textarea (for newlines).  Cmd/Ctrl+Enter is the standard
+ * "send this form right now" shortcut across web UI (Slack, GitHub, Linear).
+ *
+ * Also asserts the send button surfaces the shortcut so it's discoverable.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+import { AskUserQuestionCard } from "../components/AskUserQuestionCard";
+import { isMac } from "../utils/platform";
+import type { AskUserQuestionInput } from "../utils/askUserQuestion";
+
+const SAMPLE_INPUT: AskUserQuestionInput = {
+  questions: [
+    {
+      question: "Which approach?",
+      header: "Approach",
+      multiSelect: false,
+      options: [
+        { label: "Option A", description: "first" },
+        { label: "Option B", description: "second" },
+      ],
+    },
+  ],
+};
+
+afterEach(() => cleanup());
+
+/** Fire the platform-appropriate "action mod + Enter" combo on `window`. */
+function fireActionEnter(): void {
+  fireEvent.keyDown(window, {
+    key: "Enter",
+    metaKey: isMac,
+    ctrlKey: !isMac,
+  });
+}
+
+describe("AskUserQuestionCard — keyboard submit", () => {
+  it("Cmd/Ctrl+Enter submits when an option is selected", () => {
+    const onAllow = vi.fn();
+    render(
+      <AskUserQuestionCard
+        input={SAMPLE_INPUT}
+        onAllow={onAllow}
+        onDeny={() => {}}
+      />,
+    );
+
+    // Pick an option so the form is valid.
+    fireEvent.click(screen.getByLabelText(/Option A/i));
+
+    fireActionEnter();
+
+    expect(onAllow).toHaveBeenCalledTimes(1);
+    const updated = onAllow.mock.calls[0][0] as { answers: Record<string, string> };
+    expect(updated.answers["Which approach?"]).toBe("Option A");
+  });
+
+  it("Cmd/Ctrl+Enter does NOT submit when nothing is selected (form invalid)", () => {
+    const onAllow = vi.fn();
+    render(
+      <AskUserQuestionCard
+        input={SAMPLE_INPUT}
+        onAllow={onAllow}
+        onDeny={() => {}}
+      />,
+    );
+
+    fireActionEnter();
+
+    expect(onAllow).not.toHaveBeenCalled();
+  });
+
+  it("naked Enter (no modifier) does NOT submit — that key belongs to the textarea", () => {
+    const onAllow = vi.fn();
+    render(
+      <AskUserQuestionCard
+        input={SAMPLE_INPUT}
+        onAllow={onAllow}
+        onDeny={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/Option A/i));
+
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    expect(onAllow).not.toHaveBeenCalled();
+  });
+
+  it("the send button surfaces the keyboard shortcut for discoverability", () => {
+    render(
+      <AskUserQuestionCard
+        input={SAMPLE_INPUT}
+        onAllow={() => {}}
+        onDeny={() => {}}
+      />,
+    );
+
+    const sendBtn = screen.getByRole("button", { name: /send/i });
+    // Mac uses ⌘; Windows/Linux use Ctrl.
+    if (isMac) {
+      expect(sendBtn.textContent).toMatch(/⌘/);
+    } else {
+      expect(sendBtn.textContent).toMatch(/Ctrl/);
+    }
+  });
+});

--- a/src/__tests__/composer-enter-sends.test.tsx
+++ b/src/__tests__/composer-enter-sends.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+/**
+ * Agent composer — Enter sends, Shift+Enter inserts a newline.
+ *
+ * Hermes previously used the email-composer convention (Cmd/Ctrl+Enter
+ * sends, naked Enter inserts a newline).  Agent mode is a direct
+ * competitor to Claude.ai / ChatGPT / Cursor, all of which use the
+ * chat convention (Enter sends, Shift+Enter newline) — Hermes users
+ * coming from those tools were Enter-firing reflexively and getting
+ * stray newlines instead of sends.
+ *
+ * Contract:
+ *   - Plain Enter  → submitAgentMessage called, draft cleared.
+ *   - Shift+Enter  → submitAgentMessage NOT called (newline preserved
+ *                    via default textarea behaviour).
+ *   - Cmd/Ctrl+Enter → still sends (compat path for users who learned
+ *                      the old binding).
+ *   - During IME composition, plain Enter does NOT submit — the Enter
+ *     is committing a codepoint, not a message.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const dispatchMock = vi.fn();
+const submitAgentMessageMock = vi.fn(async () => {});
+
+interface FakeSessionState {
+  activeSessionId: string;
+  sessions: Record<string, { id: string; mode: string }>;
+  composers: Record<string, { draft: string; height: number; expanded: boolean }>;
+}
+
+const fakeState: FakeSessionState = {
+  activeSessionId: "test-session",
+  sessions: {
+    "test-session": { id: "test-session", mode: "agent" },
+  },
+  composers: {
+    // Non-empty draft so handleSubmit doesn't no-op.
+    "test-session": { draft: "hello world", height: 120, expanded: true },
+  },
+};
+
+vi.mock("../state/SessionContext", () => ({
+  useSession: () => ({
+    state: fakeState,
+    dispatch: dispatchMock,
+    switchAgentModel: vi.fn(),
+    switchAgentPermissionMode: vi.fn(),
+    switchAgentEffort: vi.fn(),
+    submitAgentMessage: submitAgentMessageMock,
+  }),
+  useComposer: () => fakeState.composers["test-session"],
+}));
+
+vi.mock("../agent/useAgentInit", () => ({
+  useAgentInit: () => null,
+}));
+vi.mock("../agent/useAgentPrewarm", () => ({
+  useAgentPrewarm: () => ({ slashCommands: [], catalog: [] }),
+}));
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: async () => () => {},
+  }),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+vi.mock("../api/agent", () => ({
+  readImageForAttachment: vi.fn(),
+}));
+
+import { SessionComposer } from "../components/SessionComposer";
+
+function getTextarea(container: HTMLElement): HTMLTextAreaElement {
+  const el = container.querySelector("textarea.session-composer-input");
+  if (!el) throw new Error("composer textarea not found");
+  return el as HTMLTextAreaElement;
+}
+
+beforeEach(() => {
+  dispatchMock.mockClear();
+  submitAgentMessageMock.mockClear();
+  // Reset the draft for each test (previous tests' clears mutated this).
+  fakeState.composers["test-session"]!.draft = "hello world";
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Agent composer — Enter sends, Shift+Enter newline", () => {
+  it("plain Enter submits the message", async () => {
+    const { container } = render(<SessionComposer />);
+    const ta = getTextarea(container);
+
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    // submitAgentMessage is async — give the promise a tick.
+    await Promise.resolve();
+    expect(submitAgentMessageMock).toHaveBeenCalledTimes(1);
+    expect(submitAgentMessageMock.mock.calls[0][1]).toBe("hello world");
+  });
+
+  it("Shift+Enter does NOT submit (newline is the default textarea behaviour)", () => {
+    const { container } = render(<SessionComposer />);
+    const ta = getTextarea(container);
+
+    fireEvent.keyDown(ta, { key: "Enter", shiftKey: true });
+
+    expect(submitAgentMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("Cmd/Ctrl+Enter still submits (compat path)", async () => {
+    const { container } = render(<SessionComposer />);
+    const ta = getTextarea(container);
+
+    // Either modifier — isActionMod handles platform routing.
+    fireEvent.keyDown(ta, { key: "Enter", metaKey: true, ctrlKey: true });
+
+    await Promise.resolve();
+    expect(submitAgentMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("Enter during an IME composition does NOT submit", () => {
+    const { container } = render(<SessionComposer />);
+    const ta = getTextarea(container);
+
+    // Composition begins; Enter commits the IME codepoint, not the
+    // message.  React/jsdom expose this via nativeEvent.isComposing on
+    // the keydown — fireEvent passes the init dict through.
+    fireEvent.compositionStart(ta);
+    fireEvent.keyDown(ta, { key: "Enter", isComposing: true });
+
+    expect(submitAgentMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("plain Enter on an empty draft is a no-op (no submit, no error)", () => {
+    fakeState.composers["test-session"]!.draft = "";
+    const { container } = render(<SessionComposer />);
+    const ta = getTextarea(container);
+
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    expect(submitAgentMessageMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/session-branch-selector-click-commits.test.tsx
+++ b/src/__tests__/session-branch-selector-click-commits.test.tsx
@@ -1,0 +1,343 @@
+// @vitest-environment jsdom
+/**
+ * Single-click commits on the Existing Branch tab.
+ *
+ * Context — what changed and why:
+ * The previous flow required two clicks: click a row to "select" (highlight)
+ * and click "Use Branch" to commit.  In multi-project sessions this trap was
+ * silent: users picked a branch in each expanded picker but never committed,
+ * the outer auto-progression never fired, and they ended up with zero
+ * isolated branches.
+ *
+ * New contract:
+ *   1. Clicking a row on the Existing Branch tab fires `onBranchSelected`
+ *      immediately — no intermediate selection state.
+ *   2. The inner "Use Branch" button is gone from the Existing tab.
+ *   3. The inner "Use current branch" button is gone from the Existing tab's
+ *      normal (list-rendered) state.  The outer "Continue without isolation"
+ *      button in SessionCreator now owns that role.
+ *   4. The New Branch tab is unchanged — still uses its "Create & Use Branch"
+ *      submit button (you cannot commit-on-click in a form).
+ *   5. Keyboard Enter on the highlighted row commits in one step (no
+ *      select-then-confirm).
+ *   6. Remote-only branches show a "remote" badge so the single click feels
+ *      intentional, not surprising.
+ *   7. Taken (in-use) branches still cannot be clicked.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+// jsdom doesn't implement Element.scrollIntoView — the picker calls it when
+// keyboard nav highlights an out-of-view row.  No-op shim so the effect runs.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function () {};
+}
+
+// ─── Mock Tauri APIs ─────────────────────────────────────────────────
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn(async () => undefined) }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+  emit: vi.fn(),
+}));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn(), save: vi.fn() }));
+
+// ─── Mock the git API used by SessionBranchSelector ──────────────────
+vi.mock("../api/git", () => ({
+  gitListBranchesForProject: vi.fn(),
+  listWorktrees: vi.fn(),
+  checkBranchAvailable: vi.fn(),
+  fetchRemoteBranches: vi.fn(),
+}));
+
+import {
+  gitListBranchesForProject,
+  listWorktrees,
+  checkBranchAvailable,
+} from "../api/git";
+import { SessionBranchSelector } from "../components/SessionBranchSelector";
+import type { GitBranch, WorktreeInfo } from "../types/git";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function makeBranch(overrides: Partial<GitBranch> = {}): GitBranch {
+  return {
+    name: "main",
+    is_current: false,
+    is_remote: false,
+    upstream: null,
+    ahead: 0,
+    behind: 0,
+    last_commit_summary: null,
+    ...overrides,
+  };
+}
+
+function setupBranches(
+  branches: GitBranch[],
+  worktrees: WorktreeInfo[] = [],
+): void {
+  vi.mocked(gitListBranchesForProject).mockResolvedValue(branches);
+  vi.mocked(listWorktrees).mockResolvedValue(worktrees);
+  vi.mocked(checkBranchAvailable).mockResolvedValue({
+    available: true,
+    usedBySession: null,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => cleanup());
+
+/**
+ * The picker auto-propagates the current local branch on mount (a v1.2.x
+ * fix for the "no isolation when user doesn't click" trap).  These tests
+ * are about USER click/keyboard behaviour layered on top of that — so the
+ * pattern is: render, wait for auto-propagation to settle, clear the mock,
+ * then exercise the click and assert on what the click alone produced.
+ */
+async function renderAndSettle(onBranchSelected: ReturnType<typeof vi.fn>): Promise<void> {
+  // Wait until either auto-propagation has fired (current branch was
+  // safe to propagate) OR the picker has rendered without firing
+  // (existingBranchName provided, or current branch is taken/missing).
+  // Either way, the list rows are visible.
+  await waitFor(() => {
+    expect(screen.queryByText(/Loading branches/i)).toBeNull();
+  });
+  onBranchSelected.mockClear();
+}
+
+// ─── Click-to-commit behavior ────────────────────────────────────────
+
+describe("SessionBranchSelector — single-click commits (Existing tab)", () => {
+  it("fires onBranchSelected immediately on row click for a local branch", async () => {
+    setupBranches([
+      makeBranch({ name: "main", is_current: true }),
+      makeBranch({ name: "feature/auth" }),
+    ]);
+    const onBranchSelected = vi.fn();
+
+    render(
+      <SessionBranchSelector
+        projectId="proj-1"
+        onBranchSelected={onBranchSelected}
+        onSkip={() => {}}
+      />,
+    );
+
+    // Wait for branches to load + auto-propagation to settle.
+    const row = await screen.findByText("feature/auth");
+    await renderAndSettle(onBranchSelected);
+
+    fireEvent.click(row);
+
+    expect(onBranchSelected).toHaveBeenCalledTimes(1);
+    expect(onBranchSelected).toHaveBeenCalledWith("feature/auth", false);
+  });
+
+  it("fires onBranchSelected with stripped name + fromRemote for a remote-only branch", async () => {
+    setupBranches([
+      makeBranch({ name: "main", is_current: true }),
+      makeBranch({ name: "origin/release-1.0", is_remote: true }),
+    ]);
+    const onBranchSelected = vi.fn();
+
+    render(
+      <SessionBranchSelector
+        projectId="proj-1"
+        onBranchSelected={onBranchSelected}
+        onSkip={() => {}}
+      />,
+    );
+
+    const row = await screen.findByText("release-1.0");
+    await renderAndSettle(onBranchSelected);
+    fireEvent.click(row);
+
+    expect(onBranchSelected).toHaveBeenCalledTimes(1);
+    expect(onBranchSelected).toHaveBeenCalledWith(
+      "release-1.0",
+      false,
+      "origin/release-1.0",
+    );
+  });
+
+  it("does NOT render a 'Use Branch' button on the Existing tab", async () => {
+    setupBranches([makeBranch({ name: "main", is_current: true })]);
+
+    render(
+      <SessionBranchSelector
+        projectId="proj-1"
+        onBranchSelected={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+
+    // Wait for the list to render
+    await screen.findByText("main");
+
+    // No "Use Branch" button — single-click is the commit.
+    expect(screen.queryByRole("button", { name: /^Use Branch$/i })).toBeNull();
+  });
+
+  it("keeps the 'Use current branch' per-project escape button", async () => {
+    // Multi-project sessions: each project can independently opt out of
+    // isolation.  The outer modal's "Continue without isolation" skips
+    // ALL projects — a different operation — so the per-project button
+    // must stay.
+    setupBranches([makeBranch({ name: "main", is_current: true })]);
+
+    render(
+      <SessionBranchSelector
+        projectId="proj-1"
+        onBranchSelected={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+
+    await screen.findByText("main");
+
+    expect(
+      screen.getByRole("button", { name: /Use current branch/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT fire onBranchSelected when clicking a taken (in-use) branch", async () => {
+    setupBranches(
+      [
+        makeBranch({ name: "main", is_current: true }),
+        makeBranch({ name: "feature/locked" }),
+      ],
+      [
+        {
+          sessionId: "other-session",
+          projectId: "proj-1",
+          branchName: "feature/locked",
+          worktreePath: "/tmp/wt",
+          isMainWorktree: false,
+        } as WorktreeInfo,
+      ],
+    );
+    const onBranchSelected = vi.fn();
+
+    render(
+      <SessionBranchSelector
+        projectId="proj-1"
+        onBranchSelected={onBranchSelected}
+        onSkip={() => {}}
+      />,
+    );
+
+    const row = await screen.findByText("feature/locked");
+    await renderAndSettle(onBranchSelected);
+    fireEvent.click(row);
+
+    // Clicks on taken rows are a no-op (the row keeps its "in use" label).
+    expect(onBranchSelected).not.toHaveBeenCalled();
+  });
+
+  it("keyboard Enter on highlighted row commits in a single step", async () => {
+    setupBranches([
+      makeBranch({ name: "main", is_current: true }),
+      makeBranch({ name: "feature/auth" }),
+    ]);
+    const onBranchSelected = vi.fn();
+
+    render(
+      <SessionBranchSelector
+        projectId="proj-1"
+        onBranchSelected={onBranchSelected}
+        onSkip={() => {}}
+      />,
+    );
+
+    // Wait for list to load + auto-propagation to settle.
+    await screen.findByText("feature/auth");
+    await renderAndSettle(onBranchSelected);
+
+    // Search input has focus; ArrowDown to highlight first item, Enter to commit.
+    const search = screen.getByPlaceholderText(/Filter branches/i);
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+    fireEvent.keyDown(search, { key: "Enter" });
+
+    // Single Enter should commit (no need for select-then-confirm).
+    await waitFor(() => {
+      expect(onBranchSelected).toHaveBeenCalledTimes(1);
+    });
+    // First row in the sorted list is "main" (priority 0).
+    expect(onBranchSelected).toHaveBeenCalledWith("main", false);
+  });
+});
+
+// ─── New Branch tab unchanged ────────────────────────────────────────
+
+describe("SessionBranchSelector — New Branch tab (unchanged)", () => {
+  it("still renders the 'Create & Use Branch' submit button", async () => {
+    setupBranches([makeBranch({ name: "main", is_current: true })]);
+
+    render(
+      <SessionBranchSelector
+        projectId="proj-1"
+        onBranchSelected={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+
+    // Wait for tabs to render, then switch to the New Branch tab.
+    const newTab = await screen.findByRole("button", { name: /New Branch/i });
+    fireEvent.click(newTab);
+
+    // The submit button must still exist — a click-on-form-field would be
+    // wrong (you're typing).
+    expect(
+      screen.getByRole("button", { name: /Create & Use Branch/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ─── Remote badge for discoverability ────────────────────────────────
+
+describe("SessionBranchSelector — remote-only branch affordance", () => {
+  it("marks remote-only rows with the remote class so users see it's a remote branch", async () => {
+    setupBranches([
+      makeBranch({ name: "main", is_current: true }),
+      makeBranch({ name: "origin/feature-x", is_remote: true }),
+    ]);
+
+    render(
+      <SessionBranchSelector
+        projectId="proj-1"
+        onBranchSelected={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+
+    const remoteRow = await screen.findByText("feature-x");
+    // Walk up to the row container and assert the remote modifier class.
+    const row = remoteRow.closest(".branch-selector-item");
+    expect(row).not.toBeNull();
+    expect(row!.className).toContain("branch-selector-item-remote");
+  });
+
+  it("does NOT mark local-only rows with the remote class", async () => {
+    setupBranches([
+      makeBranch({ name: "main", is_current: true }),
+      makeBranch({ name: "feature-x" }),
+    ]);
+
+    render(
+      <SessionBranchSelector
+        projectId="proj-1"
+        onBranchSelected={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+
+    const localRow = await screen.findByText("feature-x");
+    const row = localRow.closest(".branch-selector-item");
+    expect(row).not.toBeNull();
+    expect(row!.className).not.toContain("branch-selector-item-remote");
+  });
+});

--- a/src/components/AskUserQuestionCard.tsx
+++ b/src/components/AskUserQuestionCard.tsx
@@ -22,6 +22,7 @@ import {
   type AskUserQuestionInput,
   type AskUserQuestionOption,
 } from "../utils/askUserQuestion";
+import { fmt, isActionMod } from "../utils/platform";
 
 const OTHER_LABEL = "Other";
 
@@ -52,15 +53,32 @@ export function AskUserQuestionCard({ input, onAllow, onDeny, dialogId }: Props)
   const onDenyRef = useRef(onDeny);
   onDenyRef.current = onDeny;
 
+  // Mirror the latest submit handler and disabled flag behind a ref so
+  // the global keydown listener doesn't need to re-bind on every state
+  // change.  Set just below, where `handleSubmit` is declared.
+  const submitActionRef = useRef<() => void>(() => {});
+
   // Degenerate input: empty questions array → nothing to ask, auto-deny.
   useEffect(() => {
     if (questions.length === 0) onDenyRef.current();
   }, [questions.length]);
 
-  // Esc cancels.
+  // Global shortcuts.  Esc cancels; Cmd/Ctrl+Enter submits (when the
+  // form is valid — the ref's wrapper short-circuits on disabled state
+  // so we don't have to thread `submitDisabled` through here).
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onDenyRef.current();
+      if (e.key === "Escape") {
+        onDenyRef.current();
+        return;
+      }
+      if (e.key === "Enter" && isActionMod(e)) {
+        // Naked Enter belongs to the "Other" textarea (newlines).  Only
+        // the action-mod combo submits — this is the cross-app
+        // convention (Slack, GitHub, Linear).
+        e.preventDefault();
+        submitActionRef.current();
+      }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -118,6 +136,10 @@ export function AskUserQuestionCard({ input, onAllow, onDeny, dialogId }: Props)
     const updatedInput = buildAskAnswersUpdatedInput(input, answers);
     onAllow(updatedInput);
   }
+
+  // Keep the keydown listener's view of "submit" in sync with the latest
+  // closure (which captures the current `state`, `input`, `submitDisabled`).
+  submitActionRef.current = handleSubmit;
 
   return (
     <div
@@ -180,8 +202,10 @@ export function AskUserQuestionCard({ input, onAllow, onDeny, dialogId }: Props)
             className="aq-send"
             onClick={handleSubmit}
             disabled={submitDisabled}
+            title={`Submit answers (${fmt("{mod}")}Enter)`}
           >
-            ⏎ send
+            <span className="aq-send-kbd" aria-hidden="true">{fmt("{mod}")}⏎</span>
+            send
           </button>
         </div>
       </div>

--- a/src/components/SessionBranchSelector.tsx
+++ b/src/components/SessionBranchSelector.tsx
@@ -383,24 +383,35 @@ export function SessionBranchSelector({ projectId, existingBranchName, onBranchS
     return () => clearTimeout(timer);
   }, [newBranchName, projectId, localBranchNames]);
 
-  const handleSelectBranch = useCallback(
+  /**
+   * Single-click commits.  Clicking a row on the Existing Branch tab fires
+   * `onBranchSelected` immediately — there is no intermediate "highlighted
+   * but uncommitted" state any more.
+   *
+   * Why: in multi-project sessions the old select-then-confirm flow was a
+   * silent trap.  Users would click a branch in each expanded picker, never
+   * realise they also had to click "Use Branch", and end up with zero
+   * isolated branches.  The outer modal's "Continue" / "Continue without
+   * isolation" buttons now own the only legitimate confirmation gate.
+   *
+   * The visual "selected" state (`selectedBranch`) survives only as a brief
+   * flash before the parent collapses the picker — see the row className.
+   */
+  const handleCommitBranch = useCallback(
     (branchName: string) => {
-      setSelectedBranch((prev) => (prev === branchName ? null : branchName));
+      const branch = augmentedBranches.find((b) => b.name === branchName);
+      if (!branch || branch.taken) return;
+      setSelectedBranch(branchName); // for the brief visual ack
+      if (branch.is_remote) {
+        // For remote branches: pass the local name (stripped prefix) and the
+        // full remote ref so the worktree backend can fetch it.
+        onBranchSelected(stripRemotePrefix(branch.name), false, branch.name);
+      } else {
+        onBranchSelected(branchName, false);
+      }
     },
-    [],
+    [augmentedBranches, onBranchSelected],
   );
-
-  const handleConfirmExisting = useCallback(() => {
-    if (!selectedBranch) return;
-    const branch = augmentedBranches.find((b) => b.name === selectedBranch);
-    if (branch?.is_remote) {
-      // For remote branches: pass the local name (stripped prefix) and the full remote ref
-      const localName = stripRemotePrefix(branch.name);
-      onBranchSelected(localName, false, branch.name);
-    } else {
-      onBranchSelected(selectedBranch, false);
-    }
-  }, [selectedBranch, augmentedBranches, onBranchSelected]);
 
   const handleConfirmNew = useCallback(() => {
     if (!newBranchName.trim() || validationError || checkingAvailability) return;
@@ -418,12 +429,9 @@ export function SessionBranchSelector({ projectId, existingBranchName, onBranchS
       } else if (e.key === "Enter" && highlightedIndex >= 0) {
         e.preventDefault();
         const branch = flatFiltered[highlightedIndex];
+        // Single Enter commits — matches the mouse single-click contract.
         if (branch && !branch.taken) {
-          if (selectedBranch === branch.name) {
-            handleConfirmExisting();
-          } else {
-            handleSelectBranch(branch.name);
-          }
+          handleCommitBranch(branch.name);
         }
       }
     } else if (tab === "new") {
@@ -548,18 +556,27 @@ export function SessionBranchSelector({ projectId, existingBranchName, onBranchS
                     branch.taken ? "branch-selector-item-taken" : "",
                     selectedBranch === branch.name ? "branch-selector-item-selected" : "",
                     highlightedIndex === idx ? "branch-selector-item-highlighted" : "",
+                    branch.is_remote ? "branch-selector-item-remote" : "",
                   ]
                     .filter(Boolean)
                     .join(" ")}
-                  onClick={() => !branch.taken && handleSelectBranch(branch.name)}
+                  onClick={() => handleCommitBranch(branch.name)}
                   title={branch.last_commit_summary || undefined}
                 >
                   <span className="branch-selector-item-name">{displayName}</span>
                   {branch.is_current && (
                     <span className="branch-selector-item-current">current</span>
                   )}
+                  {branch.is_remote && !branch.taken && (
+                    <span className="branch-selector-item-remote-badge">remote</span>
+                  )}
                   {branch.taken && (
                     <span className="branch-selector-item-taken-label">in use</span>
+                  )}
+                  {/* Hover-only affordance telegraphing single-click commits.
+                      Hidden on .branch-selector-item-taken via CSS. */}
+                  {!branch.taken && (
+                    <span className="branch-selector-item-commit-hint" aria-hidden="true">→</span>
                   )}
                 </div>
               );
@@ -608,7 +625,17 @@ export function SessionBranchSelector({ projectId, existingBranchName, onBranchS
         </div>
       )}
 
-      {/* Actions */}
+      {/* Actions
+       *
+       * Existing tab: the redundant "Use Branch" button is gone — single-click
+       * on a row commits the selection (the silent multi-project confirmation
+       * trap is what we're fixing).  "Use current branch" stays, because it's
+       * the only per-project escape from isolation in multi-project sessions;
+       * the outer "Continue without isolation" skips ALL projects, which is a
+       * different operation.
+       *
+       * New tab: the submit button stays — the user is typing into a form and
+       * there is nothing to single-click on. */}
       <div className="session-creator-actions">
         <button
           className="session-creator-btn-secondary"
@@ -617,15 +644,7 @@ export function SessionBranchSelector({ projectId, existingBranchName, onBranchS
         >
           Use current branch
         </button>
-        {tab === "existing" ? (
-          <button
-            className="session-creator-btn-primary"
-            onClick={handleConfirmExisting}
-            disabled={!selectedBranch}
-          >
-            Use Branch
-          </button>
-        ) : (
+        {tab === "new" && (
           <button
             className="session-creator-btn-primary"
             onClick={handleConfirmNew}

--- a/src/components/SessionComposer.tsx
+++ b/src/components/SessionComposer.tsx
@@ -336,6 +336,31 @@ export function SessionComposer() {
       void handleSubmit();
       return;
     }
+    // Plain Enter sends; Shift+Enter inserts a newline.  This matches
+    // the chat-app convention (Claude.ai, ChatGPT, Cursor, Slack,
+    // Discord) that the agent composer competes with.  Cmd/Ctrl+Enter
+    // above remains as a compat path for users who learned the older
+    // binding.
+    //
+    // Skip the send when:
+    //   - any modifier other than Shift is held (Shift is reserved for
+    //     newline; Cmd/Ctrl is handled above; Alt is the wildcard for
+    //     OS-level shortcuts we don't want to swallow)
+    //   - an IME composition is in progress — the Enter is committing
+    //     a codepoint (CJK, dead-keys, voice dictation), not the
+    //     message.  Both `isComposingRef.current` and the native
+    //     `isComposing` flag are checked; WebKit doesn't always set
+    //     the native flag in the right places.
+    if (e.key === "Enter" && !e.shiftKey && !e.altKey) {
+      const native = e.nativeEvent as KeyboardEvent | undefined;
+      const composing = isComposingRef.current || native?.isComposing === true;
+      if (!composing) {
+        e.preventDefault();
+        e.stopPropagation();
+        void handleSubmit();
+        return;
+      }
+    }
     if (e.key === "Escape") {
       e.preventDefault();
       if (!composerSessionId) return;
@@ -1163,7 +1188,7 @@ export function SessionComposer() {
             className="session-composer-send-btn"
             onClick={() => void handleSubmit()}
             disabled={!draft.trim() && pendingImages.length === 0}
-            title={`Send (${isMac ? "⌘" : "Ctrl"}+Enter)`}
+            title={`Send (Enter · Shift+Enter for newline)`}
             aria-label="Send message"
           >
             <span className="session-composer-send-label">Send</span>

--- a/src/styles/components/AskUserQuestionCard.css
+++ b/src/styles/components/AskUserQuestionCard.css
@@ -249,3 +249,14 @@
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+.aq-send-kbd {
+  /* Inline keyboard-shortcut chip on the send button — mirrors the
+   * `.aq-cancel-kbd` "Esc" chip for visual symmetry across the two
+   * actions.  `fmt({mod})` resolves to ⌘ on macOS, "Ctrl+" elsewhere. */
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  margin-right: 6px;
+  opacity: 0.85;
+}

--- a/src/styles/components/SessionBranchSelector.css
+++ b/src/styles/components/SessionBranchSelector.css
@@ -73,18 +73,9 @@
   background: var(--bg-hover);
 }
 
-.branch-selector-item.branch-selector-item-selected {
-  background: var(--accent-dim);
-  box-shadow: inset 2px 0 0 var(--accent);
-}
-
 .branch-selector-item.branch-selector-item-highlighted {
   background: var(--bg-hover);
   box-shadow: inset 2px 0 0 var(--accent);
-}
-
-.branch-selector-item.branch-selector-item-selected.branch-selector-item-highlighted {
-  background: var(--accent-dim);
 }
 
 .branch-selector-item.branch-selector-item-taken {
@@ -98,6 +89,38 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Hover-only commit hint.  Single-click on a row commits the selection;
+ * the chevron telegraphs that the click is the action and prevents the
+ * "I selected it but nothing happened" trap that bit users in the old
+ * select-then-confirm flow. */
+.branch-selector-item-commit-hint {
+  font-size: var(--text-sm);
+  color: var(--text-3);
+  flex-shrink: 0;
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 0.12s ease, transform 0.12s ease, color 0.12s ease;
+}
+
+.branch-selector-item:hover:not(.branch-selector-item-taken) .branch-selector-item-commit-hint,
+.branch-selector-item.branch-selector-item-highlighted .branch-selector-item-commit-hint {
+  opacity: 1;
+  transform: translateX(0);
+  color: var(--accent);
+}
+
+/* Briefly flash the row when single-click commits, so the user gets a
+ * visible acknowledgement before the parent collapses the picker and
+ * auto-expands the next project. */
+@keyframes branch-selector-commit-flash {
+  0%   { background: var(--accent-dim); }
+  100% { background: transparent; }
+}
+
+.branch-selector-item.branch-selector-item-selected {
+  animation: branch-selector-commit-flash 0.35s ease-out;
 }
 
 .branch-selector-item-current {

--- a/src/styles/components/agent/AgentSessionView.css
+++ b/src/styles/components/agent/AgentSessionView.css
@@ -3322,16 +3322,14 @@ html[data-agent-timeline-style="classic"] .agent-message {
   z-index: 200;
   min-width: 280px;
   max-width: 360px;
-  /* Opaque underlay (`--bg-0` is the deepest ground — always opaque)
-   * with an `--bg-elevated` veneer painted on top.  This guarantees
-   * legibility on themes whose `--bg-elevated` is semi-transparent
-   * (e.g. Frosted Dark) without losing the slight tonal lift that
-   * `--bg-elevated` gives on themes where it's a solid color. */
-  background:
-    linear-gradient(var(--bg-elevated, var(--bg-1)), var(--bg-elevated, var(--bg-1))),
-    var(--bg-0);
-  backdrop-filter: blur(10px) saturate(120%);
-  -webkit-backdrop-filter: blur(10px) saturate(120%);
+  /* Fully opaque single fill.  Earlier we layered a gradient over `--bg-0`
+   * with `backdrop-filter: blur(10px)` as a fallback for themes whose
+   * `--bg-elevated` might be semi-transparent — but every shipped theme
+   * defines `--bg-elevated` as an opaque hex, and the backdrop-filter
+   * still leaked a subtle blurred bleed of the chat content through on
+   * some GPU compositors.  A solid `--bg-elevated` (with `--bg-1`
+   * fallback) is correct, simpler, and reliably opaque. */
+  background: var(--bg-elevated, var(--bg-1));
   border: 1px solid var(--rule-strong, var(--rule));
   border-radius: 8px;
   box-shadow:

--- a/src/styles/components/agent/AgentSessionView.css
+++ b/src/styles/components/agent/AgentSessionView.css
@@ -70,9 +70,9 @@
   align-items: center;
   gap: 10px;
   min-width: 0;
-  overflow: hidden;
-  /* Items inside the title can themselves shrink (cwd path is the
-   * usual culprit); ellipsis happens at the leaf level. */
+  /* No overflow: hidden here — it clips the brass glow on .agent-session-ticker
+   * along the bottom edge.  Children handle their own truncation (the ticker,
+   * cwd label, and model label all set white-space + ellipsis). */
 }
 
 .agent-session-header-title > * {
@@ -129,6 +129,14 @@
   letter-spacing: -0.005em;
   text-shadow: 0 0 8px var(--brass-dim);
   font-size: 13px;
+  line-height: 1.4;
+  /* Keep multi-word labels ("Running Bash", "Awaiting Claude") on a
+   * single line.  Without nowrap the title row would jump to a second
+   * line in narrow panes, causing the whole header to grow and the
+   * surrounding chips to shift on every state change. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .agent-session-cwd-name {


### PR DESCRIPTION
## Summary
- **Branch picker — single-click commits.** In multi-project sessions the old select-then-confirm flow was a silent trap: clicking a branch only "highlighted" it, and users who didn't also click "Use Branch" ended up with zero isolated branches when they hit outer Continue. Existing tab now commits on click; outer "Continue" / "Continue without isolation" remain the only confirmation gate.
- **Agent masthead — ticker stability.** "Thinking" was being clipped along its baseline because the parent had `overflow: hidden` and the brass glow extends ~8px below the text. And switching to two-word labels ("Running Bash", "Awaiting Claude") could wrap the ticker to a second line in narrow panes, making the entire header row jump. Both fixed.

## Notes
- "Use current branch" stays as a **per-project** escape on the Existing tab; the outer "Continue without isolation" skips ALL projects, which is a different operation.
- Click-commits coexists with the v1.2.x auto-propagation — auto-prop still fills `branchSelections` on mount for the no-effort case, explicit clicks layer on top.
- New Branch tab is unchanged (form submit, not click-to-commit).
- Hover/highlight reveals a small `→` chevron on each row to telegraph "click commits".
- Remote-only branches get a `remote` badge so single-click on them doesn't feel surprising.

## Test plan
- [x] `npm test` — 3473 tests pass (added 9 for click-commits + 3 for masthead ticker)
- [x] `npx tsc --noEmit` — clean
- [x] Manual: `Cmd+N` → multi-project session → click branches → verify each project shows its branch label and auto-advances to the next
- [ ] Manual: agent session, watch "Thinking" → "Running Bash" → "Awaiting Claude" transitions; no row-height jump, no glow clip
- [ ] Manual: per-project "Use current branch" still works (one project shared, another isolated)
- [ ] Manual: remote-only branch with single click triggers fetch correctly